### PR TITLE
Validate map subgraph paths against element type fields

### DIFF
--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -616,6 +616,139 @@ describe("validateGraph", () => {
     });
   });
 
+  describe("map subgraph state path validation", () => {
+    // State schema with a Task type and a list<Task> field
+    function makeMapState(): StateSchema {
+      return {
+        types: {
+          Task: {
+            fields: {
+              description: "string",
+              output: "string",
+              approved: "bool",
+            },
+          },
+        },
+        fields: {
+          tasks: { type: { kind: "list", element: "Task" } },
+        },
+      };
+    }
+
+    it("valid map subgraph state path passes", () => {
+      const graph: Graph = {
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            graph: [
+              { skill: "engineer", reads: ["task.description"], writes: ["task.output"] },
+            ],
+          },
+        ],
+      };
+      const skills = makeSkills("engineer");
+      assert.doesNotThrow(() => validateGraph(graph, skills, makeMapState()));
+    });
+
+    it("invalid map subgraph reads path errors", () => {
+      const graph: Graph = {
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            graph: [
+              { skill: "engineer", reads: ["task.nonexistent"], writes: [] },
+            ],
+          },
+        ],
+      };
+      const skills = makeSkills("engineer");
+      assert.throws(
+        () => validateGraph(graph, skills, makeMapState()),
+        (err: unknown) => {
+          assert.ok(err instanceof GraphError);
+          assert.match(
+            err.message,
+            /Map subgraph node "engineer": reads "task.nonexistent" but type "Task" has no field "nonexistent"/,
+          );
+          return true;
+        },
+      );
+    });
+
+    it("invalid map subgraph writes path errors", () => {
+      const graph: Graph = {
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            graph: [
+              { skill: "engineer", reads: [], writes: ["task.missing"] },
+            ],
+          },
+        ],
+      };
+      const skills = makeSkills("engineer");
+      assert.throws(
+        () => validateGraph(graph, skills, makeMapState()),
+        (err: unknown) => {
+          assert.ok(err instanceof GraphError);
+          assert.match(
+            err.message,
+            /Map subgraph node "engineer": writes "task.missing" but type "Task" has no field "missing"/,
+          );
+          return true;
+        },
+      );
+    });
+
+    it("multiple valid paths pass", () => {
+      const graph: Graph = {
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            graph: [
+              {
+                skill: "engineer",
+                reads: ["task.description"],
+                writes: ["task.output"],
+                then: "reviewer",
+              },
+              {
+                skill: "reviewer",
+                reads: ["task.output"],
+                writes: ["task.approved"],
+                then: "end",
+              },
+            ],
+          },
+        ],
+      };
+      const skills = makeSkills("engineer", "reviewer");
+      assert.doesNotThrow(() => validateGraph(graph, skills, makeMapState()));
+    });
+
+    it("skips subgraph path validation when state is undefined", () => {
+      const graph: Graph = {
+        nodes: [
+          {
+            over: "items",
+            as: "item",
+            graph: [
+              { skill: "worker", reads: ["item.name"], writes: ["item.result"] },
+            ],
+          },
+        ],
+      };
+      const skills = makeSkills("worker");
+      // map.over doesn't start with "state." so no state validation triggered,
+      // and no map context is resolved, so item.* paths are skipped
+      assert.doesNotThrow(() => validateGraph(graph, skills, undefined));
+    });
+  });
+
   describe("cycle exit condition (rule 5)", () => {
     it("conditional cycle with exit condition passes", () => {
       const graph: Graph = {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,6 +1,6 @@
 import { SkillEntry } from "./config.js";
 import { GraphError } from "./errors.js";
-import { StateSchema } from "./state.js";
+import { CustomType, StateSchema } from "./state.js";
 
 export interface ConditionalBranch {
   when: string;
@@ -194,10 +194,18 @@ function nodeLabel(node: GraphNode): string {
   return isMapNode(node) ? "map" : node.skill;
 }
 
+// Context for validating paths inside a map subgraph
+interface MapContext {
+  as: string;
+  typeName: string;
+  type: CustomType;
+}
+
 function validateNodes(
   nodes: GraphNode[],
   skills: Record<string, SkillEntry>,
   state: StateSchema | undefined,
+  mapCtx?: MapContext,
 ): void {
   const nodeLabels = new Set(collectNodeLabels(nodes));
 
@@ -232,32 +240,48 @@ function validateNodes(
     const label = node.skill;
 
     for (const path of node.reads) {
-      if (!path.startsWith("state.")) continue;
-      if (!state) {
-        throw new GraphError(
-          `Graph node "${label}": reads state field "${path}" but no state is declared`
-        );
-      }
-      const fieldName = path.slice("state.".length);
-      if (!(fieldName in state.fields)) {
-        throw new GraphError(
-          `Graph node "${label}": reads state field "${path}" which is not declared`
-        );
+      if (path.startsWith("state.")) {
+        if (!state) {
+          throw new GraphError(
+            `Graph node "${label}": reads state field "${path}" but no state is declared`
+          );
+        }
+        const fieldName = path.slice("state.".length);
+        if (!(fieldName in state.fields)) {
+          throw new GraphError(
+            `Graph node "${label}": reads state field "${path}" which is not declared`
+          );
+        }
+      } else if (mapCtx && path.startsWith(mapCtx.as + ".")) {
+        const fieldName = path.slice(mapCtx.as.length + 1);
+        if (!(fieldName in mapCtx.type.fields)) {
+          throw new GraphError(
+            `Map subgraph node "${label}": reads "${path}" but type "${mapCtx.typeName}" has no field "${fieldName}"`
+          );
+        }
       }
     }
 
     for (const path of node.writes) {
-      if (!path.startsWith("state.")) continue;
-      if (!state) {
-        throw new GraphError(
-          `Graph node "${label}": writes state field "${path}" but no state is declared`
-        );
-      }
-      const fieldName = path.slice("state.".length);
-      if (!(fieldName in state.fields)) {
-        throw new GraphError(
-          `Graph node "${label}": writes state field "${path}" which is not declared`
-        );
+      if (path.startsWith("state.")) {
+        if (!state) {
+          throw new GraphError(
+            `Graph node "${label}": writes state field "${path}" but no state is declared`
+          );
+        }
+        const fieldName = path.slice("state.".length);
+        if (!(fieldName in state.fields)) {
+          throw new GraphError(
+            `Graph node "${label}": writes state field "${path}" which is not declared`
+          );
+        }
+      } else if (mapCtx && path.startsWith(mapCtx.as + ".")) {
+        const fieldName = path.slice(mapCtx.as.length + 1);
+        if (!(fieldName in mapCtx.type.fields)) {
+          throw new GraphError(
+            `Map subgraph node "${label}": writes "${path}" but type "${mapCtx.typeName}" has no field "${fieldName}"`
+          );
+        }
       }
     }
   }
@@ -308,8 +332,22 @@ function validateNodes(
       );
     }
 
+    // Resolve the element type for subgraph path validation
+    let subMapCtx: MapContext | undefined;
+    if (node.over.startsWith("state.") && state) {
+      const fieldName = node.over.slice("state.".length);
+      const field = state.fields[fieldName];
+      if (field && field.type.kind === "list") {
+        const elementTypeName = field.type.element;
+        const elementType = state.types[elementTypeName];
+        if (elementType) {
+          subMapCtx = { as: node.as, typeName: elementTypeName, type: elementType };
+        }
+      }
+    }
+
     // Recursively validate the subgraph
-    validateNodes(node.graph, skills, state);
+    validateNodes(node.graph, skills, state, subMapCtx);
   }
 
   // Build index: node label -> position in this level's node list


### PR DESCRIPTION
## Summary

- When a map node iterates over a `list<TypeName>`, subgraph nodes that read/write paths prefixed with the loop variable (e.g., `task.description`) are now validated against the custom type's field definitions
- Previously these non-state paths were silently skipped during graph validation
- Adds `MapContext` to thread the element type info through recursive `validateNodes` calls

## Test plan

- [x] 5 new tests in `graph.test.ts` covering valid paths, invalid reads, invalid writes, multiple valid paths, and undefined state
- [x] All 147 tests pass (142 existing + 5 new)
- [x] `npx tsc --noEmit` passes
- [x] E2e test with `task.description`, `task.output`, `task.approved` continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)