### PR TITLE
Fix when-clause validation for custom type state fields

### DIFF
--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -1149,7 +1149,7 @@ describe("validateGraph when-clause validation", () => {
       () => validateGraph(graph, skills, state),
       (err: unknown) => {
         assert.ok(err instanceof GraphError);
-        assert.match(err.message, /when clause references "unknown.field" which is not a state or map variable path/);
+        assert.match(err.message, /when clause references "unknown.field" but "unknown" is not a declared state field/);
         return true;
       },
     );

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -362,6 +362,30 @@ function validateNodes(
             `Graph node "${label}": when clause references "${clause.path}" but type "${mapCtx.typeName}" has no field "${fieldName}"`
           );
         }
+      } else if (state) {
+        // Handle paths like "review.approved" where "review" is a state field of custom type
+        const dotIndex = clause.path.indexOf(".");
+        if (dotIndex === -1) {
+          throw new GraphError(
+            `Graph node "${label}": when clause references "${clause.path}" which is not a valid state path`
+          );
+        }
+        const fieldName = clause.path.slice(0, dotIndex);
+        const subField = clause.path.slice(dotIndex + 1);
+        if (!(fieldName in state.fields)) {
+          throw new GraphError(
+            `Graph node "${label}": when clause references "${clause.path}" but "${fieldName}" is not a declared state field`
+          );
+        }
+        const field = state.fields[fieldName];
+        if (field.type.kind === "custom" && field.type.name in state.types) {
+          const customType = state.types[field.type.name];
+          if (!(subField in customType.fields)) {
+            throw new GraphError(
+              `Graph node "${label}": when clause references "${clause.path}" but type "${field.type.name}" has no field "${subField}"`
+            );
+          }
+        }
       } else {
         throw new GraphError(
           `Graph node "${label}": when clause references "${clause.path}" which is not a state or map variable path`


### PR DESCRIPTION
## Summary

- When-clause paths like `review.approved` (where `review` is a state field of custom type `Review`) were rejected as unknown paths
- The validator now resolves state field -> custom type -> subfield
- Fixes the project's own `skillfold.yaml` which uses `review.approved == false`

## Test plan

- [x] Existing 162 tests pass
- [x] `npx tsx src/cli.ts` compiles the project config
- [x] Updated test expectation for the changed error message

Generated with [Claude Code](https://claude.com/claude-code)