### PR TITLE
Add skillfold init command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { readConfig } from "./config.js";
 import { compile } from "./compiler.js";
 import { ConfigError, CompileError, ResolveError } from "./errors.js";
+import { initProject } from "./init.js";
 import { resolveSkills } from "./resolver.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -16,31 +17,52 @@ const pkg = JSON.parse(
 function printHelp(): void {
   console.log(`skillfold v${pkg.version}
 
-Usage: skillfold [options]
+Usage: skillfold [command] [options]
+
+Commands:
+  init              Scaffold a new pipeline project
+  (default)         Compile the pipeline config
 
 Options:
   --config <path>   Config file (default: skillfold.yaml)
   --out-dir <path>  Output directory (default: build)
+  --dir <path>      Target directory for init (default: .)
   --help            Show this help
   --version         Show version`);
 }
 
-function parseArgs(argv: string[]): {
+interface Args {
+  command: "init" | "compile";
   configPath: string;
   outDir: string;
+  dir: string;
   help: boolean;
   version: boolean;
-} {
+}
+
+function parseArgs(argv: string[]): Args {
+  let command: "init" | "compile" = "compile";
   let configPath = "skillfold.yaml";
   let outDir = "build";
+  let dir = ".";
   let help = false;
   let version = false;
 
-  for (let i = 0; i < argv.length; i++) {
+  let i = 0;
+
+  // Check for subcommand as first positional arg
+  if (argv.length > 0 && argv[0] === "init") {
+    command = "init";
+    i = 1;
+  }
+
+  for (; i < argv.length; i++) {
     if (argv[i] === "--config" && argv[i + 1]) {
       configPath = argv[++i];
     } else if (argv[i] === "--out-dir" && argv[i + 1]) {
       outDir = argv[++i];
+    } else if (argv[i] === "--dir" && argv[i + 1]) {
+      dir = argv[++i];
     } else if (argv[i] === "--help") {
       help = true;
     } else if (argv[i] === "--version") {
@@ -48,7 +70,14 @@ function parseArgs(argv: string[]): {
     }
   }
 
-  return { configPath: resolve(configPath), outDir: resolve(outDir), help, version };
+  return {
+    command,
+    configPath: resolve(configPath),
+    outDir: resolve(outDir),
+    dir: resolve(dir),
+    help,
+    version,
+  };
 }
 
 function main(): void {
@@ -61,6 +90,23 @@ function main(): void {
 
   if (args.version) {
     console.log(pkg.version);
+    return;
+  }
+
+  if (args.command === "init") {
+    try {
+      const files = initProject(args.dir);
+      console.log("skillfold: project initialized");
+      for (const file of files) {
+        console.log(`  -> ${file}`);
+      }
+    } catch (err) {
+      if (err instanceof Error) {
+        console.error(`skillfold error: ${err.message}`);
+        process.exit(1);
+      }
+      throw err;
+    }
     return;
   }
 

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { compile } from "./compiler.js";
+import { readConfig } from "./config.js";
+import { initProject } from "./init.js";
+import { resolveSkills } from "./resolver.js";
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `skillfold-init-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("initProject", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("creates all expected files", () => {
+    tmpDir = makeTmpDir();
+    initProject(tmpDir);
+
+    assert.ok(existsSync(join(tmpDir, "skillfold.yaml")));
+    assert.ok(existsSync(join(tmpDir, "skills", "plan", "SKILL.md")));
+    assert.ok(existsSync(join(tmpDir, "skills", "execute", "SKILL.md")));
+
+    const config = readFileSync(join(tmpDir, "skillfold.yaml"), "utf-8");
+    assert.ok(config.includes("name: my-pipeline"));
+
+    const plan = readFileSync(join(tmpDir, "skills", "plan", "SKILL.md"), "utf-8");
+    assert.ok(plan.includes("name: plan"));
+    assert.ok(plan.includes("# Plan"));
+
+    const execute = readFileSync(join(tmpDir, "skills", "execute", "SKILL.md"), "utf-8");
+    assert.ok(execute.includes("name: execute"));
+    assert.ok(execute.includes("# Execute"));
+  });
+
+  it("generated config compiles", () => {
+    tmpDir = makeTmpDir();
+    initProject(tmpDir);
+
+    const configPath = join(tmpDir, "skillfold.yaml");
+    const outDir = join(tmpDir, "build");
+
+    const config = readConfig(configPath);
+    const bodies = resolveSkills(config, tmpDir);
+    const results = compile(config, bodies, outDir);
+
+    assert.ok(results.length > 0);
+
+    // Verify compiled skills exist on disk
+    for (const result of results) {
+      assert.ok(existsSync(result.path), `Expected ${result.path} to exist`);
+    }
+  });
+
+  it("errors if skillfold.yaml already exists", () => {
+    tmpDir = makeTmpDir();
+    writeFileSync(join(tmpDir, "skillfold.yaml"), "name: existing\n", "utf-8");
+
+    assert.throws(
+      () => initProject(tmpDir!),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.ok(err.message.includes("skillfold.yaml already exists"));
+        return true;
+      }
+    );
+  });
+
+  it("respects target directory", () => {
+    tmpDir = makeTmpDir();
+    const subDir = join(tmpDir, "my-project");
+
+    initProject(subDir);
+
+    assert.ok(existsSync(join(subDir, "skillfold.yaml")));
+    assert.ok(existsSync(join(subDir, "skills", "plan", "SKILL.md")));
+    assert.ok(existsSync(join(subDir, "skills", "execute", "SKILL.md")));
+  });
+});

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,91 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const STARTER_CONFIG = `name: my-pipeline
+
+skills:
+  plan: ./skills/plan
+  execute: ./skills/execute
+
+  planner:
+    compose: [plan]
+    description: "Analyzes the goal and produces a plan."
+
+  worker:
+    compose: [plan, execute]
+    description: "Executes tasks from the plan."
+
+  orchestrator:
+    compose: [plan]
+    description: "Coordinates pipeline execution."
+
+orchestrator: orchestrator
+
+state:
+  goal:
+    type: string
+
+  result:
+    type: string
+
+graph:
+  - planner:
+      writes: [state.goal]
+    then: worker
+
+  - worker:
+      reads: [state.goal]
+      writes: [state.result]
+    then: end
+`;
+
+const PLAN_SKILL = `---
+name: plan
+description: Analyze problems and produce structured plans.
+---
+
+# Plan
+
+You analyze problems and produce structured, actionable plans. Break work into clear steps with defined inputs and outputs.
+`;
+
+const EXECUTE_SKILL = `---
+name: execute
+description: Execute tasks and produce results.
+---
+
+# Execute
+
+You take a plan and execute it step by step, producing concrete output for each task.
+`;
+
+export function initProject(dir: string): string[] {
+  const configPath = join(dir, "skillfold.yaml");
+
+  if (existsSync(configPath)) {
+    throw new Error(
+      "skillfold.yaml already exists. Remove it first or use a different directory."
+    );
+  }
+
+  const files: string[] = [];
+
+  // Create skillfold.yaml
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(configPath, STARTER_CONFIG, "utf-8");
+  files.push("skillfold.yaml");
+
+  // Create skills/plan/SKILL.md
+  const planDir = join(dir, "skills", "plan");
+  mkdirSync(planDir, { recursive: true });
+  writeFileSync(join(planDir, "SKILL.md"), PLAN_SKILL, "utf-8");
+  files.push("skills/plan/SKILL.md");
+
+  // Create skills/execute/SKILL.md
+  const executeDir = join(dir, "skills", "execute");
+  mkdirSync(executeDir, { recursive: true });
+  writeFileSync(join(executeDir, "SKILL.md"), EXECUTE_SKILL, "utf-8");
+  files.push("skills/execute/SKILL.md");
+
+  return files;
+}


### PR DESCRIPTION
## Summary

- Adds `skillfold init` subcommand that scaffolds a starter pipeline project with `skillfold.yaml`, `skills/plan/SKILL.md`, and `skills/execute/SKILL.md`
- Supports `--dir <path>` flag to target a specific directory (defaults to `.`)
- Guards against overwriting an existing `skillfold.yaml` with a clear error message
- Updates CLI help text to document the new `init` command and `--dir` option

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (166 tests, 4 new)
- [x] Test: creates all expected files in a temp directory
- [x] Test: generated config compiles end-to-end (readConfig + resolveSkills + compile)
- [x] Test: errors if skillfold.yaml already exists
- [x] Test: respects --dir flag (creates files in subdirectory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)