### PR TITLE
Add URL-based skill references

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,7 +80,7 @@ function parseArgs(argv: string[]): Args {
   };
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
   if (args.help) {
@@ -113,7 +113,7 @@ function main(): void {
   try {
     const config = readConfig(args.configPath);
     const baseDir = dirname(args.configPath);
-    const bodies = resolveSkills(config, baseDir);
+    const bodies = await resolveSkills(config, baseDir);
     const results = compile(config, bodies, args.outDir);
 
     console.log(`skillfold: compiled ${config.name}`);

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -48,23 +48,23 @@ describe("e2e: dev-pipeline", () => {
     }
   });
 
-  it("reads config, resolves skills, and compiles without errors", () => {
+  it("reads config, resolves skills, and compiles without errors", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     const results = compile(config, bodies, outDir);
 
     assert.ok(results.length > 0);
   });
 
-  it("produces output directories for all composed skills", () => {
+  it("produces output directories for all composed skills", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const expected = [
@@ -83,12 +83,12 @@ describe("e2e: dev-pipeline", () => {
     }
   });
 
-  it("strategy/SKILL.md contains frontmatter and Strategic Thinking then Slack Integration", () => {
+  it("strategy/SKILL.md contains frontmatter and Strategic Thinking then Slack Integration", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const content = readFileSync(join(outDir, "strategy", "SKILL.md"), "utf-8");
@@ -101,12 +101,12 @@ describe("e2e: dev-pipeline", () => {
     ]);
   });
 
-  it("tech-lead/SKILL.md contains all four skills in order", () => {
+  it("tech-lead/SKILL.md contains all four skills in order", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const content = readFileSync(join(outDir, "tech-lead", "SKILL.md"), "utf-8");
@@ -118,12 +118,12 @@ describe("e2e: dev-pipeline", () => {
     ]);
   });
 
-  it("senior-engineer/SKILL.md contains Task Decomposition then Code Generation", () => {
+  it("senior-engineer/SKILL.md contains Task Decomposition then Code Generation", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const content = readFileSync(join(outDir, "senior-engineer", "SKILL.md"), "utf-8");
@@ -133,12 +133,12 @@ describe("e2e: dev-pipeline", () => {
     ]);
   });
 
-  it("reviewer/SKILL.md contains Code Review", () => {
+  it("reviewer/SKILL.md contains Code Review", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const content = readFileSync(join(outDir, "reviewer", "SKILL.md"), "utf-8");
@@ -148,12 +148,12 @@ describe("e2e: dev-pipeline", () => {
     );
   });
 
-  it("orchestrator/SKILL.md contains composed bodies before orchestrator plan", () => {
+  it("orchestrator/SKILL.md contains composed bodies before orchestrator plan", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const content = readFileSync(join(outDir, "orchestrator", "SKILL.md"), "utf-8");
@@ -167,12 +167,12 @@ describe("e2e: dev-pipeline", () => {
     ]);
   });
 
-  it("orchestrator/SKILL.md contains pipeline header and description", () => {
+  it("orchestrator/SKILL.md contains pipeline header and description", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const content = readFileSync(join(outDir, "orchestrator", "SKILL.md"), "utf-8");
@@ -181,12 +181,12 @@ describe("e2e: dev-pipeline", () => {
     assert.ok(content.includes("**dev-pipeline** pipeline"));
   });
 
-  it("orchestrator/SKILL.md contains state table with correct fields and locations", () => {
+  it("orchestrator/SKILL.md contains state table with correct fields and locations", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const content = readFileSync(join(outDir, "orchestrator", "SKILL.md"), "utf-8");
@@ -206,12 +206,12 @@ describe("e2e: dev-pipeline", () => {
     );
   });
 
-  it("orchestrator/SKILL.md contains execution plan with correct steps", () => {
+  it("orchestrator/SKILL.md contains execution plan with correct steps", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const content = readFileSync(join(outDir, "orchestrator", "SKILL.md"), "utf-8");
@@ -240,12 +240,12 @@ describe("e2e: dev-pipeline", () => {
     );
   });
 
-  it("orchestrator/SKILL.md contains map subgraph steps with correct sub-numbering", () => {
+  it("orchestrator/SKILL.md contains map subgraph steps with correct sub-numbering", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const content = readFileSync(join(outDir, "orchestrator", "SKILL.md"), "utf-8");
@@ -264,12 +264,12 @@ describe("e2e: dev-pipeline", () => {
     assert.ok(content.includes("Writes: `task.approved`"));
   });
 
-  it("orchestrator/SKILL.md contains conditional branches for reviewer", () => {
+  it("orchestrator/SKILL.md contains conditional branches for reviewer", async () => {
     tmpDir = makeTmpDir();
     const outDir = join(tmpDir, "dist");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, fixtureDir);
+    const bodies = await resolveSkills(config, fixtureDir);
     compile(config, bodies, outDir);
 
     const content = readFileSync(join(outDir, "orchestrator", "SKILL.md"), "utf-8");

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -48,7 +48,7 @@ describe("initProject", () => {
     assert.ok(execute.includes("# Execute"));
   });
 
-  it("generated config compiles", () => {
+  it("generated config compiles", async () => {
     tmpDir = makeTmpDir();
     initProject(tmpDir);
 
@@ -56,7 +56,7 @@ describe("initProject", () => {
     const outDir = join(tmpDir, "build");
 
     const config = readConfig(configPath);
-    const bodies = resolveSkills(config, tmpDir);
+    const bodies = await resolveSkills(config, tmpDir);
     const results = compile(config, bodies, outDir);
 
     assert.ok(results.length > 0);

--- a/src/remote.test.ts
+++ b/src/remote.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { ResolveError } from "./errors.js";
+import { fetchRemoteSkill, parseGitHubUrl } from "./remote.js";
+
+describe("parseGitHubUrl", () => {
+  it("parses a valid GitHub tree URL into parts", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/org/skills/tree/main/code-review"
+    );
+    assert.deepEqual(parts, {
+      owner: "org",
+      repo: "skills",
+      ref: "main",
+      path: "code-review",
+    });
+  });
+
+  it("parses a URL with nested path", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/owner/repo/tree/v2.0/src/skills/review"
+    );
+    assert.deepEqual(parts, {
+      owner: "owner",
+      repo: "repo",
+      ref: "v2.0",
+      path: "src/skills/review",
+    });
+  });
+
+  it("throws on a non-GitHub URL", () => {
+    assert.throws(
+      () => parseGitHubUrl("https://example.com/skill"),
+      /URL does not match GitHub tree URL pattern/
+    );
+  });
+
+  it("throws on a malformed GitHub URL with only owner", () => {
+    assert.throws(
+      () => parseGitHubUrl("https://github.com/only-owner"),
+      /URL does not match GitHub tree URL pattern/
+    );
+  });
+
+  it("throws on a GitHub URL missing tree segment", () => {
+    assert.throws(
+      () => parseGitHubUrl("https://github.com/owner/repo/blob/main/file.md"),
+      /URL does not match GitHub tree URL pattern/
+    );
+  });
+});
+
+describe("fetchRemoteSkill", () => {
+  it("rejects non-GitHub URLs with ResolveError", async () => {
+    await assert.rejects(
+      () => fetchRemoteSkill("my-skill", "https://example.com/skill"),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /Unsupported URL format/);
+        assert.match(err.message, /my-skill/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects malformed GitHub URLs with ResolveError", async () => {
+    await assert.rejects(
+      () =>
+        fetchRemoteSkill("bad-url", "https://github.com/only-owner"),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /Unsupported URL format/);
+        assert.match(err.message, /bad-url/);
+        return true;
+      }
+    );
+  });
+
+  it("fetches a real skill from GitHub (code-review)", async () => {
+    const content = await fetchRemoteSkill(
+      "code-review",
+      "https://github.com/byronxlg/skillfold/tree/main/skills/code-review"
+    );
+    assert.ok(
+      content.includes("Code Review"),
+      "Fetched content should contain Code Review"
+    );
+  });
+});

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,0 +1,65 @@
+import { ResolveError } from "./errors.js";
+
+const GITHUB_TREE_RE =
+  /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)$/;
+
+export interface GitHubUrlParts {
+  owner: string;
+  repo: string;
+  ref: string;
+  path: string;
+}
+
+export function parseGitHubUrl(url: string): GitHubUrlParts {
+  const match = GITHUB_TREE_RE.exec(url);
+  if (!match) {
+    throw new Error("URL does not match GitHub tree URL pattern");
+  }
+  return {
+    owner: match[1],
+    repo: match[2],
+    ref: match[3],
+    path: match[4],
+  };
+}
+
+export async function fetchRemoteSkill(
+  name: string,
+  url: string
+): Promise<string> {
+  if (!url.startsWith("https://github.com/")) {
+    throw new ResolveError(
+      name,
+      "Unsupported URL format. Only GitHub tree URLs are supported"
+    );
+  }
+
+  let parts: GitHubUrlParts;
+  try {
+    parts = parseGitHubUrl(url);
+  } catch {
+    throw new ResolveError(
+      name,
+      "Unsupported URL format. Only GitHub tree URLs are supported"
+    );
+  }
+
+  const rawUrl = `https://raw.githubusercontent.com/${parts.owner}/${parts.repo}/${parts.ref}/${parts.path}/SKILL.md`;
+
+  let response: Response;
+  try {
+    response = await fetch(rawUrl);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ResolveError(name, `Network error fetching ${rawUrl}: ${message}`);
+  }
+
+  if (!response.ok) {
+    throw new ResolveError(
+      name,
+      `Failed to fetch ${rawUrl}: HTTP ${response.status}`
+    );
+  }
+
+  return response.text();
+}

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -24,7 +24,7 @@ describe("resolveSkills", () => {
     }
   });
 
-  it("resolves atomic skills, returns trimmed body content", () => {
+  it("resolves atomic skills, returns trimmed body content", async () => {
     tmpDir = makeTmpDir();
 
     const skillDir = join(tmpDir, "skills", "review");
@@ -38,12 +38,12 @@ describe("resolveSkills", () => {
       },
     };
 
-    const bodies = resolveSkills(config, tmpDir);
+    const bodies = await resolveSkills(config, tmpDir);
     assert.equal(bodies.size, 1);
     assert.equal(bodies.get("review"), "Review the code carefully.");
   });
 
-  it("skips composed skills", () => {
+  it("skips composed skills", async () => {
     tmpDir = makeTmpDir();
 
     const skillDir = join(tmpDir, "skills", "lint");
@@ -58,13 +58,13 @@ describe("resolveSkills", () => {
       },
     };
 
-    const bodies = resolveSkills(config, tmpDir);
+    const bodies = await resolveSkills(config, tmpDir);
     assert.equal(bodies.size, 1);
     assert.ok(bodies.has("lint"));
     assert.ok(!bodies.has("quality"));
   });
 
-  it("throws ResolveError for missing directory", () => {
+  it("throws ResolveError for missing directory", async () => {
     tmpDir = makeTmpDir();
 
     const config: Config = {
@@ -74,7 +74,7 @@ describe("resolveSkills", () => {
       },
     };
 
-    assert.throws(() => resolveSkills(config, tmpDir!), (err: unknown) => {
+    await assert.rejects(() => resolveSkills(config, tmpDir!), (err: unknown) => {
       assert.ok(err instanceof ResolveError);
       assert.match(err.message, /Directory not found/);
       assert.match(err.message, /ghost/);
@@ -82,7 +82,7 @@ describe("resolveSkills", () => {
     });
   });
 
-  it("throws ResolveError for missing SKILL.md", () => {
+  it("throws ResolveError for missing SKILL.md", async () => {
     tmpDir = makeTmpDir();
 
     const skillDir = join(tmpDir, "skills", "empty");
@@ -95,7 +95,7 @@ describe("resolveSkills", () => {
       },
     };
 
-    assert.throws(() => resolveSkills(config, tmpDir!), (err: unknown) => {
+    await assert.rejects(() => resolveSkills(config, tmpDir!), (err: unknown) => {
       assert.ok(err instanceof ResolveError);
       assert.match(err.message, /SKILL\.md not found/);
       assert.match(err.message, /empty/);
@@ -103,7 +103,7 @@ describe("resolveSkills", () => {
     });
   });
 
-  it("strips YAML frontmatter from skill body", () => {
+  it("strips YAML frontmatter from skill body", async () => {
     tmpDir = makeTmpDir();
 
     const skillDir = join(tmpDir, "skills", "review");
@@ -129,7 +129,7 @@ Review the code carefully.
       },
     };
 
-    const bodies = resolveSkills(config, tmpDir);
+    const bodies = await resolveSkills(config, tmpDir);
     assert.equal(bodies.size, 1);
     const body = bodies.get("review")!;
     assert.ok(!body.includes("---"), "Body should not contain frontmatter delimiters");
@@ -138,7 +138,7 @@ Review the code carefully.
     assert.ok(body.includes("Review the code carefully."), "Body should contain the body text");
   });
 
-  it("preserves body when no frontmatter present", () => {
+  it("preserves body when no frontmatter present", async () => {
     tmpDir = makeTmpDir();
 
     const skillDir = join(tmpDir, "skills", "lint");
@@ -152,7 +152,26 @@ Review the code carefully.
       },
     };
 
-    const bodies = resolveSkills(config, tmpDir);
+    const bodies = await resolveSkills(config, tmpDir);
     assert.equal(bodies.get("lint"), "# Lint\n\nRun the linter.");
+  });
+
+  it("resolves a remote skill from a real GitHub URL, stripping frontmatter", async () => {
+    const config: Config = {
+      name: "test",
+      skills: {
+        "code-review": {
+          path: "https://github.com/byronxlg/skillfold/tree/main/skills/code-review",
+        },
+      },
+    };
+
+    const bodies = await resolveSkills(config, "/unused");
+    assert.equal(bodies.size, 1);
+    const body = bodies.get("code-review")!;
+    assert.ok(
+      body.includes("Code Review"),
+      "Remote skill body should contain Code Review"
+    );
   });
 });

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,16 +1,38 @@
-import { readFileSync, existsSync } from "node:fs";
-import { resolve, join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
 import { type Config, isAtomic } from "./config.js";
 import { ResolveError } from "./errors.js";
+import { fetchRemoteSkill } from "./remote.js";
 
-export function resolveSkills(
+export function stripFrontmatter(content: string): string {
+  const trimmed = content.trim();
+  if (trimmed.startsWith("---\n") || trimmed.startsWith("---\r\n")) {
+    const endIndex = trimmed.indexOf("\n---", 3);
+    if (endIndex !== -1) {
+      return trimmed.slice(endIndex + 4).trim();
+    }
+  }
+  return trimmed;
+}
+
+export async function resolveSkills(
   config: Config,
   baseDir: string
-): Map<string, string> {
+): Promise<Map<string, string>> {
   const bodies = new Map<string, string>();
+  const remotePromises: { name: string; promise: Promise<string> }[] = [];
 
   for (const [name, skill] of Object.entries(config.skills)) {
     if (!isAtomic(skill)) continue;
+
+    if (skill.path.startsWith("https://")) {
+      remotePromises.push({
+        name,
+        promise: fetchRemoteSkill(name, skill.path),
+      });
+      continue;
+    }
 
     const skillDir = resolve(baseDir, skill.path);
     const skillFile = join(skillDir, "SKILL.md");
@@ -30,14 +52,18 @@ export function resolveSkills(
       throw new ResolveError(name, `Cannot read ${skillFile}`);
     }
 
-    let body = content.trim();
-    if (body.startsWith("---\n") || body.startsWith("---\r\n")) {
-      const endIndex = body.indexOf("\n---", 3);
-      if (endIndex !== -1) {
-        body = body.slice(endIndex + 4).trim();
-      }
+    bodies.set(name, stripFrontmatter(content));
+  }
+
+  if (remotePromises.length > 0) {
+    const results = await Promise.all(
+      remotePromises.map(({ name, promise }) =>
+        promise.then((content) => ({ name, content }))
+      )
+    );
+    for (const { name, content } of results) {
+      bodies.set(name, stripFrontmatter(content));
     }
-    bodies.set(name, body);
   }
 
   return bodies;


### PR DESCRIPTION
## Summary

- Add `src/remote.ts` with `fetchRemoteSkill` and `parseGitHubUrl` to fetch SKILL.md files from GitHub tree URLs via raw.githubusercontent.com
- Make `resolveSkills` in `src/resolver.ts` async, routing `https://` paths through remote fetch and local paths through existing `readFileSync` logic. Remote skills are fetched in parallel with `Promise.all`.
- Extract `stripFrontmatter` helper from inline logic and apply it to both local and remote content
- Update `src/cli.ts` to `await resolveSkills`
- Update all test files (`resolver.test.ts`, `e2e.test.ts`, `init.test.ts`) for async
- Add `src/remote.test.ts` with URL parsing tests and a real-fetch integration test against this repo's own `skills/code-review`
- Add resolver test for remote skill resolution with frontmatter stripping

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (175 tests, 0 failures)
- [x] Real-fetch tests hit `github.com/byronxlg/skillfold/tree/main/skills/code-review` and verify content

Generated with [Claude Code](https://claude.com/claude-code)