### PR TITLE
Add pipeline imports

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { readConfig } from "./config.js";
+import { loadConfig } from "./config.js";
 import { compile } from "./compiler.js";
 import { ConfigError, CompileError, ResolveError } from "./errors.js";
 import { initProject } from "./init.js";
@@ -111,7 +111,7 @@ async function main(): Promise<void> {
   }
 
   try {
-    const config = readConfig(args.configPath);
+    const config = await loadConfig(args.configPath);
     const baseDir = dirname(args.configPath);
     const bodies = await resolveSkills(config, baseDir);
     const results = compile(config, bodies, args.outDir);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 
-import { isAtomic, isComposed, readConfig } from "./config.js";
+import { isAtomic, isComposed, loadConfig, readConfig } from "./config.js";
+import { compile } from "./compiler.js";
 import { ConfigError } from "./errors.js";
+import { resolveSkills } from "./resolver.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = join(__dirname, "..", "test", "fixtures", "imports");
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `skillfold-config-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -566,6 +572,160 @@ orchestrator: nonexistent
     assert.throws(() => readConfig(configPath), (err: unknown) => {
       assert.ok(err instanceof ConfigError);
       assert.match(err.message, /Orchestrator references unknown skill "nonexistent"/);
+      return true;
+    });
+  });
+});
+
+describe("loadConfig imports", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("local import merges skills", async () => {
+    const configPath = join(fixturesDir, "main", "skillfold.yaml");
+    const config = await loadConfig(configPath);
+    assert.ok("common-skill" in config.skills, "imported skill should be present");
+    assert.ok("local-skill" in config.skills, "local skill should be present");
+    assert.ok("combined" in config.skills, "composed skill should be present");
+  });
+
+  it("composed skill references imported skill", async () => {
+    const configPath = join(fixturesDir, "main", "skillfold.yaml");
+    const config = await loadConfig(configPath);
+    const combined = config.skills["combined"];
+    assert.ok(isComposed(combined));
+    assert.deepEqual(combined.compose, ["common-skill", "local-skill"]);
+  });
+
+  it("state merges from import", async () => {
+    const configPath = join(fixturesDir, "main", "skillfold.yaml");
+    const config = await loadConfig(configPath);
+    assert.ok(config.state, "merged config should have state");
+    assert.ok("SharedType" in config.state.types, "imported custom type should be present");
+    assert.ok("shared-field" in config.state.fields, "imported state field should be present");
+  });
+
+  it("local override wins", async () => {
+    const configPath = join(fixturesDir, "override", "skillfold.yaml");
+    const config = await loadConfig(configPath);
+    const skill = config.skills["common-skill"];
+    assert.ok(isAtomic(skill));
+    // Local path should be ./skills/common (not the imported ../shared path)
+    assert.equal(skill.path, "./skills/common");
+  });
+
+  it("imported graph is ignored", async () => {
+    tmpDir = makeTmpDir();
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(configPath, `
+imports:
+  - ${join(fixturesDir, "with-graph", "skillfold.yaml")}
+
+name: no-graph
+skills:
+  my-skill: ./dummy
+`, "utf-8");
+    const config = await loadConfig(configPath);
+    assert.equal(config.graph, undefined, "graph from import should not carry over");
+  });
+
+  it("imported imports are ignored", async () => {
+    tmpDir = makeTmpDir();
+    const configPath = join(tmpDir, "skillfold.yaml");
+    // Import a config that itself has imports - those nested imports should be ignored
+    writeFileSync(configPath, `
+imports:
+  - ${join(fixturesDir, "nested-imports", "skillfold.yaml")}
+
+name: flat
+skills:
+  top-skill: ./dummy
+`, "utf-8");
+    const config = await loadConfig(configPath);
+    // nested-imports imports shared, but since nested imports are ignored,
+    // common-skill should NOT be in our merged config
+    assert.ok(!("common-skill" in config.skills), "nested import's skills should not be present");
+    // nested-skill from the directly imported config should be present
+    assert.ok("nested-skill" in config.skills, "directly imported skill should be present");
+  });
+
+  it("missing import file throws ConfigError", async () => {
+    tmpDir = makeTmpDir();
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(configPath, `
+imports:
+  - ./nonexistent/skillfold.yaml
+
+name: broken
+skills:
+  my-skill: ./dummy
+`, "utf-8");
+    await assert.rejects(() => loadConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /Cannot read imported config/);
+      return true;
+    });
+  });
+
+  it("full pipeline: loadConfig, resolveSkills, compile", async () => {
+    tmpDir = makeTmpDir();
+    const outDir = join(tmpDir, "build");
+    const configPath = join(fixturesDir, "main", "skillfold.yaml");
+    const baseDir = dirname(configPath);
+
+    const config = await loadConfig(configPath);
+    const bodies = await resolveSkills(config, baseDir);
+    const results = compile(config, bodies, outDir);
+
+    assert.ok(results.length > 0, "should produce compile results");
+    // The composed skill 'combined' should be compiled
+    assert.ok(
+      existsSync(join(outDir, "combined", "SKILL.md")),
+      "combined/SKILL.md should exist"
+    );
+
+    const content = readFileSync(join(outDir, "combined", "SKILL.md"), "utf-8");
+    assert.ok(content.includes("Common Skill"), "should contain imported skill body");
+    assert.ok(content.includes("Local Skill"), "should contain local skill body");
+  });
+
+  it("invalid imports type throws ConfigError", async () => {
+    tmpDir = makeTmpDir();
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(configPath, `
+imports: not-an-array
+
+name: broken
+skills:
+  my-skill: ./dummy
+`, "utf-8");
+    await assert.rejects(() => loadConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /Imports must be an array of strings/);
+      return true;
+    });
+  });
+
+  it("imports with non-string elements throws ConfigError", async () => {
+    tmpDir = makeTmpDir();
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(configPath, `
+imports:
+  - 42
+
+name: broken
+skills:
+  my-skill: ./dummy
+`, "utf-8");
+    await assert.rejects(() => loadConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /Imports must be an array of strings/);
       return true;
     });
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
 
 import { parse } from "yaml";
 
 import { ConfigError } from "./errors.js";
 import { Graph, parseGraph, validateGraph } from "./graph.js";
+import { fetchRemoteConfig } from "./remote.js";
 import { parseState, StateSchema } from "./state.js";
 
 export interface AtomicSkill {
@@ -23,6 +25,15 @@ export interface Config {
   state?: StateSchema;
   graph?: Graph;
   orchestrator?: string;
+}
+
+export interface RawConfig {
+  name: string;
+  skills: Record<string, SkillEntry>;
+  rawState?: Record<string, unknown>;
+  rawGraph?: unknown[];
+  orchestrator?: string;
+  imports?: string[];
 }
 
 export function isAtomic(skill: SkillEntry): skill is AtomicSkill {
@@ -142,14 +153,8 @@ function detectCycles(skills: Record<string, SkillEntry>): void {
   }
 }
 
-export function readConfig(configPath: string): Config {
-  let content: string;
-  try {
-    content = readFileSync(configPath, "utf-8");
-  } catch {
-    throw new ConfigError(`Cannot read config file: ${configPath}`);
-  }
-
+// Phase 1: Parse YAML and normalize structure without cross-validation
+export function parseRawConfig(content: string): RawConfig {
   const raw = parse(content);
   if (typeof raw !== "object" || raw === null) {
     throw new ConfigError("Config must be a YAML object");
@@ -165,33 +170,63 @@ export function readConfig(configPath: string): Config {
 
   const skills = normalizeSkills(raw.skills);
   validateNames(skills);
-  validateReferences(skills);
-  detectCycles(skills);
 
-  const config: Config = { name: raw.name, skills };
+  const result: RawConfig = { name: raw.name, skills };
 
   if (raw.state !== undefined) {
     if (typeof raw.state !== "object" || raw.state === null) {
       throw new ConfigError("State must be a YAML object");
     }
-    const skillNames = new Set(Object.keys(skills));
-    config.state = parseState(raw.state as Record<string, unknown>, skillNames);
+    result.rawState = raw.state as Record<string, unknown>;
   }
 
   if (raw.graph !== undefined) {
     if (!Array.isArray(raw.graph)) {
       throw new ConfigError("Graph must be a YAML array");
     }
-    const graph = parseGraph(raw.graph);
-    validateGraph(graph, skills, config.state);
-    config.graph = graph;
+    result.rawGraph = raw.graph;
   }
 
   if (raw.orchestrator !== undefined) {
     if (typeof raw.orchestrator !== "string") {
       throw new ConfigError("Orchestrator must be a string (skill name)");
     }
-    if (!(raw.orchestrator in skills)) {
+    result.orchestrator = raw.orchestrator;
+  }
+
+  if (raw.imports !== undefined) {
+    if (
+      !Array.isArray(raw.imports) ||
+      !raw.imports.every((v: unknown) => typeof v === "string")
+    ) {
+      throw new ConfigError("Imports must be an array of strings");
+    }
+    result.imports = raw.imports;
+  }
+
+  return result;
+}
+
+// Phase 2: Run full validation on a (possibly merged) RawConfig
+export function validateAndBuild(raw: RawConfig): Config {
+  validateReferences(raw.skills);
+  detectCycles(raw.skills);
+
+  const config: Config = { name: raw.name, skills: raw.skills };
+
+  if (raw.rawState !== undefined) {
+    const skillNames = new Set(Object.keys(raw.skills));
+    config.state = parseState(raw.rawState, skillNames);
+  }
+
+  if (raw.rawGraph !== undefined) {
+    const graph = parseGraph(raw.rawGraph);
+    validateGraph(graph, raw.skills, config.state);
+    config.graph = graph;
+  }
+
+  if (raw.orchestrator !== undefined) {
+    if (!(raw.orchestrator in raw.skills)) {
       throw new ConfigError(
         `Orchestrator references unknown skill "${raw.orchestrator}"`
       );
@@ -200,4 +235,121 @@ export function readConfig(configPath: string): Config {
   }
 
   return config;
+}
+
+// Rebase imported atomic skill paths from importDir-relative to targetDir-relative.
+// Remote (https://) paths are left unchanged.
+function rebaseSkillPaths(
+  skills: Record<string, SkillEntry>,
+  importDir: string,
+  targetDir: string,
+): Record<string, SkillEntry> {
+  const result: Record<string, SkillEntry> = {};
+  for (const [name, skill] of Object.entries(skills)) {
+    if (isAtomic(skill) && !skill.path.startsWith("https://")) {
+      const abs = resolve(importDir, skill.path);
+      const rebased = relative(targetDir, abs);
+      result[name] = { path: rebased };
+    } else {
+      result[name] = skill;
+    }
+  }
+  return result;
+}
+
+// Merge helpers
+function mergeSkills(
+  base: Record<string, SkillEntry>,
+  overlay: Record<string, SkillEntry>,
+): Record<string, SkillEntry> {
+  return { ...base, ...overlay };
+}
+
+function mergeRawState(
+  base: Record<string, unknown> | undefined,
+  overlay: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!base) return overlay;
+  if (!overlay) return base;
+  return { ...base, ...overlay };
+}
+
+// Resolve imports: load each import, merge skills and state, ignore graph/orchestrator/imports
+async function resolveImports(
+  raw: RawConfig,
+  baseDir: string,
+): Promise<RawConfig> {
+  if (!raw.imports || raw.imports.length === 0) {
+    return raw;
+  }
+
+  let mergedSkills: Record<string, SkillEntry> = {};
+  let mergedState: Record<string, unknown> | undefined;
+
+  for (const importPath of raw.imports) {
+    let content: string;
+    let importDir: string | undefined;
+
+    if (importPath.startsWith("https://")) {
+      content = await fetchRemoteConfig(importPath);
+      // Remote imports keep their paths as-is (already URLs or relative to remote)
+    } else {
+      const resolved = resolve(baseDir, importPath);
+      importDir = dirname(resolved);
+      try {
+        content = readFileSync(resolved, "utf-8");
+      } catch {
+        throw new ConfigError(`Cannot read imported config: ${resolved}`);
+      }
+    }
+
+    const imported = parseRawConfig(content);
+    // Ignore imported config's imports (no recursion in v1)
+    // Rebase local skill paths so they resolve correctly from the importing config's dir
+    const skills = importDir
+      ? rebaseSkillPaths(imported.skills, importDir, baseDir)
+      : imported.skills;
+    mergedSkills = mergeSkills(mergedSkills, skills);
+    mergedState = mergeRawState(mergedState, imported.rawState);
+  }
+
+  // Apply local on top (last-write-wins)
+  mergedSkills = mergeSkills(mergedSkills, raw.skills);
+  mergedState = mergeRawState(mergedState, raw.rawState);
+
+  return {
+    name: raw.name,
+    skills: mergedSkills,
+    rawState: mergedState,
+    rawGraph: raw.rawGraph,
+    orchestrator: raw.orchestrator,
+    // imports consumed
+  };
+}
+
+// Original synchronous entry point (unchanged API)
+export function readConfig(configPath: string): Config {
+  let content: string;
+  try {
+    content = readFileSync(configPath, "utf-8");
+  } catch {
+    throw new ConfigError(`Cannot read config file: ${configPath}`);
+  }
+
+  const raw = parseRawConfig(content);
+  return validateAndBuild(raw);
+}
+
+// Async entry point that resolves imports before validation
+export async function loadConfig(configPath: string): Promise<Config> {
+  let content: string;
+  try {
+    content = readFileSync(configPath, "utf-8");
+  } catch {
+    throw new ConfigError(`Cannot read config file: ${configPath}`);
+  }
+
+  const raw = parseRawConfig(content);
+  const merged = await resolveImports(raw, dirname(configPath));
+  return validateAndBuild(merged);
 }

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,4 +1,4 @@
-import { ResolveError } from "./errors.js";
+import { ConfigError, ResolveError } from "./errors.js";
 
 const GITHUB_TREE_RE =
   /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)$/;
@@ -58,6 +58,41 @@ export async function fetchRemoteSkill(
     throw new ResolveError(
       name,
       `Failed to fetch ${rawUrl}: HTTP ${response.status}`
+    );
+  }
+
+  return response.text();
+}
+
+export async function fetchRemoteConfig(url: string): Promise<string> {
+  if (!url.startsWith("https://github.com/")) {
+    throw new ConfigError(
+      `Unsupported import URL format: ${url}. Only GitHub tree URLs are supported`
+    );
+  }
+
+  let parts: GitHubUrlParts;
+  try {
+    parts = parseGitHubUrl(url);
+  } catch {
+    throw new ConfigError(
+      `Unsupported import URL format: ${url}. Only GitHub tree URLs are supported`
+    );
+  }
+
+  const rawUrl = `https://raw.githubusercontent.com/${parts.owner}/${parts.repo}/${parts.ref}/${parts.path}/skillfold.yaml`;
+
+  let response: Response;
+  try {
+    response = await fetch(rawUrl);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ConfigError(`Network error fetching import from ${rawUrl}: ${message}`);
+  }
+
+  if (!response.ok) {
+    throw new ConfigError(
+      `Failed to fetch import from ${rawUrl}: HTTP ${response.status}`
     );
   }
 

--- a/test/fixtures/imports/main/skillfold.yaml
+++ b/test/fixtures/imports/main/skillfold.yaml
@@ -1,0 +1,9 @@
+imports:
+  - ../shared/skillfold.yaml
+
+name: main-pipeline
+skills:
+  local-skill: ./skills/local
+  combined:
+    compose: [common-skill, local-skill]
+    description: "Uses both imported and local skills."

--- a/test/fixtures/imports/main/skills/local/SKILL.md
+++ b/test/fixtures/imports/main/skills/local/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: local
+description: A local skill.
+---
+# Local Skill
+Defined locally.

--- a/test/fixtures/imports/nested-imports/skillfold.yaml
+++ b/test/fixtures/imports/nested-imports/skillfold.yaml
@@ -1,0 +1,6 @@
+imports:
+  - ../shared/skillfold.yaml
+
+name: nested
+skills:
+  nested-skill: ./dummy

--- a/test/fixtures/imports/override/skillfold.yaml
+++ b/test/fixtures/imports/override/skillfold.yaml
@@ -1,0 +1,6 @@
+imports:
+  - ../shared/skillfold.yaml
+
+name: override-pipeline
+skills:
+  common-skill: ./skills/common

--- a/test/fixtures/imports/override/skills/common/SKILL.md
+++ b/test/fixtures/imports/override/skills/common/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: common
+description: Overridden common skill.
+---
+# Overridden Common Skill
+This replaces the shared version.

--- a/test/fixtures/imports/shared/skillfold.yaml
+++ b/test/fixtures/imports/shared/skillfold.yaml
@@ -1,0 +1,8 @@
+name: shared
+skills:
+  common-skill: ./skills/common
+state:
+  SharedType:
+    value: string
+  shared-field:
+    type: string

--- a/test/fixtures/imports/shared/skills/common/SKILL.md
+++ b/test/fixtures/imports/shared/skills/common/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: common
+description: A shared skill.
+---
+# Common Skill
+Shared across pipelines.

--- a/test/fixtures/imports/with-graph/skillfold.yaml
+++ b/test/fixtures/imports/with-graph/skillfold.yaml
@@ -1,0 +1,9 @@
+name: graph-config
+skills:
+  planner: ./dummy
+state:
+  goal:
+    type: string
+graph:
+  - planner:
+      writes: [state.goal]


### PR DESCRIPTION
## Summary

- Configs can now import skills and state from other configs via an `imports` array (local paths or GitHub URLs)
- Imports bring in skills and state only - graph, orchestrator, and name are not imported
- Merge order: imports in array order, then local config (last-write-wins per key)
- Imported configs' own imports are ignored (no recursion in v1)
- Validation runs on the merged result

## Implementation

- `src/remote.ts`: Added `fetchRemoteConfig` for GitHub URL imports
- `src/config.ts`: Refactored `readConfig` into `parseRawConfig` + `validateAndBuild` phases, added `resolveImports` with path rebasing, added async `loadConfig` entry point
- `src/cli.ts`: Switched from `readConfig` to `loadConfig`
- 10 new tests covering local imports, state merging, overrides, graph/import ignoring, missing files, full pipeline, and validation errors

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (185 tests, 0 failures)
- [x] Existing tests unaffected (readConfig still works synchronously for non-import configs)
- [x] New `loadConfig imports` test suite covers: local import merging, composed skill references, state merging, local override wins, imported graph ignored, nested imports ignored, missing import error, full pipeline (load + resolve + compile), invalid imports type, non-string import elements

Generated with [Claude Code](https://claude.com/claude-code)