### PR TITLE
Add `skillfold graph` command for Mermaid flowcharts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,9 +5,10 @@ import { fileURLToPath } from "node:url";
 
 import { loadConfig } from "./config.js";
 import { compile } from "./compiler.js";
-import { ConfigError, CompileError, ResolveError } from "./errors.js";
+import { ConfigError, CompileError, GraphError, ResolveError } from "./errors.js";
 import { initProject } from "./init.js";
 import { resolveSkills } from "./resolver.js";
+import { generateMermaid } from "./visualize.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(
@@ -21,6 +22,7 @@ Usage: skillfold [command] [options]
 
 Commands:
   init              Scaffold a new pipeline project
+  graph             Output Mermaid flowchart of the execution graph
   (default)         Compile the pipeline config
 
 Options:
@@ -32,7 +34,7 @@ Options:
 }
 
 interface Args {
-  command: "init" | "compile";
+  command: "init" | "compile" | "graph";
   configPath: string;
   outDir: string;
   dir: string;
@@ -41,7 +43,7 @@ interface Args {
 }
 
 function parseArgs(argv: string[]): Args {
-  let command: "init" | "compile" = "compile";
+  let command: "init" | "compile" | "graph" = "compile";
   let configPath = "skillfold.yaml";
   let outDir = "build";
   let dir = ".";
@@ -53,6 +55,9 @@ function parseArgs(argv: string[]): Args {
   // Check for subcommand as first positional arg
   if (argv.length > 0 && argv[0] === "init") {
     command = "init";
+    i = 1;
+  } else if (argv.length > 0 && argv[0] === "graph") {
+    command = "graph";
     i = 1;
   }
 
@@ -102,6 +107,25 @@ async function main(): Promise<void> {
       }
     } catch (err) {
       if (err instanceof Error) {
+        console.error(`skillfold error: ${err.message}`);
+        process.exit(1);
+      }
+      throw err;
+    }
+    return;
+  }
+
+  if (args.command === "graph") {
+    try {
+      const config = await loadConfig(args.configPath);
+      if (!config.graph) {
+        console.error("skillfold error: No graph defined in config");
+        process.exit(1);
+      }
+      const output = generateMermaid(config.graph);
+      process.stdout.write(output);
+    } catch (err) {
+      if (err instanceof ConfigError || err instanceof GraphError) {
         console.error(`skillfold error: ${err.message}`);
         process.exit(1);
       }

--- a/src/visualize.test.ts
+++ b/src/visualize.test.ts
@@ -1,0 +1,244 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { Graph, GraphNode, MapNode, StepNode } from "./graph.js";
+import { generateMermaid } from "./visualize.js";
+
+// Helper: build a StepNode
+function step(
+  skill: string,
+  opts?: { reads?: string[]; writes?: string[]; then?: StepNode["then"] },
+): StepNode {
+  return {
+    skill,
+    reads: opts?.reads ?? [],
+    writes: opts?.writes ?? [],
+    ...(opts?.then !== undefined ? { then: opts.then } : {}),
+  };
+}
+
+// Helper: build a MapNode
+function map(
+  over: string,
+  as: string,
+  graph: GraphNode[],
+  then?: MapNode["then"],
+): MapNode {
+  return {
+    over,
+    as,
+    graph,
+    ...(then !== undefined ? { then } : {}),
+  };
+}
+
+describe("generateMermaid", () => {
+  it("renders a linear graph with arrows between nodes", () => {
+    const graph: Graph = {
+      nodes: [
+        step("alpha", { then: "bravo" }),
+        step("bravo", { then: "charlie" }),
+        step("charlie"),
+      ],
+    };
+    const output = generateMermaid(graph);
+    assert.equal(
+      output,
+      [
+        "graph TD",
+        "    alpha --> bravo",
+        "    bravo --> charlie",
+        "    charlie --> end_node([end])",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("renders conditional transitions with labels", () => {
+    const graph: Graph = {
+      nodes: [
+        step("strategist", { then: "reviewer" }),
+        step("reviewer", {
+          then: [
+            { when: "review.approved == false", to: "strategist" },
+            { when: "review.approved == true", to: "end" },
+          ],
+        }),
+      ],
+    };
+    const output = generateMermaid(graph);
+    assert.equal(
+      output,
+      [
+        "graph TD",
+        "    strategist --> reviewer",
+        '    reviewer -->|"review.approved == false"| strategist',
+        '    reviewer -->|"review.approved == true"| end_node([end])',
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("renders a map node as a subgraph with inner nodes", () => {
+    const graph: Graph = {
+      nodes: [
+        step("strategy", { then: "map" }),
+        map("state.tasks", "task", [
+          step("engineer", { then: "reviewer" }),
+          step("reviewer", {
+            then: [
+              { when: "task.approved == false", to: "engineer" },
+              { when: "task.approved == true", to: "end" },
+            ],
+          }),
+        ]),
+      ],
+    };
+    const output = generateMermaid(graph);
+    // The map subgraph should be rendered with its inner nodes
+    assert.ok(output.includes('subgraph map_state_tasks["map over state.tasks"]'));
+    assert.ok(output.includes("        engineer --> reviewer"));
+    assert.ok(
+      output.includes(
+        '        reviewer -->|"task.approved == false"| engineer',
+      ),
+    );
+    assert.ok(
+      output.includes(
+        '        reviewer -->|"task.approved == true"| end_map_state_tasks([end])',
+      ),
+    );
+    assert.ok(output.includes("    end"));
+  });
+
+  it("renders terminal end node for explicit then: end", () => {
+    const graph: Graph = {
+      nodes: [step("alpha", { then: "end" })],
+    };
+    const output = generateMermaid(graph);
+    assert.equal(
+      output,
+      ["graph TD", "    alpha --> end_node([end])", ""].join("\n"),
+    );
+  });
+
+  it("renders hyphenated names with underscore IDs and correct labels", () => {
+    const graph: Graph = {
+      nodes: [
+        step("senior-engineer", { then: "code-reviewer" }),
+        step("code-reviewer", { then: "end" }),
+      ],
+    };
+    const output = generateMermaid(graph);
+    assert.ok(output.includes('senior_engineer["senior-engineer"]'));
+    assert.ok(output.includes('code_reviewer["code-reviewer"]'));
+    assert.ok(output.includes("senior_engineer --> code_reviewer"));
+    assert.ok(output.includes("code_reviewer --> end_node([end])"));
+  });
+
+  it("renders implicit fall-through between nodes with no then", () => {
+    const graph: Graph = {
+      nodes: [step("alpha"), step("bravo"), step("charlie")],
+    };
+    const output = generateMermaid(graph);
+    assert.equal(
+      output,
+      [
+        "graph TD",
+        "    alpha --> bravo",
+        "    bravo --> charlie",
+        "    charlie --> end_node([end])",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("renders the project config graph correctly", () => {
+    const graph: Graph = {
+      nodes: [
+        step("strategist", {
+          writes: ["state.direction"],
+          then: "architect",
+        }),
+        step("architect", {
+          reads: ["state.direction"],
+          writes: ["state.plan"],
+          then: "engineer",
+        }),
+        step("engineer", {
+          reads: ["state.plan"],
+          writes: ["state.implementation"],
+          then: "reviewer",
+        }),
+        step("reviewer", {
+          reads: ["state.implementation"],
+          writes: ["state.review"],
+          then: [
+            { when: "review.approved == false", to: "engineer" },
+            { when: "review.approved == true", to: "end" },
+          ],
+        }),
+      ],
+    };
+    const output = generateMermaid(graph);
+    assert.equal(
+      output,
+      [
+        "graph TD",
+        "    strategist --> architect",
+        "    architect --> engineer",
+        "    engineer --> reviewer",
+        '    reviewer -->|"review.approved == false"| engineer',
+        '    reviewer -->|"review.approved == true"| end_node([end])',
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("renders the brief example with map correctly", () => {
+    const graph: Graph = {
+      nodes: [
+        step("strategy", { then: "tech-lead" }),
+        step("tech-lead", { then: "map" }),
+        map("state.tasks", "task", [
+          step("senior-engineer", { then: "reviewer" }),
+          step("reviewer", {
+            then: [
+              { when: "task.approved == false", to: "senior-engineer" },
+              { when: "task.approved == true", to: "end" },
+            ],
+          }),
+        ]),
+      ],
+    };
+    const output = generateMermaid(graph);
+    assert.equal(
+      output,
+      [
+        "graph TD",
+        "    strategy --> tech_lead",
+        '    tech_lead["tech-lead"]',
+        "    tech_lead --> map_state_tasks",
+        '    subgraph map_state_tasks["map over state.tasks"]',
+        '        senior_engineer["senior-engineer"]',
+        "        senior_engineer --> reviewer",
+        '        reviewer -->|"task.approved == false"| senior_engineer',
+        '        reviewer -->|"task.approved == true"| end_map_state_tasks([end])',
+        "    end",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("renders implicit fall-through to a map node", () => {
+    const graph: Graph = {
+      nodes: [
+        step("planner"),
+        map("state.items", "item", [step("worker")]),
+      ],
+    };
+    const output = generateMermaid(graph);
+    assert.ok(output.includes("planner --> map_state_items"));
+    assert.ok(output.includes("worker --> end_map_state_items([end])"));
+  });
+});

--- a/src/visualize.ts
+++ b/src/visualize.ts
@@ -1,0 +1,128 @@
+import { Graph, GraphNode, isConditionalThen, isMapNode } from "./graph.js";
+
+// Sanitize a name into a valid Mermaid node ID by replacing non-alphanumeric
+// characters with underscores.
+function sanitizeId(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_]/g, "_");
+}
+
+// Only emit a label declaration if the name differs from its sanitized ID.
+function nodeDecl(name: string): string {
+  const id = sanitizeId(name);
+  if (id !== name) {
+    return `${id}["${name}"]`;
+  }
+  return id;
+}
+
+// Build a mapping from graph-level node labels ("skill" for steps, "map" for
+// map nodes) to their Mermaid IDs. This lets `then: "map"` resolve to the
+// correct subgraph ID.
+function buildIdMap(nodes: GraphNode[]): Map<string, string> {
+  const ids = new Map<string, string>();
+  for (const node of nodes) {
+    if (isMapNode(node)) {
+      ids.set("map", `map_${sanitizeId(node.over)}`);
+    } else {
+      ids.set(node.skill, sanitizeId(node.skill));
+    }
+  }
+  return ids;
+}
+
+// Resolve a then-target name to a Mermaid ID using the id map.
+function resolveTarget(target: string, idMap: Map<string, string>): string {
+  return idMap.get(target) ?? sanitizeId(target);
+}
+
+// Render nodes at one level of the graph, collecting lines into the output array.
+function renderNodes(
+  nodes: GraphNode[],
+  lines: string[],
+  indent: string,
+  endNodeId: string,
+): void {
+  const idMap = buildIdMap(nodes);
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+
+    if (isMapNode(node)) {
+      const subgraphId = `map_${sanitizeId(node.over)}`;
+      const subgraphLabel = `map over ${node.over}`;
+      lines.push(`${indent}subgraph ${subgraphId}["${subgraphLabel}"]`);
+      const innerIndent = indent + "    ";
+      const innerEndId = `end_${subgraphId}`;
+      renderNodes(node.graph, lines, innerIndent, innerEndId);
+      lines.push(`${indent}end`);
+
+      // Connect map subgraph to the next node if there's a then
+      if (node.then !== undefined) {
+        renderThen(lines, indent, subgraphId, node.then, endNodeId, idMap);
+      } else {
+        // Implicit fall-through: connect to next sibling if present
+        const nextNode = nodes[i + 1];
+        if (nextNode) {
+          const nextId = isMapNode(nextNode)
+            ? `map_${sanitizeId(nextNode.over)}`
+            : sanitizeId(nextNode.skill);
+          lines.push(`${indent}${subgraphId} --> ${nextId}`);
+        }
+      }
+    } else {
+      const currentId = sanitizeId(node.skill);
+
+      // Emit a node declaration if the name needs a label
+      if (currentId !== node.skill) {
+        lines.push(`${indent}${nodeDecl(node.skill)}`);
+      }
+
+      if (node.then !== undefined) {
+        renderThen(lines, indent, currentId, node.then, endNodeId, idMap);
+      } else {
+        // Implicit fall-through
+        const nextNode = nodes[i + 1];
+        if (nextNode) {
+          const nextTarget = isMapNode(nextNode)
+            ? `map_${sanitizeId(nextNode.over)}`
+            : sanitizeId(nextNode.skill);
+          lines.push(`${indent}${currentId} --> ${nextTarget}`);
+        } else {
+          // Last node with no then: arrow to end
+          lines.push(`${indent}${currentId} --> ${endNodeId}([end])`);
+        }
+      }
+    }
+  }
+}
+
+function renderThen(
+  lines: string[],
+  indent: string,
+  fromId: string,
+  then: NonNullable<GraphNode["then"]>,
+  endNodeId: string,
+  idMap: Map<string, string>,
+): void {
+  if (isConditionalThen(then)) {
+    for (const branch of then) {
+      const targetId =
+        branch.to === "end"
+          ? `${endNodeId}([end])`
+          : resolveTarget(branch.to, idMap);
+      lines.push(`${indent}${fromId} -->|"${branch.when}"| ${targetId}`);
+    }
+  } else {
+    if (then === "end") {
+      lines.push(`${indent}${fromId} --> ${endNodeId}([end])`);
+    } else {
+      lines.push(`${indent}${fromId} --> ${resolveTarget(then, idMap)}`);
+    }
+  }
+}
+
+export function generateMermaid(graph: Graph): string {
+  const lines: string[] = ["graph TD"];
+  renderNodes(graph.nodes, lines, "    ", "end_node");
+  return lines.join("\n") + "\n";
+}


### PR DESCRIPTION
## Summary

- Add `skillfold graph` subcommand that loads the config, walks the execution graph, and prints a Mermaid `graph TD` flowchart to stdout
- New `src/visualize.ts` module with `generateMermaid(graph)` function supporting unconditional/conditional transitions, map subgraphs, hyphenated node names, implicit fall-through, and terminal end nodes
- Update `src/cli.ts` with `graph` command parsing and handler
- 9 new tests in `src/visualize.test.ts` covering linear graphs, conditionals, map subgraphs, end nodes, hyphenated names, implicit fall-through, and both example configs from the task spec

Example output for the project's own config:

```mermaid
graph TD
    strategist --> architect
    architect --> engineer
    engineer --> reviewer
    reviewer -->|"review.approved == false"| engineer
    reviewer -->|"review.approved == true"| end_node([end])
```

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (194 tests, 0 failures)
- [x] `npx tsx src/cli.ts graph` produces valid Mermaid for the project config
- [ ] CI passes