### PR TITLE
Enhance skillfold graph to show full skill lineage

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -122,7 +122,7 @@ async function main(): Promise<void> {
         console.error("skillfold error: No team defined in config");
         process.exit(1);
       }
-      const output = generateMermaid(config.team.flow);
+      const output = generateMermaid(config);
       process.stdout.write(output);
     } catch (err) {
       if (err instanceof ConfigError || err instanceof GraphError) {

--- a/src/visualize.test.ts
+++ b/src/visualize.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { Graph, GraphNode, MapNode, StepNode } from "./graph.js";
+import type { Config } from "./config.js";
+import type { GraphNode, MapNode, StepNode } from "./graph.js";
 import { generateMermaid } from "./visualize.js";
 
 // Helper: build a StepNode
@@ -32,16 +33,33 @@ function map(
   };
 }
 
+// Helper: build a Config with only atomic skills (no composition subgraphs)
+function atomicConfig(
+  nodes: GraphNode[],
+  skillNames?: string[],
+): Config {
+  const names = skillNames ?? nodes
+    .filter((n): n is StepNode => "skill" in n)
+    .map((n) => n.skill);
+  const skills: Record<string, { path: string }> = {};
+  for (const name of names) {
+    skills[name] = { path: `./skills/${name}` };
+  }
+  return {
+    name: "test",
+    skills,
+    team: { flow: { nodes } },
+  };
+}
+
 describe("generateMermaid", () => {
-  it("renders a linear graph with arrows between nodes", () => {
-    const graph: Graph = {
-      nodes: [
-        step("alpha", { then: "bravo" }),
-        step("bravo", { then: "charlie" }),
-        step("charlie"),
-      ],
-    };
-    const output = generateMermaid(graph);
+  it("renders a linear graph with arrows between atomic nodes", () => {
+    const config = atomicConfig([
+      step("alpha", { then: "bravo" }),
+      step("bravo", { then: "charlie" }),
+      step("charlie"),
+    ]);
+    const output = generateMermaid(config);
     assert.equal(
       output,
       [
@@ -55,18 +73,16 @@ describe("generateMermaid", () => {
   });
 
   it("renders conditional transitions with labels", () => {
-    const graph: Graph = {
-      nodes: [
-        step("strategist", { then: "reviewer" }),
-        step("reviewer", {
-          then: [
-            { when: "review.approved == false", to: "strategist" },
-            { when: "review.approved == true", to: "end" },
-          ],
-        }),
-      ],
-    };
-    const output = generateMermaid(graph);
+    const config = atomicConfig([
+      step("strategist", { then: "reviewer" }),
+      step("reviewer", {
+        then: [
+          { when: "review.approved == false", to: "strategist" },
+          { when: "review.approved == true", to: "end" },
+        ],
+      }),
+    ]);
+    const output = generateMermaid(config);
     assert.equal(
       output,
       [
@@ -80,8 +96,8 @@ describe("generateMermaid", () => {
   });
 
   it("renders a map node as a subgraph with inner nodes", () => {
-    const graph: Graph = {
-      nodes: [
+    const config = atomicConfig(
+      [
         step("strategy", { then: "map" }),
         map("state.tasks", "task", [
           step("engineer", { then: "reviewer" }),
@@ -93,9 +109,9 @@ describe("generateMermaid", () => {
           }),
         ]),
       ],
-    };
-    const output = generateMermaid(graph);
-    // The map subgraph should be rendered with its inner nodes
+      ["strategy", "engineer", "reviewer"],
+    );
+    const output = generateMermaid(config);
     assert.ok(output.includes('subgraph map_state_tasks["map over state.tasks"]'));
     assert.ok(output.includes("        engineer --> reviewer"));
     assert.ok(
@@ -112,24 +128,20 @@ describe("generateMermaid", () => {
   });
 
   it("renders terminal end node for explicit then: end", () => {
-    const graph: Graph = {
-      nodes: [step("alpha", { then: "end" })],
-    };
-    const output = generateMermaid(graph);
+    const config = atomicConfig([step("alpha", { then: "end" })]);
+    const output = generateMermaid(config);
     assert.equal(
       output,
       ["graph TD", "    alpha --> end_node([end])", ""].join("\n"),
     );
   });
 
-  it("renders hyphenated names with underscore IDs and correct labels", () => {
-    const graph: Graph = {
-      nodes: [
-        step("senior-engineer", { then: "code-reviewer" }),
-        step("code-reviewer", { then: "end" }),
-      ],
-    };
-    const output = generateMermaid(graph);
+  it("renders hyphenated atomic names with underscore IDs and correct labels", () => {
+    const config = atomicConfig([
+      step("senior-engineer", { then: "code-reviewer" }),
+      step("code-reviewer", { then: "end" }),
+    ]);
+    const output = generateMermaid(config);
     assert.ok(output.includes('senior_engineer["senior-engineer"]'));
     assert.ok(output.includes('code_reviewer["code-reviewer"]'));
     assert.ok(output.includes("senior_engineer --> code_reviewer"));
@@ -137,10 +149,12 @@ describe("generateMermaid", () => {
   });
 
   it("renders implicit fall-through between nodes with no then", () => {
-    const graph: Graph = {
-      nodes: [step("alpha"), step("bravo"), step("charlie")],
-    };
-    const output = generateMermaid(graph);
+    const config = atomicConfig([
+      step("alpha"),
+      step("bravo"),
+      step("charlie"),
+    ]);
+    const output = generateMermaid(config);
     assert.equal(
       output,
       [
@@ -153,92 +167,303 @@ describe("generateMermaid", () => {
     );
   });
 
-  it("renders the project config graph correctly", () => {
-    const graph: Graph = {
-      nodes: [
-        step("strategist", {
-          writes: ["state.direction"],
-          then: "architect",
-        }),
-        step("architect", {
-          reads: ["state.direction"],
-          writes: ["state.plan"],
-          then: "engineer",
-        }),
-        step("engineer", {
-          reads: ["state.plan"],
-          writes: ["state.implementation"],
-          then: "reviewer",
-        }),
-        step("reviewer", {
-          reads: ["state.implementation"],
-          writes: ["state.review"],
-          then: [
-            { when: "review.approved == false", to: "engineer" },
-            { when: "review.approved == true", to: "end" },
-          ],
-        }),
-      ],
-    };
-    const output = generateMermaid(graph);
-    assert.equal(
-      output,
-      [
-        "graph TD",
-        "    strategist --> architect",
-        "    architect --> engineer",
-        "    engineer --> reviewer",
-        '    reviewer -->|"review.approved == false"| engineer',
-        '    reviewer -->|"review.approved == true"| end_node([end])',
-        "",
-      ].join("\n"),
-    );
-  });
-
-  it("renders the brief example with map correctly", () => {
-    const graph: Graph = {
-      nodes: [
-        step("strategy", { then: "tech-lead" }),
-        step("tech-lead", { then: "map" }),
-        map("state.tasks", "task", [
-          step("senior-engineer", { then: "reviewer" }),
-          step("reviewer", {
-            then: [
-              { when: "task.approved == false", to: "senior-engineer" },
-              { when: "task.approved == true", to: "end" },
-            ],
-          }),
-        ]),
-      ],
-    };
-    const output = generateMermaid(graph);
-    assert.equal(
-      output,
-      [
-        "graph TD",
-        "    strategy --> tech_lead",
-        '    tech_lead["tech-lead"]',
-        "    tech_lead --> map_state_tasks",
-        '    subgraph map_state_tasks["map over state.tasks"]',
-        '        senior_engineer["senior-engineer"]',
-        "        senior_engineer --> reviewer",
-        '        reviewer -->|"task.approved == false"| senior_engineer',
-        '        reviewer -->|"task.approved == true"| end_map_state_tasks([end])',
-        "    end",
-        "",
-      ].join("\n"),
-    );
-  });
-
   it("renders implicit fall-through to a map node", () => {
-    const graph: Graph = {
-      nodes: [
+    const config = atomicConfig(
+      [
         step("planner"),
         map("state.items", "item", [step("worker")]),
       ],
-    };
-    const output = generateMermaid(graph);
+      ["planner", "worker"],
+    );
+    const output = generateMermaid(config);
     assert.ok(output.includes("planner --> map_state_items"));
     assert.ok(output.includes("worker --> end_map_state_items([end])"));
+  });
+
+  it("renders composed skills as subgraphs with leaf atomics", () => {
+    const config: Config = {
+      name: "test",
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        review: { path: "./skills/review" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+        },
+        reviewer: {
+          compose: ["review"],
+          description: "Reviews code.",
+        },
+      },
+      team: {
+        flow: {
+          nodes: [
+            step("engineer", { then: "reviewer" }),
+            step("reviewer", { then: "end" }),
+          ],
+        },
+      },
+    };
+    const output = generateMermaid(config);
+    // Engineer subgraph with leaf atomics
+    assert.ok(output.includes("subgraph engineer"));
+    assert.ok(output.includes('engineer_planning["planning"]'));
+    assert.ok(output.includes('engineer_coding["coding"]'));
+    // Reviewer subgraph with leaf atomic
+    assert.ok(output.includes("subgraph reviewer"));
+    assert.ok(output.includes('reviewer_review["review"]'));
+    // Flow edges connect subgraphs
+    assert.ok(output.includes("engineer --> reviewer"));
+    assert.ok(output.includes("reviewer --> end_node([end])"));
+  });
+
+  it("renders recursive composition as flattened leaf atomics", () => {
+    const config: Config = {
+      name: "test",
+      skills: {
+        a: { path: "./skills/a" },
+        b: { path: "./skills/b" },
+        c: { path: "./skills/c" },
+        inner: { compose: ["a", "b"], description: "Inner." },
+        outer: { compose: ["inner", "c"], description: "Outer." },
+      },
+      team: {
+        flow: {
+          nodes: [step("outer", { then: "end" })],
+        },
+      },
+    };
+    const output = generateMermaid(config);
+    assert.ok(output.includes("subgraph outer"));
+    assert.ok(output.includes('outer_a["a"]'));
+    assert.ok(output.includes('outer_b["b"]'));
+    assert.ok(output.includes('outer_c["c"]'));
+    // Inner composed skill should NOT appear as a leaf
+    assert.ok(!output.includes('outer_inner'));
+  });
+
+  it("renders writes as edge labels on non-conditional edges", () => {
+    const config = atomicConfig([
+      step("planner", {
+        writes: ["state.plan"],
+        then: "worker",
+      }),
+      step("worker", {
+        reads: ["state.plan"],
+        writes: ["state.result"],
+        then: "end",
+      }),
+    ]);
+    const output = generateMermaid(config);
+    assert.ok(output.includes('planner -->|"plan"| worker'));
+    assert.ok(output.includes('worker -->|"result"| end_node([end])'));
+  });
+
+  it("renders writes on implicit fall-through edges", () => {
+    const config = atomicConfig([
+      step("planner", { writes: ["state.plan"] }),
+      step("worker", { writes: ["state.result"] }),
+    ]);
+    const output = generateMermaid(config);
+    assert.ok(output.includes('planner -->|"plan"| worker'));
+    assert.ok(output.includes('worker -->|"result"| end_node([end])'));
+  });
+
+  it("renders multiple writes comma-separated in edge label", () => {
+    const config = atomicConfig([
+      step("planner", {
+        writes: ["state.plan", "state.tasks"],
+        then: "end",
+      }),
+    ]);
+    const output = generateMermaid(config);
+    assert.ok(output.includes('planner -->|"plan, tasks"| end_node([end])'));
+  });
+
+  it("does not add writes label to conditional edges", () => {
+    const config = atomicConfig([
+      step("checker", {
+        writes: ["state.result"],
+        then: [
+          { when: "result == true", to: "end" },
+        ],
+      }),
+    ]);
+    const output = generateMermaid(config);
+    // Conditional edge keeps the when clause, not the writes
+    assert.ok(output.includes('checker -->|"result == true"| end_node([end])'));
+    // Should not have a separate writes label
+    assert.ok(!output.includes('"result"'));
+  });
+
+  it("renders the project config with composition and state", () => {
+    const config: Config = {
+      name: "skillfold-team",
+      skills: {
+        "skillfold-context": { path: "./skills/skillfold-context" },
+        "product-strategy": { path: "./skills/product-strategy" },
+        "task-decomposition": { path: "./skills/task-decomposition" },
+        architecture: { path: "./skills/architecture" },
+        "code-generation": { path: "./skills/code-generation" },
+        testing: { path: "./skills/testing" },
+        github: { path: "./skills/github" },
+        "code-review": { path: "./skills/code-review" },
+        strategist: {
+          compose: ["skillfold-context", "product-strategy", "task-decomposition"],
+          description: "Sets direction.",
+        },
+        architect: {
+          compose: ["skillfold-context", "architecture", "task-decomposition"],
+          description: "Designs systems.",
+        },
+        engineer: {
+          compose: ["skillfold-context", "code-generation", "testing", "github"],
+          description: "Writes code.",
+        },
+        reviewer: {
+          compose: ["skillfold-context", "code-review", "testing", "github"],
+          description: "Reviews code.",
+        },
+      },
+      team: {
+        flow: {
+          nodes: [
+            step("strategist", {
+              writes: ["state.direction"],
+              then: "architect",
+            }),
+            step("architect", {
+              reads: ["state.direction"],
+              writes: ["state.plan"],
+              then: "engineer",
+            }),
+            step("engineer", {
+              reads: ["state.plan"],
+              writes: ["state.implementation"],
+              then: "reviewer",
+            }),
+            step("reviewer", {
+              reads: ["state.implementation"],
+              writes: ["state.review"],
+              then: [
+                { when: "review.approved == false", to: "engineer" },
+                { when: "review.approved == true", to: "end" },
+              ],
+            }),
+          ],
+        },
+      },
+    };
+    const output = generateMermaid(config);
+
+    // Composition subgraphs
+    assert.ok(output.includes("subgraph strategist"));
+    assert.ok(output.includes('strategist_skillfold_context["skillfold-context"]'));
+    assert.ok(output.includes('strategist_product_strategy["product-strategy"]'));
+    assert.ok(output.includes('strategist_task_decomposition["task-decomposition"]'));
+
+    assert.ok(output.includes("subgraph architect"));
+    assert.ok(output.includes('architect_architecture["architecture"]'));
+
+    assert.ok(output.includes("subgraph engineer"));
+    assert.ok(output.includes('engineer_code_generation["code-generation"]'));
+    assert.ok(output.includes('engineer_testing["testing"]'));
+
+    assert.ok(output.includes("subgraph reviewer"));
+    assert.ok(output.includes('reviewer_code_review["code-review"]'));
+
+    // State writes on edges
+    assert.ok(output.includes('strategist -->|"direction"| architect'));
+    assert.ok(output.includes('architect -->|"plan"| engineer'));
+    assert.ok(output.includes('engineer -->|"implementation"| reviewer'));
+
+    // Conditional edges keep their labels
+    assert.ok(output.includes('reviewer -->|"review.approved == false"| engineer'));
+    assert.ok(output.includes('reviewer -->|"review.approved == true"| end_node([end])'));
+  });
+
+  it("renders composed skills inside map subgraphs", () => {
+    const config: Config = {
+      name: "test",
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        setup: { path: "./skills/setup" },
+        worker: {
+          compose: ["planning", "coding"],
+          description: "Does work.",
+        },
+      },
+      team: {
+        flow: {
+          nodes: [
+            step("setup", { then: "map" }),
+            map("state.tasks", "task", [
+              step("worker", { then: "end" }),
+            ]),
+          ],
+        },
+      },
+    };
+    const output = generateMermaid(config);
+    // Map subgraph should contain composition subgraph for worker
+    assert.ok(output.includes('subgraph map_state_tasks["map over state.tasks"]'));
+    assert.ok(output.includes("subgraph worker"));
+    assert.ok(output.includes('worker_planning["planning"]'));
+    assert.ok(output.includes('worker_coding["coding"]'));
+  });
+
+  it("handles mixed atomic and composed skills in the flow", () => {
+    const config: Config = {
+      name: "test",
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        deploy: { path: "./skills/deploy" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+        },
+      },
+      team: {
+        flow: {
+          nodes: [
+            step("engineer", { then: "deploy" }),
+            step("deploy", { then: "end" }),
+          ],
+        },
+      },
+    };
+    const output = generateMermaid(config);
+    // Engineer is composed -> subgraph
+    assert.ok(output.includes("subgraph engineer"));
+    // Deploy is atomic -> plain node
+    assert.ok(!output.includes("subgraph deploy"));
+    // Flow connects them
+    assert.ok(output.includes("engineer --> deploy"));
+  });
+
+  it("deduplicates shared atomics in composition", () => {
+    const config: Config = {
+      name: "test",
+      skills: {
+        shared: { path: "./skills/shared" },
+        unique: { path: "./skills/unique" },
+        mid1: { compose: ["shared"], description: "Mid 1." },
+        mid2: { compose: ["shared", "unique"], description: "Mid 2." },
+        top: { compose: ["mid1", "mid2"], description: "Top." },
+      },
+      team: {
+        flow: {
+          nodes: [step("top", { then: "end" })],
+        },
+      },
+    };
+    const output = generateMermaid(config);
+    // "shared" should appear only once in the subgraph
+    const sharedCount = output.split('top_shared["shared"]').length - 1;
+    assert.equal(sharedCount, 1, "shared should appear exactly once");
+    assert.ok(output.includes('top_unique["unique"]'));
   });
 });

--- a/src/visualize.ts
+++ b/src/visualize.ts
@@ -1,4 +1,5 @@
-import { Graph, GraphNode, isConditionalThen, isMapNode } from "./graph.js";
+import { type Config, type SkillEntry, isComposed } from "./config.js";
+import { type GraphNode, isConditionalThen, isMapNode } from "./graph.js";
 
 // Sanitize a name into a valid Mermaid node ID by replacing non-alphanumeric
 // characters with underscores.
@@ -6,13 +7,38 @@ function sanitizeId(name: string): string {
   return name.replace(/[^a-zA-Z0-9_]/g, "_");
 }
 
-// Only emit a label declaration if the name differs from its sanitized ID.
-function nodeDecl(name: string): string {
-  const id = sanitizeId(name);
-  if (id !== name) {
-    return `${id}["${name}"]`;
+// Resolve a composed skill to its leaf atomic skill names (deduplicated,
+// order-preserving). Recursion handles nested composition.
+function getLeafAtomics(
+  name: string,
+  skills: Record<string, SkillEntry>,
+  visited?: Set<string>,
+): string[] {
+  const skill = skills[name];
+  if (!skill || !isComposed(skill)) return [name];
+
+  visited = visited ?? new Set();
+  if (visited.has(name)) return [];
+  visited.add(name);
+
+  const leaves: string[] = [];
+  const seen = new Set<string>();
+  for (const ref of skill.compose) {
+    for (const leaf of getLeafAtomics(ref, skills, new Set(visited))) {
+      if (!seen.has(leaf)) {
+        seen.add(leaf);
+        leaves.push(leaf);
+      }
+    }
   }
-  return id;
+  return leaves;
+}
+
+// Format state writes as a Mermaid edge label. Strips the "state." prefix
+// for brevity.
+function formatWritesLabel(writes: string[]): string {
+  if (writes.length === 0) return "";
+  return writes.map((w) => w.replace(/^state\./, "")).join(", ");
 }
 
 // Build a mapping from graph-level node labels ("skill" for steps, "map" for
@@ -35,12 +61,55 @@ function resolveTarget(target: string, idMap: Map<string, string>): string {
   return idMap.get(target) ?? sanitizeId(target);
 }
 
+// Render an edge with an optional writes label.
+function renderEdge(
+  lines: string[],
+  indent: string,
+  fromId: string,
+  toId: string,
+  writes: string[],
+): void {
+  const label = formatWritesLabel(writes);
+  if (label) {
+    lines.push(`${indent}${fromId} -->|"${label}"| ${toId}`);
+  } else {
+    lines.push(`${indent}${fromId} --> ${toId}`);
+  }
+}
+
+function renderThen(
+  lines: string[],
+  indent: string,
+  fromId: string,
+  then: NonNullable<GraphNode["then"]>,
+  endNodeId: string,
+  idMap: Map<string, string>,
+  writes: string[],
+): void {
+  if (isConditionalThen(then)) {
+    for (const branch of then) {
+      const targetId =
+        branch.to === "end"
+          ? `${endNodeId}([end])`
+          : resolveTarget(branch.to, idMap);
+      lines.push(`${indent}${fromId} -->|"${branch.when}"| ${targetId}`);
+    }
+  } else {
+    if (then === "end") {
+      renderEdge(lines, indent, fromId, `${endNodeId}([end])`, writes);
+    } else {
+      renderEdge(lines, indent, fromId, resolveTarget(then, idMap), writes);
+    }
+  }
+}
+
 // Render nodes at one level of the graph, collecting lines into the output array.
 function renderNodes(
   nodes: GraphNode[],
   lines: string[],
   indent: string,
   endNodeId: string,
+  skills: Record<string, SkillEntry>,
 ): void {
   const idMap = buildIdMap(nodes);
 
@@ -53,14 +122,12 @@ function renderNodes(
       lines.push(`${indent}subgraph ${subgraphId}["${subgraphLabel}"]`);
       const innerIndent = indent + "    ";
       const innerEndId = `end_${subgraphId}`;
-      renderNodes(node.graph, lines, innerIndent, innerEndId);
+      renderNodes(node.graph, lines, innerIndent, innerEndId, skills);
       lines.push(`${indent}end`);
 
-      // Connect map subgraph to the next node if there's a then
       if (node.then !== undefined) {
-        renderThen(lines, indent, subgraphId, node.then, endNodeId, idMap);
+        renderThen(lines, indent, subgraphId, node.then, endNodeId, idMap, []);
       } else {
-        // Implicit fall-through: connect to next sibling if present
         const nextNode = nodes[i + 1];
         if (nextNode) {
           const nextId = isMapNode(nextNode)
@@ -71,58 +138,71 @@ function renderNodes(
       }
     } else {
       const currentId = sanitizeId(node.skill);
+      const skill = skills[node.skill];
+      const composed = skill !== undefined && isComposed(skill);
 
-      // Emit a node declaration if the name needs a label
-      if (currentId !== node.skill) {
-        lines.push(`${indent}${nodeDecl(node.skill)}`);
+      if (composed) {
+        // Render composed skill as a subgraph with leaf atomics
+        const leaves = getLeafAtomics(node.skill, skills);
+        if (currentId !== node.skill) {
+          lines.push(
+            `${indent}subgraph ${currentId}["${node.skill}"]`,
+          );
+        } else {
+          lines.push(`${indent}subgraph ${currentId}`);
+        }
+        const innerIndent = indent + "    ";
+        for (const leaf of leaves) {
+          const leafId = `${currentId}_${sanitizeId(leaf)}`;
+          lines.push(`${innerIndent}${leafId}["${leaf}"]`);
+        }
+        lines.push(`${indent}end`);
+      } else {
+        // Atomic or unknown skill: plain node
+        if (currentId !== node.skill) {
+          lines.push(`${indent}${currentId}["${node.skill}"]`);
+        }
       }
 
       if (node.then !== undefined) {
-        renderThen(lines, indent, currentId, node.then, endNodeId, idMap);
+        renderThen(
+          lines,
+          indent,
+          currentId,
+          node.then,
+          endNodeId,
+          idMap,
+          node.writes,
+        );
       } else {
-        // Implicit fall-through
         const nextNode = nodes[i + 1];
         if (nextNode) {
           const nextTarget = isMapNode(nextNode)
             ? `map_${sanitizeId(nextNode.over)}`
             : sanitizeId(nextNode.skill);
-          lines.push(`${indent}${currentId} --> ${nextTarget}`);
+          renderEdge(lines, indent, currentId, nextTarget, node.writes);
         } else {
-          // Last node with no then: arrow to end
-          lines.push(`${indent}${currentId} --> ${endNodeId}([end])`);
+          renderEdge(
+            lines,
+            indent,
+            currentId,
+            `${endNodeId}([end])`,
+            node.writes,
+          );
         }
       }
     }
   }
 }
 
-function renderThen(
-  lines: string[],
-  indent: string,
-  fromId: string,
-  then: NonNullable<GraphNode["then"]>,
-  endNodeId: string,
-  idMap: Map<string, string>,
-): void {
-  if (isConditionalThen(then)) {
-    for (const branch of then) {
-      const targetId =
-        branch.to === "end"
-          ? `${endNodeId}([end])`
-          : resolveTarget(branch.to, idMap);
-      lines.push(`${indent}${fromId} -->|"${branch.when}"| ${targetId}`);
-    }
-  } else {
-    if (then === "end") {
-      lines.push(`${indent}${fromId} --> ${endNodeId}([end])`);
-    } else {
-      lines.push(`${indent}${fromId} --> ${resolveTarget(then, idMap)}`);
-    }
-  }
-}
-
-export function generateMermaid(graph: Graph): string {
+export function generateMermaid(config: Config): string {
   const lines: string[] = ["graph TD"];
-  renderNodes(graph.nodes, lines, "    ", "end_node");
+  renderNodes(
+    config.team!.flow.nodes,
+    lines,
+    "    ",
+    "end_node",
+    config.skills,
+  );
   return lines.join("\n") + "\n";
 }


### PR DESCRIPTION
## Summary

- Composed skills in the flow render as Mermaid subgraphs showing their leaf atomic skills
- Recursive composition is flattened with deduplication (diamond compositions handled)
- Non-conditional edges show state writes as labels (e.g., `-->|"direction"|`)
- Conditional edges keep their existing `when` clause labels
- `generateMermaid` signature changed from `(graph: Graph)` to `(config: Config)`

Before (agent-to-agent only):
```
strategist --> architect
architect --> engineer
```

After (full lineage):
```
subgraph strategist
    skillfold-context
    product-strategy
    task-decomposition
end
strategist -->|"direction"| architect
subgraph architect
    skillfold-context
    architecture
    task-decomposition
end
```

## Test plan

- [x] Type check passes
- [x] 211 tests pass (17 in generateMermaid suite, up from 9)
- [x] New tests cover: composition subgraphs, recursive flattening, deduplication, write labels, conditional edge handling, mixed atomic/composed, map inner compositions
- [x] Verified output on project config and dev-pipeline fixture

Generated with [Claude Code](https://claude.com/claude-code)