### PR TITLE
Rewrite README for clarity and completeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Output: `build/planner/SKILL.md`, `build/worker/SKILL.md`, `build/orchestrator/S
 Write one YAML config. The compiler produces one `SKILL.md` per agent.
 
 ```yaml
+name: dev-team
+
 skills:
   atomic:
     planning: ./skills/planning
@@ -54,6 +56,8 @@ state:
   Review:
     approved: bool
     feedback: string
+  code:
+    type: string
   review:
     type: Review
 


### PR DESCRIPTION
## Summary

- Add before/after hook showing the pain of manual SKILL.md maintenance vs. one config file
- Restructure Quick Start (2 commands, output), How It Works (trimmed YAML + orchestrator output), and Features (grouped scannable list: Composition, Validation, Team Flows, Tooling)
- Document shared library with all 10 skills, import syntax, and 3 example configs
- Expand self-hosting section naming all 5 agents, the review loop, and state-to-infrastructure mapping
- Add npm, CI, and MIT badges; trim config reference to one example per sub-section with link to BRIEF.md; update test count to 238

Final result: 268 lines, 12 sections, skimmable in 2 minutes.

Closes #16, closes #17, closes #18, closes #19, closes #20

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Confirm all relative links (BRIEF.md, skillfold.yaml, library/examples/) resolve
- [ ] Check code examples match actual config syntax
- [ ] Ensure line count is in the 250-300 target range (268 lines)

Generated with [Claude Code](https://claude.com/claude-code)