### PR TITLE
Include library in npm package, bump to v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "skillfold",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Compiler for multi-agent AI pipelines. Compose skills, wire team flows, generate orchestrators.",
   "type": "module",
   "bin": {
     "skillfold": "./dist/cli.js"
   },
-  "files": ["dist"],
+  "files": ["dist", "library"],
   "keywords": ["agent", "skills", "pipeline", "compiler", "multi-agent", "orchestrator", "skill-composition"],
   "repository": {
     "type": "git",


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `library` to the `files` array in package.json so shared skills ship with the npm package
- Bump version from 0.5.0 to 0.6.0 (0.5.0 was never published)

The documented import path `node_modules/skillfold/library/skillfold.yaml` was broken for all npm installs because `files: ["dist"]` excluded the library directory.

Verified: `npm pack --dry-run` now shows all 14 library files (10 skills, 3 examples, 1 config). 247 tests pass.

Closes #35