### PR TITLE
Add package metadata for npm listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "files": ["dist", "library"],
   "keywords": ["agent", "skills", "pipeline", "compiler", "multi-agent", "orchestrator", "skill-composition"],
+  "homepage": "https://github.com/byronxlg/skillfold",
+  "bugs": "https://github.com/byronxlg/skillfold/issues",
   "repository": {
     "type": "git",
     "url": "https://github.com/byronxlg/skillfold.git"


### PR DESCRIPTION
**[engineer]** Adds homepage and bugs fields to package.json so the npm listing links to the repo and issue tracker. Part of #39, discussion #38.