### PR TITLE
Add skillfold list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Commands:
   (default)         Compile the pipeline config
   init              Scaffold a new pipeline project
   validate          Validate config without compiling
+  list              Display a structured summary of the pipeline
   graph             Output Mermaid flowchart of the team flow
 
 Options:
@@ -286,7 +287,7 @@ Conditional transitions, parallel map, and imports are documented in [BRIEF.md](
 ### Tests
 
 ```bash
-npm test          # 247 tests, node:test, no extra dependencies
+npm test          # 253 tests, node:test, no extra dependencies
 npx tsc --noEmit  # type check
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { isAtomic, isComposed, loadConfig } from "./config.js";
 import { compile } from "./compiler.js";
 import { ConfigError, CompileError, GraphError, ResolveError } from "./errors.js";
 import { initProject } from "./init.js";
+import { listPipeline } from "./list.js";
 import { resolveSkills } from "./resolver.js";
 import { generateMermaid } from "./visualize.js";
 
@@ -23,6 +24,7 @@ Usage: skillfold [command] [options]
 Commands:
   init              Scaffold a new pipeline project
   validate          Validate config without compiling
+  list              Display a structured summary of the pipeline
   graph             Output Mermaid flowchart of the team flow
   (default)         Compile the pipeline config
 
@@ -35,7 +37,7 @@ Options:
 }
 
 interface Args {
-  command: "init" | "compile" | "graph" | "validate";
+  command: "init" | "compile" | "graph" | "list" | "validate";
   configPath: string;
   outDir: string;
   dir: string;
@@ -44,7 +46,7 @@ interface Args {
 }
 
 function parseArgs(argv: string[]): Args {
-  let command: "init" | "compile" | "graph" | "validate" = "compile";
+  let command: "init" | "compile" | "graph" | "list" | "validate" = "compile";
   let configPath = "skillfold.yaml";
   let outDir = "build";
   let dir = ".";
@@ -59,6 +61,9 @@ function parseArgs(argv: string[]): Args {
     i = 1;
   } else if (argv.length > 0 && argv[0] === "graph") {
     command = "graph";
+    i = 1;
+  } else if (argv.length > 0 && argv[0] === "list") {
+    command = "list";
     i = 1;
   } else if (argv.length > 0 && argv[0] === "validate") {
     command = "validate";
@@ -131,6 +136,20 @@ async function main(): Promise<void> {
       }
       const output = generateMermaid(config);
       process.stdout.write(output);
+    } catch (err) {
+      if (err instanceof ConfigError || err instanceof GraphError) {
+        console.error(`skillfold error: ${err.message}`);
+        process.exit(1);
+      }
+      throw err;
+    }
+    return;
+  }
+
+  if (args.command === "list") {
+    try {
+      const config = await loadConfig(args.configPath);
+      process.stdout.write(listPipeline(config));
     } catch (err) {
       if (err instanceof ConfigError || err instanceof GraphError) {
         console.error(`skillfold error: ${err.message}`);

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -1,0 +1,186 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseRawConfig, validateAndBuild } from "./config.js";
+import { listPipeline } from "./list.js";
+
+describe("listPipeline", () => {
+  it("renders skills, state, and team flow", () => {
+    const raw = parseRawConfig(`
+name: test-pipeline
+skills:
+  atomic:
+    planning: ./skills/planning
+    coding: ./skills/coding
+    review: ./skills/review
+  composed:
+    engineer:
+      compose: [planning, coding]
+      description: "Implements the plan."
+    reviewer:
+      compose: [review]
+      description: "Reviews code."
+state:
+  Review:
+    approved: bool
+    feedback: string
+  code:
+    type: string
+  review:
+    type: Review
+team:
+  flow:
+    - engineer:
+        writes: [state.code]
+      then: reviewer
+    - reviewer:
+        reads: [state.code]
+        writes: [state.review]
+      then:
+        - when: review.approved == false
+          to: engineer
+        - when: review.approved == true
+          to: end
+`);
+    const config = validateAndBuild(raw);
+    const output = listPipeline(config);
+
+    assert.ok(output.startsWith("test-pipeline\n"));
+    assert.ok(output.includes("Skills (3 atomic, 2 composed):"));
+    assert.ok(output.includes("planning"));
+    assert.ok(output.includes("(atomic)"));
+    assert.ok(output.includes("engineer"));
+    assert.ok(output.includes("= planning + coding"));
+    assert.ok(output.includes("State (2 fields, 1 types):"));
+    assert.ok(output.includes("code"));
+    assert.ok(output.includes("string"));
+    assert.ok(output.includes("Review { approved: bool, feedback: string }"));
+    assert.ok(output.includes("Team Flow:"));
+    assert.ok(output.includes("engineer -> reviewer"));
+    assert.ok(output.includes("reviewer -> engineer (when review.approved == false)"));
+    assert.ok(output.includes("reviewer -> end (when review.approved == true)"));
+  });
+
+  it("renders minimal config without state or team", () => {
+    const raw = parseRawConfig(`
+name: minimal
+skills:
+  atomic:
+    one: ./skills/one
+`);
+    const config = validateAndBuild(raw);
+    const output = listPipeline(config);
+
+    assert.ok(output.startsWith("minimal\n"));
+    assert.ok(output.includes("Skills (1 atomic, 0 composed):"));
+    assert.ok(output.includes("one"));
+    assert.ok(!output.includes("State"));
+    assert.ok(!output.includes("Team Flow"));
+  });
+
+  it("marks remote skills", () => {
+    const raw = parseRawConfig(`
+name: remote-test
+skills:
+  atomic:
+    local: ./skills/local
+    remote-skill: https://github.com/org/repo/tree/main/skills/shared
+`);
+    const config = validateAndBuild(raw);
+    const output = listPipeline(config);
+
+    assert.ok(output.includes("local"));
+    assert.ok(output.includes("(atomic)"));
+    assert.ok(output.includes("remote-skill"));
+    assert.ok(output.includes("(atomic, remote)"));
+  });
+
+  it("renders state locations", () => {
+    const raw = parseRawConfig(`
+name: location-test
+skills:
+  atomic:
+    github: ./skills/github
+  composed:
+    agent:
+      compose: [github]
+      description: "Test agent."
+state:
+  plan:
+    type: string
+    location:
+      skill: github
+      path: discussions/general
+      kind: reply
+  code:
+    type: string
+    location:
+      skill: github
+      path: pull-requests
+`);
+    const config = validateAndBuild(raw);
+    const output = listPipeline(config);
+
+    assert.ok(output.includes("-> github: discussions/general (reply)"));
+    assert.ok(output.includes("-> github: pull-requests"));
+  });
+
+  it("renders map nodes in team flow", () => {
+    const raw = parseRawConfig(`
+name: map-test
+skills:
+  atomic:
+    planner: ./skills/planner
+    worker: ./skills/worker
+  composed:
+    lead:
+      compose: [planner]
+      description: "Plans work."
+    dev:
+      compose: [worker]
+      description: "Does work."
+state:
+  Task:
+    title: string
+  tasks:
+    type: "list<Task>"
+team:
+  flow:
+    - lead:
+        writes: [state.tasks]
+      then: map
+    - map:
+        over: state.tasks
+        as: task
+        graph:
+          - dev:
+              reads: [task.title]
+`);
+    const config = validateAndBuild(raw);
+    const output = listPipeline(config);
+
+    assert.ok(output.includes("lead -> map"));
+    assert.ok(output.includes("map -> end"));
+  });
+
+  it("renders composed skill with multiple components", () => {
+    const raw = parseRawConfig(`
+name: multi-compose
+skills:
+  atomic:
+    a: ./skills/a
+    b: ./skills/b
+    c: ./skills/c
+    d: ./skills/d
+  composed:
+    agent:
+      compose: [a, b, c, d]
+      description: "Multi-skill agent."
+`);
+    const config = validateAndBuild(raw);
+    const output = listPipeline(config);
+
+    assert.ok(output.includes("agent"));
+    assert.ok(output.includes("= a + b + c + d"));
+  });
+});

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,0 +1,122 @@
+import { type Config, type SkillEntry, isAtomic, isComposed } from "./config.js";
+import { type GraphNode, isConditionalThen, isMapNode } from "./graph.js";
+import { type StateField, type StateSchema } from "./state.js";
+
+function formatStateType(field: StateField): string {
+  switch (field.type.kind) {
+    case "primitive":
+      return field.type.value;
+    case "list":
+      return `list<${field.type.element}>`;
+    case "custom":
+      return field.type.name;
+  }
+}
+
+function formatLocation(field: StateField): string {
+  if (!field.location) return "";
+  const parts = [field.location.skill + ": " + field.location.path];
+  if (field.location.kind) {
+    parts.push(`(${field.location.kind})`);
+  }
+  return "-> " + parts.join(" ");
+}
+
+function isRemote(skill: SkillEntry): boolean {
+  return isAtomic(skill) && skill.path.startsWith("https://");
+}
+
+function renderSkills(
+  skills: Record<string, SkillEntry>,
+): string[] {
+  const entries = Object.entries(skills);
+  const atomics = entries.filter(([, s]) => isAtomic(s));
+  const composed = entries.filter(([, s]) => isComposed(s));
+  const lines: string[] = [];
+
+  lines.push(`Skills (${atomics.length} atomic, ${composed.length} composed):`);
+
+  for (const [name, skill] of atomics) {
+    const tags: string[] = ["atomic"];
+    if (isRemote(skill)) tags.push("remote");
+    lines.push(`  ${name.padEnd(20)} (${tags.join(", ")})`);
+  }
+
+  for (const [name, skill] of composed) {
+    if (!isComposed(skill)) continue;
+    lines.push(`  ${name.padEnd(20)} = ${skill.compose.join(" + ")}`);
+  }
+
+  return lines;
+}
+
+function renderState(state: StateSchema): string[] {
+  const fieldEntries = Object.entries(state.fields);
+  const typeEntries = Object.entries(state.types);
+  const lines: string[] = [];
+
+  lines.push(`State (${fieldEntries.length} fields, ${typeEntries.length} types):`);
+
+  for (const [name, field] of fieldEntries) {
+    const typeStr = formatStateType(field).padEnd(20);
+    const location = formatLocation(field);
+    lines.push(`  ${name.padEnd(20)} ${typeStr} ${location}`.trimEnd());
+  }
+
+  for (const [name, type] of typeEntries) {
+    const fieldDefs = Object.entries(type.fields)
+      .map(([fn, ft]) => `${fn}: ${ft}`)
+      .join(", ");
+    lines.push(`  ${name} { ${fieldDefs} }`);
+  }
+
+  return lines;
+}
+
+function nodeLabel(node: GraphNode): string {
+  return isMapNode(node) ? "map" : node.skill;
+}
+
+function renderFlowEdges(nodes: GraphNode[]): string[] {
+  const lines: string[] = [];
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const label = nodeLabel(node);
+
+    if (node.then === undefined) {
+      const next = i + 1 < nodes.length ? nodeLabel(nodes[i + 1]) : "end";
+      lines.push(`  ${label} -> ${next}`);
+    } else if (isConditionalThen(node.then)) {
+      for (const branch of node.then) {
+        const whenStr = `when ${branch.when}`;
+        lines.push(`  ${label} -> ${branch.to} (${whenStr})`);
+      }
+    } else {
+      lines.push(`  ${label} -> ${node.then}`);
+    }
+  }
+
+  return lines;
+}
+
+export function listPipeline(config: Config): string {
+  const sections: string[] = [];
+
+  sections.push(config.name);
+  sections.push("");
+  sections.push(...renderSkills(config.skills));
+
+  if (config.state) {
+    sections.push("");
+    sections.push(...renderState(config.state));
+  }
+
+  if (config.team) {
+    sections.push("");
+    sections.push("Team Flow:");
+    sections.push(...renderFlowEdges(config.team.flow.nodes));
+  }
+
+  return sections.join("\n") + "\n";
+}


### PR DESCRIPTION
**[engineer]**

Closes #43. Part of discussion #42.

## Summary

- Add `skillfold list` command that reads the config and displays a structured summary of the pipeline
- Shows skills (atomic with remote detection, composed with composition chains), state fields with types and locations, and team flow topology
- Add `src/list.ts` with `listPipeline(config)` function and `src/list.test.ts` with 6 tests
- Update CLI help and README to include the new command

## Test plan

- [x] All 253 tests pass (`npm test`)
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Manual verification: `npx tsx src/cli.ts list` produces expected output against the project's own `skillfold.yaml`
- [ ] CI passes on Node 20 + 22