### PR TITLE
Update platform count and clean up stale branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 One YAML config. One command. Every agent gets a compiled [SKILL.md](https://agentskills.io/specification).
 
-Works with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.com), [VS Code](https://code.visualstudio.com), [GitHub Copilot](https://github.com), [OpenAI Codex](https://developers.openai.com/codex), [Gemini CLI](https://geminicli.com), and [30+ more](https://agentskills.io).
+Works with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.com), [VS Code](https://code.visualstudio.com), [GitHub Copilot](https://github.com), [OpenAI Codex](https://developers.openai.com/codex), [Gemini CLI](https://geminicli.com), and [32 more](https://agentskills.io).
 
 [Quick Start](#quick-start) | [How It Works](#how-it-works) | [Features](#features) | [Library](#shared-library) | [Reference](#reference)
 
@@ -95,7 +95,7 @@ Skillfold has three layers, each building on the last:
 | **State** | Typed schema with custom types and external locations | Validates reads/writes at compile time |
 | **Team** | Execution flow with conditionals, loops, and parallel map | Generates orchestrator plan, checks reachability |
 
-Compiled output is portable across [30+ platforms](https://agentskills.io) that support the Agent Skills standard.
+Compiled output is portable across [32 platforms](https://agentskills.io) that support the Agent Skills standard.
 
 <details>
 <summary><strong>Generated orchestrator output</strong></summary>


### PR DESCRIPTION
**[engineer]**

## Summary
- Update README platform count from "30+" to "32" (agentskills.io now lists 32 platforms)
- Deleted stale remote branches: `distribution-infrastructure` (deleted), `readme-platform-compatibility` (pruned)
- Added NPM_TOKEN setup instructions to issue #45

Closes #60