### PR TITLE
Add --check flag for CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,4 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npm test
+      - run: npx tsx src/cli.ts && npx tsx src/cli.ts --check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Configuration language and compiler for multi-agent AI pipelines. Compiles YAML 
 
 - **Run compiler**: `npx tsx src/cli.ts`
 - **Validate config**: `npx tsx src/cli.ts validate`
+- **Check output is current**: `npx tsx src/cli.ts --check`
 - **List pipeline**: `npx tsx src/cli.ts list`
 - **Run with custom config**: `npx tsx src/cli.ts --config path.yaml --out-dir out/`
 - **Build**: `npm run build`
@@ -134,6 +135,7 @@ Located in `library/examples/`:
 - `skillfold list` command for pipeline introspection (skills, state, team flow)
 - Getting-started tutorial (`docs/getting-started.md`) walking users from install to compiled pipeline
 - JSON Schema (`skillfold.schema.json`) for IDE autocompletion and config validation
+- `--check` flag for CI integration (verifies compiled output is up-to-date without writing)
 - Automated npm publish via GitHub Actions (`.github/workflows/publish.yml`, triggered on release)
 - Test suite covering config, resolver, compiler, state, graph, orchestrator, visualize, remote, init, library, validate, list, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Options:
   --config <path>   Config file (default: skillfold.yaml)
   --out-dir <path>  Output directory (default: build)
   --dir <path>      Target directory for init (default: .)
+  --check           Verify compiled output is up-to-date (exit 1 if stale)
   --help            Show this help
   --version         Show version
 ```
@@ -305,7 +306,7 @@ Conditional transitions, parallel map, and imports are documented in [BRIEF.md](
 ### Tests
 
 ```bash
-npm test          # 253 tests, node:test, no extra dependencies
+npm test          # 257 tests, node:test, no extra dependencies
 npx tsc --noEmit  # type check
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillfold",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Compiler for multi-agent AI pipelines. Compose skills, wire team flows, generate orchestrators.",
   "type": "module",
   "bin": {

--- a/skills/skillfold-context/SKILL.md
+++ b/skills/skillfold-context/SKILL.md
@@ -51,7 +51,7 @@ The codebase is TypeScript (strict, ESM modules). Key modules:
 
 ## What's Implemented
 
-All compiler features are working: skill composition with atomic/composed sub-sections, state schema, flow validation, map subgraph validation, when-clause parsing, orchestrator generation, spec-compliant output, URL-based skill references, pipeline imports, graph visualization with full composition lineage, `skillfold init`, `skillfold validate`, and `skillfold list`. Published on npm as `skillfold`. 253 tests, CI on GitHub Actions. The project self-hosts its own dev team via `skillfold.yaml`.
+All compiler features are working: skill composition with atomic/composed sub-sections, state schema, flow validation, map subgraph validation, when-clause parsing, orchestrator generation, spec-compliant output, URL-based skill references, pipeline imports, graph visualization with full composition lineage, `skillfold init`, `skillfold validate`, `skillfold list`, and `--check` for CI integration. Published on npm as `skillfold`. 257 tests, CI on GitHub Actions. The project self-hosts its own dev team via `skillfold.yaml`.
 
 ## What's Next
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { isAtomic, isComposed, loadConfig } from "./config.js";
-import { compile } from "./compiler.js";
+import { check, compile } from "./compiler.js";
 import { ConfigError, CompileError, GraphError, ResolveError } from "./errors.js";
 import { initProject } from "./init.js";
 import { listPipeline } from "./list.js";
@@ -32,6 +32,7 @@ Options:
   --config <path>   Config file (default: skillfold.yaml)
   --out-dir <path>  Output directory (default: build)
   --dir <path>      Target directory for init (default: .)
+  --check           Verify compiled output is up-to-date (exit 1 if stale)
   --help            Show this help
   --version         Show version`);
 }
@@ -41,6 +42,7 @@ interface Args {
   configPath: string;
   outDir: string;
   dir: string;
+  check: boolean;
   help: boolean;
   version: boolean;
 }
@@ -50,6 +52,7 @@ function parseArgs(argv: string[]): Args {
   let configPath = "skillfold.yaml";
   let outDir = "build";
   let dir = ".";
+  let checkMode = false;
   let help = false;
   let version = false;
 
@@ -77,6 +80,8 @@ function parseArgs(argv: string[]): Args {
       outDir = argv[++i];
     } else if (argv[i] === "--dir" && argv[i + 1]) {
       dir = argv[++i];
+    } else if (argv[i] === "--check") {
+      checkMode = true;
     } else if (argv[i] === "--help") {
       help = true;
     } else if (argv[i] === "--version") {
@@ -89,6 +94,7 @@ function parseArgs(argv: string[]): Args {
     configPath: resolve(configPath),
     outDir: resolve(outDir),
     dir: resolve(dir),
+    check: checkMode,
     help,
     version,
   };
@@ -196,11 +202,27 @@ async function main(): Promise<void> {
     const config = await loadConfig(args.configPath);
     const baseDir = dirname(args.configPath);
     const bodies = await resolveSkills(config, baseDir);
-    const results = compile(config, bodies, args.outDir);
 
-    console.log(`skillfold: compiled ${config.name}`);
-    for (const result of results) {
-      console.log(`  -> ${result.path}`);
+    if (args.check) {
+      const results = check(config, bodies, args.outDir);
+      const stale = results.filter((r) => r.status !== "ok");
+
+      if (stale.length === 0) {
+        console.log(`skillfold: ${config.name} output is up-to-date (${results.length} files)`);
+      } else {
+        console.error(`skillfold: ${config.name} output is stale`);
+        for (const result of stale) {
+          console.error(`  ${result.status}: ${result.path}`);
+        }
+        process.exit(1);
+      }
+    } else {
+      const results = compile(config, bodies, args.outDir);
+
+      console.log(`skillfold: compiled ${config.name}`);
+      for (const result of results) {
+        console.log(`  -> ${result.path}`);
+      }
     }
   } catch (err) {
     if (

--- a/src/compiler.test.ts
+++ b/src/compiler.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import type { Config } from "./config.js";
 import { CompileError } from "./errors.js";
-import { compile } from "./compiler.js";
+import { check, compile } from "./compiler.js";
 import type { Graph } from "./graph.js";
 import type { StateSchema } from "./state.js";
 
@@ -282,5 +282,96 @@ describe("compile", () => {
     assert.equal(lines[1], "name: agent");
     assert.equal(lines[2], "description: An agent that does things.");
     assert.equal(lines[3], "---");
+  });
+});
+
+describe("check", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  function makeConfig(): { config: Config; bodies: Map<string, string> } {
+    const config: Config = {
+      name: "test",
+      skills: {
+        lint: { path: "./skills/lint" },
+        format: { path: "./skills/format" },
+        quality: { compose: ["lint", "format"], description: "Runs quality checks." },
+      },
+    };
+    const bodies = new Map<string, string>();
+    bodies.set("lint", "Run the linter.");
+    bodies.set("format", "Format the code.");
+    return { config, bodies };
+  }
+
+  it("returns ok when compiled output matches on disk", () => {
+    tmpDir = makeTmpDir();
+    const outDir = join(tmpDir, "dist");
+    const { config, bodies } = makeConfig();
+
+    compile(config, bodies, outDir);
+    const results = check(config, bodies, outDir);
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].name, "quality");
+    assert.equal(results[0].status, "ok");
+  });
+
+  it("returns stale when on-disk content differs", () => {
+    tmpDir = makeTmpDir();
+    const outDir = join(tmpDir, "dist");
+    const { config, bodies } = makeConfig();
+
+    compile(config, bodies, outDir);
+    writeFileSync(join(outDir, "quality", "SKILL.md"), "old content", "utf-8");
+    const results = check(config, bodies, outDir);
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].status, "stale");
+  });
+
+  it("returns missing when output file does not exist", () => {
+    tmpDir = makeTmpDir();
+    const outDir = join(tmpDir, "dist");
+    const { config, bodies } = makeConfig();
+
+    const results = check(config, bodies, outDir);
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].status, "missing");
+  });
+
+  it("checks orchestrator output when team is defined", () => {
+    tmpDir = makeTmpDir();
+    const outDir = join(tmpDir, "dist");
+
+    const graph: Graph = {
+      nodes: [
+        { skill: "worker", reads: [], writes: [] },
+      ],
+    };
+
+    const config: Config = {
+      name: "orch-test",
+      skills: {
+        worker: { path: "./skills/worker" },
+      },
+      team: { flow: graph },
+    };
+
+    const bodies = new Map<string, string>();
+
+    compile(config, bodies, outDir);
+    const results = check(config, bodies, outDir);
+
+    const orchResult = results.find((r) => r.name === "orchestrator");
+    assert.ok(orchResult);
+    assert.equal(orchResult.status, "ok");
   });
 });

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { type Config, isComposed } from "./config.js";
@@ -40,9 +40,56 @@ function formatFrontmatter(name: string, description: string): string {
   return `---\nname: ${name}\ndescription: ${description}\n---\n`;
 }
 
+export interface GenerateResult {
+  name: string;
+  path: string;
+  content: string;
+}
+
 export interface CompileResult {
   name: string;
   path: string;
+}
+
+export interface CheckResult {
+  name: string;
+  path: string;
+  status: "ok" | "stale" | "missing";
+}
+
+export function generate(
+  config: Config,
+  bodies: Map<string, string>,
+  outDir: string
+): GenerateResult[] {
+  const results: GenerateResult[] = [];
+
+  for (const [name, skill] of Object.entries(config.skills)) {
+    if (!isComposed(skill)) continue;
+
+    const parts = expand(name, config, bodies, new Set());
+    const body = parts.join("\n\n");
+    const outPath = join(outDir, name, "SKILL.md");
+
+    const output = formatFrontmatter(name, skill.description) + "\n" + body + "\n";
+    results.push({ name, path: outPath, content: output });
+  }
+
+  if (config.team) {
+    const orchestratorMd = generateOrchestrator(config);
+
+    if (config.team.orchestrator) {
+      const target = results.find((r) => r.name === config.team!.orchestrator);
+      if (target) {
+        target.content = target.content + "\n" + orchestratorMd;
+      }
+    } else {
+      const outPath = join(outDir, "orchestrator", "SKILL.md");
+      results.push({ name: "orchestrator", path: outPath, content: orchestratorMd });
+    }
+  }
+
+  return results;
 }
 
 export function compile(
@@ -52,35 +99,35 @@ export function compile(
 ): CompileResult[] {
   mkdirSync(outDir, { recursive: true });
 
-  const results: CompileResult[] = [];
+  const generated = generate(config, bodies, outDir);
 
-  for (const [name, skill] of Object.entries(config.skills)) {
-    if (!isComposed(skill)) continue;
-
-    const parts = expand(name, config, bodies, new Set());
-    const body = parts.join("\n\n");
-    const skillDir = join(outDir, name);
-    mkdirSync(skillDir, { recursive: true });
-    const outPath = join(skillDir, "SKILL.md");
-
-    const output = formatFrontmatter(name, skill.description) + "\n" + body + "\n";
-    writeFileSync(outPath, output, "utf-8");
-    results.push({ name, path: outPath });
+  for (const result of generated) {
+    mkdirSync(join(outDir, result.name), { recursive: true });
+    writeFileSync(result.path, result.content, "utf-8");
   }
 
-  if (config.team) {
-    const orchestratorMd = generateOrchestrator(config);
+  return generated.map(({ name, path }) => ({ name, path }));
+}
 
-    if (config.team.orchestrator) {
-      const targetPath = join(outDir, config.team.orchestrator, "SKILL.md");
-      const existing = readFileSync(targetPath, "utf-8");
-      writeFileSync(targetPath, existing + "\n" + orchestratorMd, "utf-8");
+export function check(
+  config: Config,
+  bodies: Map<string, string>,
+  outDir: string
+): CheckResult[] {
+  const generated = generate(config, bodies, outDir);
+  const results: CheckResult[] = [];
+
+  for (const result of generated) {
+    if (!existsSync(result.path)) {
+      results.push({ name: result.name, path: result.path, status: "missing" });
+      continue;
+    }
+
+    const existing = readFileSync(result.path, "utf-8");
+    if (existing === result.content) {
+      results.push({ name: result.name, path: result.path, status: "ok" });
     } else {
-      const orchDir = join(outDir, "orchestrator");
-      mkdirSync(orchDir, { recursive: true });
-      const outPath = join(orchDir, "SKILL.md");
-      writeFileSync(outPath, orchestratorMd, "utf-8");
-      results.push({ name: "orchestrator", path: outPath });
+      results.push({ name: result.name, path: result.path, status: "stale" });
     }
   }
 


### PR DESCRIPTION
**[orchestrator]**

## Summary

- Extract `generate()` from `compile()` to separate content generation from file writing
- Add `check()` function that compares generated output against on-disk files
- Add `--check` CLI flag: exits 0 if output is current, exits 1 if stale/missing
- Add `--check` step to CI workflow to dogfood the feature
- Bump version to v0.8.0
- 4 new tests (257 total)

## Why

The `--check` flag gives CI pipelines a reason to integrate skillfold. It catches stale builds when someone edits config but forgets to recompile - analogous to `prettier --check` or `tsc --noEmit`.

## Test plan

- [x] All 257 tests pass
- [x] Type check clean (`tsc --noEmit`)
- [x] Manual test: `skillfold && skillfold --check` reports up-to-date
- [x] Manual test: modify output file, `skillfold --check` reports stale and exits 1

Closes #64

Generated with [Claude Code](https://claude.com/claude-code)