### PR TITLE
Add skillfold-cli skill to library and fix platform count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/
   init.ts         - skillfold init scaffolding
   errors.ts       - ConfigError, ResolveError, CompileError, GraphError
 skills/           - Atomic skill definitions (each has a SKILL.md)
-library/          - Shared skills library (10 generic skills + 3 example configs)
+library/          - Shared skills library (11 generic skills + 3 example configs)
 docs/             - Getting-started tutorial and documentation
 dist/             - tsc compiled JS (npm package, gitignored)
 build/            - Compiled skill output (default --out-dir, gitignored)
@@ -78,7 +78,7 @@ Read BRIEF.md for full context. Key points:
 
 ## Shared Skills Library
 
-The `library/` directory contains 10 generic, reusable atomic skills and 3 example pipeline configs. It exists as an import target - other configs can pull in library skills via the `imports` field.
+The `library/` directory contains 11 generic, reusable atomic skills and 3 example pipeline configs. It exists as an import target - other configs can pull in library skills via the `imports` field.
 
 ### Skills
 
@@ -92,6 +92,7 @@ The `library/` directory contains 10 generic, reusable atomic skills and 3 examp
 - **summarization** - Condense information with audience-appropriate detail levels
 - **github-workflow** - Work with GitHub branches, PRs, issues, reviews via `gh` CLI
 - **file-management** - Read, create, edit, and organize files and directories
+- **skillfold-cli** - Use the skillfold compiler to manage pipeline configs
 
 ### Import Syntax
 
@@ -129,7 +130,7 @@ Located in `library/examples/`:
 - End-to-end test with the brief's full example config
 - CI via GitHub Actions (Node 20 + 22)
 - Graph visualization with full composition lineage and state writes (`skillfold graph`)
-- Shared skills library with 10 generic atomic skills and 3 example pipeline configs
+- Shared skills library with 11 generic atomic skills and 3 example pipeline configs
 - `skillfold init` shows library import hint in generated config and CLI output
 - `skillfold validate` command for config validation without compiling output
 - `skillfold list` command for pipeline introspection (skills, state, team flow)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 One YAML config. One command. Every agent gets a compiled [SKILL.md](https://agentskills.io/specification).
 
-Works with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.com), [VS Code](https://code.visualstudio.com), [GitHub Copilot](https://github.com), [OpenAI Codex](https://developers.openai.com/codex), [Gemini CLI](https://geminicli.com), and [32 more](https://agentskills.io).
+Works with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.com), [VS Code](https://code.visualstudio.com), [GitHub Copilot](https://github.com), [OpenAI Codex](https://developers.openai.com/codex), [Gemini CLI](https://geminicli.com), and [26 more](https://agentskills.io).
 
 [Quick Start](#quick-start) | [How It Works](#how-it-works) | [Features](#features) | [Library](#shared-library) | [Reference](#reference)
 
@@ -156,7 +156,7 @@ imports:
 
 ## Shared Library
 
-Skillfold ships with **10 generic skills** you can import into any pipeline:
+Skillfold ships with **11 generic skills** you can import into any pipeline:
 
 | Skill | Purpose |
 |-------|---------|
@@ -170,6 +170,7 @@ Skillfold ships with **10 generic skills** you can import into any pipeline:
 | summarization | Condense information for target audiences |
 | github-workflow | Work with branches, PRs, issues via `gh` CLI |
 | file-management | Read, create, edit, and organize files |
+| skillfold-cli | Use the skillfold compiler to manage pipeline configs |
 
 Three ready-made example configs are included in [`library/examples/`](library/examples/):
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -213,7 +213,7 @@ Validation catches:
 
 ## 7. Use the shared library
 
-Skillfold ships with 10 generic skills you can import instead of writing from scratch: `planning`, `research`, `decision-making`, `code-writing`, `code-review`, `testing`, `writing`, `summarization`, `github-workflow`, and `file-management`.
+Skillfold ships with 11 generic skills you can import instead of writing from scratch: `planning`, `research`, `decision-making`, `code-writing`, `code-review`, `testing`, `writing`, `summarization`, `github-workflow`, `file-management`, and `skillfold-cli`.
 
 To use them, uncomment the imports line in your config:
 

--- a/library/skillfold.yaml
+++ b/library/skillfold.yaml
@@ -12,3 +12,4 @@ skills:
     summarization: ./skills/summarization
     github-workflow: ./skills/github-workflow
     file-management: ./skills/file-management
+    skillfold-cli: ./skills/skillfold-cli

--- a/library/skills/skillfold-cli/SKILL.md
+++ b/library/skills/skillfold-cli/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: skillfold-cli
+description: Use the skillfold compiler to manage multi-agent pipeline configs. Compile, validate, inspect, and visualize pipelines defined in skillfold.yaml.
+---
+
+# Skillfold CLI
+
+You use the skillfold compiler to manage multi-agent pipeline configurations. Skillfold compiles YAML config into standard SKILL.md files per the Agent Skills specification.
+
+## Config File
+
+The pipeline is defined in `skillfold.yaml` at the project root. It has three top-level sections:
+
+- **skills** - Atomic skill directories and composition rules
+- **state** - Typed state schema with custom types and external locations
+- **team** - Orchestrator designation and execution flow
+
+## Commands
+
+### Compile
+
+```bash
+npx skillfold
+```
+
+Compiles the pipeline config and writes one SKILL.md per agent to the output directory (default: `build/`). Each output file contains the concatenated bodies of the agent's composed skills plus YAML frontmatter.
+
+### Validate
+
+```bash
+npx skillfold validate
+```
+
+Validates the config without writing any output. Checks skill references, state types, flow transitions, cycle exit conditions, and write conflicts. Use this for quick feedback while editing config.
+
+### Check
+
+```bash
+npx skillfold --check
+```
+
+Verifies that compiled output on disk matches what the compiler would generate. Exits with code 1 if any output is stale or missing. Designed for CI pipelines to catch uncommitted config changes.
+
+### List
+
+```bash
+npx skillfold list
+```
+
+Displays a structured summary of the pipeline: skills (atomic and composed with their composition chains), state fields with types and locations, and team flow with transitions.
+
+### Graph
+
+```bash
+npx skillfold graph
+```
+
+Outputs a Mermaid flowchart of the team flow. Shows full skill composition lineage (which atomic skills compose each agent) and state writes on edges.
+
+### Init
+
+```bash
+npx skillfold init
+```
+
+Scaffolds a new pipeline project with a starter `skillfold.yaml` and two example skills. Use this to get started quickly in a new directory.
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--config <path>` | Config file path (default: `skillfold.yaml`) |
+| `--out-dir <path>` | Output directory (default: `build`) |
+| `--dir <path>` | Target directory for init (default: `.`) |
+| `--check` | Verify compiled output is up-to-date |
+| `--help` | Show help |
+| `--version` | Show version |
+
+## Workflow
+
+A typical workflow when modifying the pipeline:
+
+1. Edit `skillfold.yaml` to change skills, state, or team flow
+2. Run `npx skillfold validate` to catch errors early
+3. Run `npx skillfold` to compile the pipeline
+4. Run `npx skillfold list` to inspect the result
+5. Commit both the config and the compiled output
+
+For CI, add `npx skillfold --check` to verify compiled output stays in sync with the config source of truth.

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -29,7 +29,7 @@ describe("library: skillfold.yaml", () => {
     assert.equal(config.name, "skillfold-library");
   });
 
-  it("declares all 10 atomic skills", () => {
+  it("declares all 11 atomic skills", () => {
     const config = readConfig(libraryConfigPath);
     const expected = [
       "planning",
@@ -42,11 +42,12 @@ describe("library: skillfold.yaml", () => {
       "summarization",
       "github-workflow",
       "file-management",
+      "skillfold-cli",
     ];
     for (const name of expected) {
       assert.ok(name in config.skills, `Expected skill "${name}" to be declared`);
     }
-    assert.equal(Object.keys(config.skills).length, 10);
+    assert.equal(Object.keys(config.skills).length, 11);
   });
 
   it("has no state or team sections", () => {


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `library/skills/skillfold-cli/SKILL.md` that teaches agents how to use the skillfold compiler (init, compile, validate, list, graph, --check). The tool that compiles SKILL.md files now describes itself as a skill.
- Fix README platform count: "32 more" after naming 6 implies 38 total, but agentskills.io has 32. Changed to "26 more" so the math works.
- Register the new skill in `library/skillfold.yaml` (10 -> 11 skills)
- Update all references: README, CLAUDE.md, docs/getting-started.md, library test

## Test plan

- [x] `npm test` passes (258 tests, up from 257)
- [x] `npx tsc --noEmit` type checks
- [ ] New SKILL.md has valid frontmatter and >15 non-empty body lines (tested by existing library skill directory test)
- [ ] Library config parses with 11 skills (tested by updated count assertion)

Closes #67, closes #68