### PR TITLE
Fix install instructions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,6 @@ npm install -g skillfold    # global install
 npx skillfold               # or run directly
 ```
 
-The npm registry may lag behind the latest release. To install directly from GitHub:
-
-```bash
-npm install github:byronxlg/skillfold
-```
-
 Requires Node.js 20+. Single dependency: `yaml`.
 
 ### CLI

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,10 +4,10 @@ This tutorial walks you from zero to a compiled multi-agent pipeline. By the end
 
 ## 1. Install
 
-Install skillfold from GitHub (the npm registry may be behind the latest version):
+Install skillfold from npm:
 
 ```bash
-npm install github:byronxlg/skillfold
+npm install skillfold
 ```
 
 Requires Node.js 20+. Verify with `npx skillfold --version`.


### PR DESCRIPTION
Remove outdated GitHub install fallback. Use npm install skillfold as primary install path. Closes #80