### PR TITLE
Add agentskills field to package.json for skill discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,21 @@
   },
   "files": ["dist", "library", "skillfold.schema.json"],
   "keywords": ["agent", "skills", "pipeline", "compiler", "multi-agent", "orchestrator", "skill-composition"],
+  "agentskills": {
+    "skills": [
+      { "name": "planning", "path": "./library/skills/planning" },
+      { "name": "research", "path": "./library/skills/research" },
+      { "name": "decision-making", "path": "./library/skills/decision-making" },
+      { "name": "code-writing", "path": "./library/skills/code-writing" },
+      { "name": "code-review", "path": "./library/skills/code-review" },
+      { "name": "testing", "path": "./library/skills/testing" },
+      { "name": "writing", "path": "./library/skills/writing" },
+      { "name": "summarization", "path": "./library/skills/summarization" },
+      { "name": "github-workflow", "path": "./library/skills/github-workflow" },
+      { "name": "file-management", "path": "./library/skills/file-management" },
+      { "name": "skillfold-cli", "path": "./library/skills/skillfold-cli" }
+    ]
+  },
   "homepage": "https://github.com/byronxlg/skillfold",
   "bugs": "https://github.com/byronxlg/skillfold/issues",
   "repository": {


### PR DESCRIPTION
**[engineer]**

Closes #86

Adds an `agentskills` field to `package.json` per the npm distribution RFC (agentskills/agentskills#81). This declares all 11 library skills with their paths, making them auto-discoverable by [`npm-agentskills`](https://github.com/onmax/npm-agentskills) and any future tooling implementing the convention.

## Changes

- Added `agentskills.skills` array to `package.json` listing all 11 library skills

## Test plan

- [x] All 260 tests pass
- [x] Skill names match SKILL.md `name` fields
- [x] Paths are correct relative to package root