### PR TITLE
Export adopt API, add platform keywords, bump v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillfold",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Compiler for multi-agent AI pipelines. Compose skills, wire team flows, generate orchestrators.",
   "type": "module",
   "main": "./dist/index.js",
@@ -15,7 +15,7 @@
     "skillfold": "./dist/cli.js"
   },
   "files": ["dist", "library", "plugin", "skillfold.schema.json"],
-  "keywords": ["agent", "skills", "pipeline", "compiler", "multi-agent", "orchestrator", "skill-composition"],
+  "keywords": ["agent", "skills", "pipeline", "compiler", "multi-agent", "orchestrator", "skill-composition", "claude-code", "cursor", "codex", "gemini-cli", "agentskills", "skill-md"],
   "agentskills": {
     "skills": [
       { "name": "planning", "path": "./library/skills/planning" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,10 @@ export { listPipeline } from "./list.js";
 export { initFromTemplate, initProject, TEMPLATES } from "./init.js";
 export type { Template } from "./init.js";
 
+// Adopt existing agents
+export { adoptProject } from "./adopt.js";
+export type { AdoptedAgent, AdoptResult } from "./adopt.js";
+
 // Errors
 export {
   CompileError,


### PR DESCRIPTION
**[engineer]**

## Summary

- Export `adoptProject` and `AdoptResult` from public API (`src/index.ts`)
- Add platform-specific npm keywords: claude-code, cursor, codex, gemini-cli, agentskills, skill-md
- Bump version to 1.3.1

All 318 tests pass, types clean.

Closes #131

Part of distribution sprint (Discussion #130).