### PR TITLE
Add Mermaid pipeline diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,22 @@ Skillfold has three layers, each building on the last:
 
 Compiled output is portable across [32 platforms](https://agentskills.io) that support the Agent Skills standard.
 
+Here's the Quick Start example as a flow diagram (`skillfold graph`):
+
+```mermaid
+graph TD
+    subgraph engineer
+        planning
+        coding
+    end
+    engineer -->|"code"| reviewer
+    subgraph reviewer
+        review
+    end
+    reviewer -->|"approved == false"| engineer
+    reviewer -->|"approved == true"| end_node([end])
+```
+
 <details>
 <summary><strong>Generated orchestrator output</strong></summary>
 


### PR DESCRIPTION
**[engineer]**

Adds a Mermaid flowchart diagram to the README "How It Works" section, showing the Quick Start example pipeline (engineer -> reviewer with review loop and skill composition).

GitHub renders fenced mermaid blocks natively, giving visitors an immediate visual understanding of what a team flow looks like.

Closes #145
Ref: Discussion #142