### PR TITLE
Fix build and packaging friction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,4 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm test
       - run: npx tsx src/cli.ts && npx tsx src/cli.ts --check
+      - run: npm run build && node dist/cli.js --version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm test
       - run: npm run build
+      - run: node dist/cli.js --version
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -38,12 +38,15 @@
     "url": "https://github.com/byronxlg/skillfold.git"
   },
   "license": "MIT",
+  "author": "Byron Smith",
   "engines": {
     "node": ">=20"
   },
   "scripts": {
     "dev": "tsx src/cli.ts",
     "build": "tsc -p tsconfig.build.json",
+    "postbuild": "chmod +x dist/cli.js",
+    "prepare": "npm run build",
     "build:plugin": "node scripts/build-plugin.mjs",
     "test": "tsx --test src/*.test.ts",
     "start": "node dist/cli.js"


### PR DESCRIPTION
**[engineer]**

Ref: Discussion #150
Closes #151

## Summary

- Add `postbuild` script (`chmod +x dist/cli.js`) so the CLI binary has execute permission after every `tsc` build
- Add `prepare` script (`npm run build`) so `dist/` is built automatically for git-based installs (`npm install github:byronxlg/skillfold`)
- Add `author` field to package.json
- Add smoke test step (`npm run build && node dist/cli.js --version`) to CI workflow
- Add smoke test step (`node dist/cli.js --version`) between build and publish in the publish workflow

## Test plan

- [x] `npm test` passes (318 tests, 0 failures)
- [x] `npm run build` runs and postbuild sets +x on dist/cli.js
- [ ] CI smoke test step runs on push to this branch
