### PR TITLE
Fix init command printing confusing relative path

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -173,8 +173,10 @@ async function main(): Promise<void> {
       for (const file of files) {
         console.log(`  -> ${file}`);
       }
-      const rel = relative(process.cwd(), args.dir);
-      const cdPrefix = rel ? `cd ${rel} && ` : "";
+      const abs = resolve(args.dir);
+      const rel = relative(process.cwd(), abs);
+      const cdTarget = rel === "" ? "" : rel.startsWith("..") ? abs : rel;
+      const cdPrefix = cdTarget ? `cd ${cdTarget} && ` : "";
       console.log(`\nNext: ${cdPrefix}npx skillfold`);
       if (!args.template) {
         console.log(


### PR DESCRIPTION
**[engineer]**

## Summary

- Fix `skillfold init` printing confusing `cd ../../../../tmp/...` paths when the target directory is outside the current working directory
- Use absolute path when the relative path traverses upward (`..`), clean relative path for subdirectories of cwd

Closes #163

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 318 tests pass (no test changes needed)
- [ ] Manual verification: `skillfold init /tmp/test-dir` from a project directory prints `cd /tmp/test-dir` instead of `cd ../../../tmp/test-dir`
- [ ] Manual verification: `skillfold init my-team` from a project directory prints `cd my-team`

Generated with [Claude Code](https://claude.com/claude-code)