### PR TITLE
Add terminal demo to README and sharpen submission draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,58 @@ npx skillfold                # compile it
 
 For a step-by-step walkthrough, see the [Getting Started](docs/getting-started.md) guide. To compile directly to your platform, see the [Integration Guide](docs/integrations.md).
 
+<details>
+<summary><strong>See it in action</strong></summary>
+
+```
+$ npx skillfold init my-team --template dev-team
+skillfold: project initialized
+  -> skillfold.yaml
+
+$ npx skillfold --target claude-code
+skillfold: compiled dev-team
+  -> .claude/skills/planner/SKILL.md
+  -> .claude/skills/engineer/SKILL.md
+  -> .claude/skills/reviewer/SKILL.md
+  -> .claude/skills/orchestrator/SKILL.md
+  -> .claude/agents/planner.md
+  -> .claude/agents/engineer.md
+  -> .claude/agents/reviewer.md
+
+$ npx skillfold list
+dev-team
+
+Skills (11 atomic, 3 composed):
+  planning             (atomic)
+  research             (atomic)
+  decision-making      (atomic)
+  code-writing         (atomic)
+  code-review          (atomic)
+  testing              (atomic)
+  writing              (atomic)
+  summarization        (atomic)
+  github-workflow      (atomic)
+  file-management      (atomic)
+  skillfold-cli        (atomic)
+  planner              = planning + decision-making
+  engineer             = planning + code-writing + testing
+  reviewer             = code-review + testing
+
+State (3 fields, 1 types):
+  plan                 string
+  implementation       string
+  review               Review
+  Review { approved: bool, feedback: string }
+
+Team Flow:
+  planner -> engineer
+  engineer -> reviewer
+  reviewer -> end (when review.approved == true)
+  reviewer -> engineer (when review.approved == false)
+```
+
+</details>
+
 Add state and team flow to go beyond skill composition:
 
 ```yaml

--- a/docs/awesome-claude-code-submission.md
+++ b/docs/awesome-claude-code-submission.md
@@ -1,9 +1,12 @@
 # awesome-claude-code Submission Draft
 
-Submit this via the GitHub web UI at:
+IMPORTANT: This submission MUST be done via the GitHub web UI by a human.
+Do NOT attempt to submit programmatically.
+
+Submit at:
 https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml
 
-Earliest submission date: March 26, 2026 (repo must be at least one week old).
+Earliest submission date: ~April 3, 2026 (cooldown expiration from previous submission).
 
 ---
 
@@ -25,61 +28,27 @@ Earliest submission date: March 26, 2026 (repo must be at least one week old).
 
 **Description:**
 
-YAML pipeline compiler with native Claude Code integration. Install the plugin for `/skillfold` slash command access, or use `--target claude-code` to compile directly to `.claude/agents/*.md` layout. Define atomic skills once, compose them into agents, wire agents into typed team flows with conditional routing and parallel map, and compile to standard SKILL.md files. Works across Claude Code, Cursor, Codex, and Gemini CLI.
+Configuration language and compiler for multi-agent AI pipelines. Compiles YAML config into standard SKILL.md files - define skills once, compose them into agents, wire agents into typed execution flows with conditional routing and parallel map. Ships with a Claude Code plugin and `--target claude-code` for native `.claude/agents/` output.
 
 **Validate Claims:**
-
-Scaffold and compile a pipeline directly to Claude Code agent layout:
 
 ```bash
 npx skillfold init demo --template dev-team
 cd demo
 npx skillfold --target claude-code
-```
-
-Inspect the output - you'll see `.claude/agents/planner.md`, `.claude/agents/engineer.md`, `.claude/agents/reviewer.md` with composed skill instructions and YAML frontmatter.
-
-To see a composed agent with multiple skills (planning + code-writing + testing):
-
-```bash
 cat .claude/agents/engineer.md
 ```
 
-To adopt an existing Claude Code project that already has agents in `.claude/agents/`:
-
-```bash
-npx skillfold adopt
-npx skillfold --target claude-code
-```
-
-This round-trips existing agent files through the compiler and back to `.claude/agents/` layout.
+The engineer agent file contains composed instructions from planning + code-writing + testing skills, with YAML frontmatter for Claude Code.
 
 **Specific Task(s):**
 
-1. Run `npx skillfold init demo --template dev-team && cd demo && npx skillfold --target claude-code` to scaffold and compile a pipeline to Claude Code layout.
-2. Inspect `.claude/agents/engineer.md` to see composed skill instructions with YAML frontmatter.
-3. Run `npx skillfold graph` to see the Mermaid flowchart of the team flow.
+Run `npx skillfold init demo --template dev-team && cd demo && npx skillfold --target claude-code` to scaffold a 3-agent pipeline and compile it to Claude Code layout. Inspect `.claude/agents/engineer.md` to see composed skill instructions.
 
 **Specific Prompt(s):**
 
-Install the skillfold plugin for Claude Code:
-
-```bash
-npm install skillfold
-```
-
-The plugin at `node_modules/skillfold/plugin/` is auto-discovered by Claude Code. Use the `/skillfold` slash command to compile your pipeline.
-
-Alternatively, compile directly to Claude Code agent layout without the plugin:
-
-```bash
-npx skillfold init my-team --template dev-team
-cd my-team
-npx skillfold --target claude-code
-```
-
-This generates `.claude/agents/*.md` files ready for Claude Code to use immediately.
+After installing the plugin (`npm install skillfold`), use the `/skillfold` slash command in Claude Code to compile your pipeline config.
 
 **Additional Comments:**
 
-Skillfold is a compile-time orchestrator - no runtime agent framework, no SDK, no daemon. The compiler validates skill references, state types, write conflicts, and cycle exit conditions before any agent runs. Atomic skills compose recursively into agents, and team flows define the execution graph with typed state. The output is plain Markdown files that Claude Code reads natively. Ships with 11 reusable library skills and 3 example pipeline configs.
+Unlike the other orchestrators in this section (Claude Squad, Crystal, sudocode, TSK, etc.), Skillfold is not a runtime framework - it has no daemon, no SDK, no process manager. It is a compiler that runs once and produces plain Markdown files. The compiled output works with Claude Code natively. This makes it complementary to runtime orchestrators rather than competitive with them.


### PR DESCRIPTION
**[engineer]**

## Summary

- Add collapsible "See it in action" terminal output section to README, placed between Quick Start and the state/team flow example. Shows `init --template`, `--target claude-code`, and `list` output in a `<details>` block so it doesn't bloat above-the-fold content.
- Rewrite `docs/awesome-claude-code-submission.md` to match the awesome-claude-code form requirements: concise 3-sentence description (no emojis, not promotional), single copy-paste validate block, one focused task, one exact prompt, and differentiation from runtime orchestrators in additional comments.
- Update earliest submission date to ~April 3, 2026 with prominent reminder that submission must be done via GitHub web UI by a human.

Closes #167, closes #170, closes #171

## Test plan

- [x] All 318 tests pass (documentation-only changes, no source code modified)
- [ ] Verify README renders correctly on GitHub (details block, code formatting)
- [ ] Verify submission draft fields match the awesome-claude-code form structure