### PR TITLE
Update stale test counts and audit doc alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Located in `library/examples/`:
 - `--target claude-code` output mode generating `.claude/agents/*.md`, `.claude/skills/{name}/SKILL.md`, and `.claude/commands/run-pipeline.md`
 - `skillfold plugin` command for packaging pipelines as distributable Claude Code plugins
 - `skillfold adopt` command for adopting existing Claude Code agents into a pipeline
-- Test suite with 322 tests across 58 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, and e2e modules
+- Test suite with 328 tests across 59 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/docs/awesome-claude-code-submission.md
+++ b/docs/awesome-claude-code-submission.md
@@ -29,7 +29,7 @@ Earliest submission date: March 26, 2026 (7-day repo age requirement met).
 
 **Description:**
 
-Compile-time pipeline compiler that turns YAML config into Claude Code agents. Atomic skills compose into agents, team flows define typed execution graphs with conditional routing and parallel map, and `--target claude-code` compiles everything to `.claude/agents/*.md` with no runtime or daemon. Single dependency, 322 tests.
+Compile-time pipeline compiler that turns YAML config into Claude Code agents. Atomic skills compose into agents, team flows define typed execution graphs with conditional routing and parallel map, and `--target claude-code` compiles everything to `.claude/agents/*.md` with no runtime or daemon. Single dependency, 328 tests.
 
 **Validate Claims:**
 
@@ -55,7 +55,7 @@ Then tell Claude Code: "Use /skillfold to compile the pipeline and show me the g
 
 **Additional Comments:**
 
-Every other orchestrator in the awesome-claude-code list is a runtime tool - it launches agents, manages sessions, and coordinates execution while agents run. Skillfold is the only compile-time tool in the category. It validates skill references, state types, write conflicts, and cycle exit conditions at build time, then produces plain Markdown files that Claude Code reads natively. When a pipeline has a team flow, the compiler also generates an executable `/run-pipeline` command that orchestrates the agents with a step-by-step execution plan, state table, and Agent tool invocations. There is no process to run, no server to start, and no SDK to integrate. The compiler has 322 tests, a single dependency (yaml), and runs on Node 20+.
+Every other orchestrator in the awesome-claude-code list is a runtime tool - it launches agents, manages sessions, and coordinates execution while agents run. Skillfold is the only compile-time tool in the category. It validates skill references, state types, write conflicts, and cycle exit conditions at build time, then produces plain Markdown files that Claude Code reads natively. When a pipeline has a team flow, the compiler also generates an executable `/run-pipeline` command that orchestrates the agents with a step-by-step execution plan, state table, and Agent tool invocations. There is no process to run, no server to start, and no SDK to integrate. The compiler has 328 tests, a single dependency (yaml), and runs on Node 20+.
 
 ---
 
@@ -89,7 +89,7 @@ scoring criteria helps confirm Skillfold is ready.
   stored or logged.
 - **Single dependency** - The only runtime dependency is `yaml` (YAML parser).
   No transitive dependency tree to audit.
-- **322 tests** across 58 suites, run with `node:test` (zero test framework
+- **328 tests** across 59 suites, run with `node:test` (zero test framework
   dependencies).
 - **MIT license**, clearly stated in LICENSE and package.json.
 - **CI on Node 20 + 22** via GitHub Actions, with `--check` flag for verifying

--- a/skills/skillfold-context/SKILL.md
+++ b/skills/skillfold-context/SKILL.md
@@ -51,7 +51,7 @@ The codebase is TypeScript (strict, ESM modules). Key modules:
 
 ## What's Implemented
 
-All compiler features are working: skill composition with atomic/composed sub-sections, state schema, flow validation, map subgraph validation, when-clause parsing, orchestrator generation, spec-compliant output, URL-based skill references (with private repo auth via GITHUB_TOKEN), pipeline imports, graph visualization with full composition lineage, `skillfold init`, `skillfold adopt`, `skillfold validate`, `skillfold list`, and `--check` for CI integration. Published on npm as `skillfold`. 322 tests, CI on GitHub Actions. The project self-hosts its own dev team via `skillfold.yaml`.
+All compiler features are working: skill composition with atomic/composed sub-sections, state schema, flow validation, map subgraph validation, when-clause parsing, orchestrator generation, spec-compliant output, URL-based skill references (with private repo auth via GITHUB_TOKEN), pipeline imports, graph visualization with full composition lineage, `skillfold init`, `skillfold adopt`, `skillfold validate`, `skillfold list`, and `--check` for CI integration. Published on npm as `skillfold`. 328 tests, CI on GitHub Actions. The project self-hosts its own dev team via `skillfold.yaml`.
 
 ## What's Next
 


### PR DESCRIPTION
**[engineer]**

## Summary

- Updated test suite references from "322 tests across 58 suites" to "328 tests across 59 suites" in three files: `CLAUDE.md`, `docs/awesome-claude-code-submission.md`, and `skills/skillfold-context/SKILL.md`
- Audited `docs/getting-started.md` - all CLI commands, output descriptions, config examples, and library skill counts are accurate
- Audited `docs/integrations.md` - all platform targets, command syntax, and directory paths are accurate

No issues found in either audited doc.

Closes #206