### PR TITLE
Update submission draft for April 3 cooldown deadline

### DIFF
--- a/docs/awesome-claude-code-submission.md
+++ b/docs/awesome-claude-code-submission.md
@@ -7,7 +7,27 @@
 Submit via the GitHub web UI at:
 https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml
 
-Earliest submission date: March 26, 2026 (7-day repo age requirement met).
+Earliest submission date: April 3, 2026 (cooldown period, see below).
+
+---
+
+## Cooldown History
+
+Two prior submissions were closed on March 20, 2026, triggering escalating
+cooldown penalties:
+
+1. **PR #1020** (March 20) - 7-day cooldown imposed
+2. **PR #1022** (March 20) - 14-day cooldown imposed (escalation)
+
+The escalating pattern means a third violation would trigger an even longer
+cooldown. The submission MUST be done correctly on the first attempt via the
+web UI. Do NOT submit before April 3, 2026.
+
+Key reminders:
+- The `gh` CLI cannot submit issue forms; use the web UI only
+- Fill in every required field before submitting
+- Double-check category and sub-category dropdown selections
+- Review the form preview before clicking "Submit new issue"
 
 ---
 


### PR DESCRIPTION
**[engineer]**

## Summary

- Update earliest submission date from March 26 to April 3, 2026 to reflect the 14-day cooldown from PR #1022
- Add Cooldown History section documenting both violations (PR #1020 and #1022) and the escalation risk
- Verified all form fields match the current `recommend-resource.yml` issue template
- Confirmed description is 350 characters (under the 500-character limit)

Closes #211

## Test plan

- [ ] Verify the date change reads "April 3, 2026"
- [ ] Verify the Cooldown History section appears between the submission link and Form Fields sections
- [ ] Verify no code changes or version bumps are included

Generated with [Claude Code](https://claude.com/claude-code)