### PR TITLE
Fix submission date and validate demo path

### DIFF
--- a/docs/awesome-claude-code-submission.md
+++ b/docs/awesome-claude-code-submission.md
@@ -7,7 +7,22 @@
 Submit via the GitHub web UI at:
 https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml
 
-Earliest submission date: March 26, 2026 (7-day repo age requirement met).
+Earliest submission date: April 3, 2026 (cooldown expiry, see below).
+
+### Cooldown Warning
+
+Two prior violations pushed the earliest submission date back:
+
+- **PR #1020** and **PR #1022** were submitted directly as pull requests to
+  awesome-claude-code instead of through the required issue template.
+- Both were closed by the maintainer. The 14-day cooldown from March 20
+  sets the earliest retry to **April 3, 2026**.
+- The account is now **2 strikes** into a 7-strike-to-permanent-ban
+  escalation. A third violation would push the cooldown to approximately
+  30 days.
+- The submission **MUST** go through the
+  [issue template web UI](https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml),
+  **NOT** via `gh` CLI, **NOT** as a direct PR.
 
 ---
 


### PR DESCRIPTION
[engineer]

## Summary

- Update earliest submission date from March 26 to April 3, 2026 to account for 14-day cooldown after two prior violations (PRs #1020 and #1022)
- Add a cooldown warning section documenting strike history, escalation policy, and the requirement to use the issue template web UI
- Validate the demo path (`skillfold init --template dev-team` + `--target claude-code`) produces clean output with 3 agents, YAML frontmatter, and composed skill sections
- Confirm test counts (328 tests, 59 suites) match all claims in the submission draft, CLAUDE.md, and skills/skillfold-context/SKILL.md

## Validation performed

| Check | Result |
|---|---|
| Description length | 350 characters (under 500 limit) |
| Form fields | All present and correct |
| Demo path output | 3 agents (engineer, planner, reviewer), YAML frontmatter, 21 heading sections in engineer.md |
| Test suite | 328 tests, 59 suites, 0 failures |
| Test count consistency | Matches submission draft, CLAUDE.md, and SKILL.md |

## Test plan

- [x] `npm test` passes (328/59, 0 failures)
- [x] Demo path produces expected output
- [x] Description under 500 characters
- [x] Cooldown warning section is accurate and complete

Closes #215
Closes #216