### PR TITLE
Add 33 edge-case tests across 5 modules (328 -> 361)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Located in `library/examples/`:
 - `--target claude-code` output mode generating `.claude/agents/*.md`, `.claude/skills/{name}/SKILL.md`, and `.claude/commands/run-pipeline.md`
 - `skillfold plugin` command for packaging pipelines as distributable Claude Code plugins
 - `skillfold adopt` command for adopting existing Claude Code agents into a pipeline
-- Test suite with 328 tests across 59 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, and e2e modules
+- Test suite with 361 tests across 70 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -394,6 +394,78 @@ orchestrator: review
       return true;
     });
   });
+
+  it("rejects composed skill without compose field", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  composed:
+    quality:
+      description: "No compose field."
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /must have a "compose" field/);
+      return true;
+    });
+  });
+
+  it("rejects composed skill with empty description", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose: [lint]
+      description: ""
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /composed skills must have a description/);
+      return true;
+    });
+  });
+
+  it("rejects empty YAML file", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, "");
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /Config must be a YAML object/);
+      return true;
+    });
+  });
+
+  it("rejects skills section that is not an object", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills: not-an-object
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      return true;
+    });
+  });
+
+  it("rejects skill name ending with a hyphen", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    bad-name-: ./skills/bad
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /name must be lowercase alphanumeric with hyphens/);
+      return true;
+    });
+  });
 });
 
 describe("readConfig name validation", () => {

--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -1180,6 +1180,246 @@ describe("validateGraph when-clause validation", () => {
   });
 });
 
+describe("parseGraph edge cases", () => {
+  it("rejects empty conditional then array", () => {
+    assert.throws(
+      () => parseGraph([{ strategy: {}, then: [] }]),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /conditional then must not be empty/);
+        return true;
+      },
+    );
+  });
+
+  it("rejects map node with non-object value", () => {
+    assert.throws(
+      () => parseGraph([{ map: "not-an-object" }]),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /value must be an object/);
+        return true;
+      },
+    );
+  });
+
+  it("rejects step node with non-object non-null value", () => {
+    assert.throws(
+      () => parseGraph([{ strategy: "bad-value" }]),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /value must be an object or omitted/);
+        return true;
+      },
+    );
+  });
+
+  it("rejects array element that is itself an array", () => {
+    assert.throws(
+      () => parseGraph([["nested"]]),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /must be an object/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("validateGraph: map over state without state declared", () => {
+  it("map over state.* with no state schema errors", () => {
+    const graph: Graph = {
+      nodes: [
+        {
+          over: "state.items",
+          as: "item",
+          graph: [
+            { skill: "worker", reads: [], writes: [] },
+          ],
+        },
+      ],
+    };
+    const skills = makeSkills("worker");
+    assert.throws(
+      () => validateGraph(graph, skills, undefined),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /references state but no state is declared/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("validateGraph: writes without state declared", () => {
+  it("writing state path without state schema errors", () => {
+    const graph: Graph = {
+      nodes: [
+        { skill: "strategy", reads: [], writes: ["state.goal"] },
+      ],
+    };
+    const skills = makeSkills("strategy");
+    assert.throws(
+      () => validateGraph(graph, skills, undefined),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /writes state field "state.goal" but no state is declared/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("validateGraph: when-clause with no state and non-state path", () => {
+  it("when-clause with dotted path and no state errors", () => {
+    const graph: Graph = {
+      nodes: [
+        {
+          skill: "checker",
+          reads: [],
+          writes: [],
+          then: [
+            { when: "some.field == true", to: "end" },
+          ],
+        },
+      ],
+    };
+    const skills = makeSkills("checker");
+    assert.throws(
+      () => validateGraph(graph, skills, undefined),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /not a state or map variable path/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("parseWhenClause edge cases", () => {
+  it("parses != with boolean value", () => {
+    const clause = parseWhenClause("state.active != false", 'Graph node "a"');
+    assert.deepEqual(clause, { path: "state.active", operator: "!=", value: false });
+  });
+
+  it("parses == with unquoted string value", () => {
+    const clause = parseWhenClause("state.mode == draft", 'Graph node "a"');
+    assert.deepEqual(clause, { path: "state.mode", operator: "==", value: "draft" });
+  });
+
+  it("parses == with negative numeric value", () => {
+    const clause = parseWhenClause("state.count == -1", 'Graph node "a"');
+    assert.deepEqual(clause, { path: "state.count", operator: "==", value: -1 });
+  });
+
+  it("parses == with zero value", () => {
+    const clause = parseWhenClause("state.count == 0", 'Graph node "a"');
+    assert.deepEqual(clause, { path: "state.count", operator: "==", value: 0 });
+  });
+
+  it("throws on when clause with empty path (== at start)", () => {
+    assert.throws(
+      () => parseWhenClause(" == true", 'Graph node "a"'),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /invalid when clause/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("validateGraph: when-clause with custom type sub-field", () => {
+  it("valid custom type sub-field in when-clause passes", () => {
+    const graph: Graph = {
+      nodes: [
+        { skill: "engineer", reads: [], writes: ["state.code"], then: "reviewer" },
+        {
+          skill: "reviewer",
+          reads: ["state.code"],
+          writes: ["state.review"],
+          then: [
+            { when: "review.approved == true", to: "end" },
+            { when: "review.approved == false", to: "engineer" },
+          ],
+        },
+      ],
+    };
+    const skills = makeSkills("engineer", "reviewer");
+    const state: StateSchema = {
+      types: {
+        Review: {
+          fields: { approved: "bool", feedback: "string" },
+        },
+      },
+      fields: {
+        code: { type: { kind: "primitive", value: "string" } },
+        review: { type: { kind: "custom", name: "Review" } },
+      },
+    };
+    assert.doesNotThrow(() => validateGraph(graph, skills, state));
+  });
+
+  it("invalid custom type sub-field in when-clause errors", () => {
+    const graph: Graph = {
+      nodes: [
+        {
+          skill: "reviewer",
+          reads: [],
+          writes: [],
+          then: [
+            { when: "review.nonexistent == true", to: "end" },
+          ],
+        },
+      ],
+    };
+    const skills = makeSkills("reviewer");
+    const state: StateSchema = {
+      types: {
+        Review: {
+          fields: { approved: "bool" },
+        },
+      },
+      fields: {
+        review: { type: { kind: "custom", name: "Review" } },
+      },
+    };
+    assert.throws(
+      () => validateGraph(graph, skills, state),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /type "Review" has no field "nonexistent"/);
+        return true;
+      },
+    );
+  });
+
+  it("when-clause with path that has no dot and state present errors", () => {
+    const graph: Graph = {
+      nodes: [
+        {
+          skill: "checker",
+          reads: [],
+          writes: [],
+          then: [
+            { when: "nodots == true", to: "end" },
+          ],
+        },
+      ],
+    };
+    const skills = makeSkills("checker");
+    const state = makeState({ status: { kind: "primitive", value: "string" } });
+    assert.throws(
+      () => validateGraph(graph, skills, state),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /not a valid state path/);
+        return true;
+      },
+    );
+  });
+});
+
 describe("type guards", () => {
   it("isMapNode returns true for MapNode", () => {
     assert.equal(isMapNode({ over: "state.tasks", as: "task", graph: [] }), true);

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -183,4 +183,56 @@ skills:
     assert.ok(output.includes("agent"));
     assert.ok(output.includes("= a + b + c + d"));
   });
+
+  it("renders state with list type fields", () => {
+    const raw = parseRawConfig(`
+name: list-state-test
+skills:
+  atomic:
+    worker: ./skills/worker
+state:
+  Task:
+    title: string
+    done: bool
+  tasks:
+    type: "list<Task>"
+  status:
+    type: string
+`);
+    const config = validateAndBuild(raw);
+    const output = listPipeline(config);
+
+    assert.ok(output.includes("State (2 fields, 1 types):"));
+    assert.ok(output.includes("list<Task>"));
+    assert.ok(output.includes("Task { title: string, done: bool }"));
+  });
+
+  it("renders implicit fall-through in team flow", () => {
+    const raw = parseRawConfig(`
+name: fall-through
+skills:
+  atomic:
+    a: ./skills/a
+    b: ./skills/b
+  composed:
+    first:
+      compose: [a]
+      description: "First agent."
+    second:
+      compose: [b]
+      description: "Second agent."
+team:
+  flow:
+    - first:
+        writes: []
+    - second:
+        writes: []
+`);
+    const config = validateAndBuild(raw);
+    const output = listPipeline(config);
+
+    assert.ok(output.includes("Team Flow:"));
+    assert.ok(output.includes("first -> second"));
+    assert.ok(output.includes("second -> end"));
+  });
 });

--- a/src/remote.test.ts
+++ b/src/remote.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { ResolveError } from "./errors.js";
-import { fetchRemoteSkill, getGitHubHeaders, parseGitHubUrl } from "./remote.js";
+import { ConfigError, ResolveError } from "./errors.js";
+import { fetchRemoteConfig, fetchRemoteSkill, getGitHubHeaders, parseGitHubUrl } from "./remote.js";
 
 describe("getGitHubHeaders", () => {
   it("returns Authorization header when GITHUB_TOKEN is set", () => {
@@ -81,6 +81,39 @@ describe("parseGitHubUrl", () => {
       /URL does not match GitHub tree URL pattern/
     );
   });
+
+  it("throws on a GitHub URL with tree but no path after ref", () => {
+    assert.throws(
+      () => parseGitHubUrl("https://github.com/owner/repo/tree/main"),
+      /URL does not match GitHub tree URL pattern/
+    );
+  });
+
+  it("throws on a bare GitHub domain with no path segments", () => {
+    assert.throws(
+      () => parseGitHubUrl("https://github.com/"),
+      /URL does not match GitHub tree URL pattern/
+    );
+  });
+
+  it("throws on an HTTP (non-HTTPS) GitHub URL", () => {
+    assert.throws(
+      () => parseGitHubUrl("http://github.com/owner/repo/tree/main/skill"),
+      /URL does not match GitHub tree URL pattern/
+    );
+  });
+
+  it("parses a URL with a ref containing dots (e.g. tag)", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/org/repo/tree/v1.2.3/skills/shared"
+    );
+    assert.deepEqual(parts, {
+      owner: "org",
+      repo: "repo",
+      ref: "v1.2.3",
+      path: "skills/shared",
+    });
+  });
 });
 
 describe("fetchRemoteSkill", () => {
@@ -109,6 +142,18 @@ describe("fetchRemoteSkill", () => {
     );
   });
 
+  it("rejects GitHub URL with owner/repo but no tree segment", async () => {
+    await assert.rejects(
+      () => fetchRemoteSkill("no-tree", "https://github.com/owner/repo"),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /Unsupported URL format/);
+        assert.match(err.message, /no-tree/);
+        return true;
+      }
+    );
+  });
+
   it("fetches a real skill from GitHub (code-review)", async () => {
     const content = await fetchRemoteSkill(
       "code-review",
@@ -117,6 +162,30 @@ describe("fetchRemoteSkill", () => {
     assert.ok(
       content.includes("Code Review"),
       "Fetched content should contain Code Review"
+    );
+  });
+});
+
+describe("fetchRemoteConfig", () => {
+  it("rejects non-GitHub URLs with ConfigError", async () => {
+    await assert.rejects(
+      () => fetchRemoteConfig("https://example.com/config"),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /Unsupported import URL format/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects malformed GitHub URLs with ConfigError", async () => {
+    await assert.rejects(
+      () => fetchRemoteConfig("https://github.com/owner-only"),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /Unsupported import URL format/);
+        return true;
+      }
     );
   });
 });

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -411,4 +411,63 @@ describe("parseState", () => {
       assert.deepEqual(schema.fields, {});
     });
   });
+
+  describe("list of primitives", () => {
+    it("rejects list<string> since element must be a custom type", () => {
+      const raw = {
+        names: { type: "list<string>" },
+      };
+      assert.throws(
+        () => parseState(raw, NO_SKILLS),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /unknown type "string"/);
+          return true;
+        }
+      );
+    });
+  });
+
+  describe("field missing type key", () => {
+    it("entry with object but no type key is treated as custom type definition", () => {
+      const raw = {
+        MyType: { name: "string", age: "number" },
+      };
+      const schema = parseState(raw, NO_SKILLS);
+      assert.ok("MyType" in schema.types);
+      assert.deepEqual(schema.types["MyType"].fields, { name: "string", age: "number" });
+    });
+  });
+
+  describe("non-string field values in custom type", () => {
+    it("rejects custom type field with non-string type value", () => {
+      const raw = {
+        BadType: { name: 42 },
+      };
+      assert.throws(
+        () => parseState(raw, NO_SKILLS),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          return true;
+        }
+      );
+    });
+  });
+
+  describe("location with unknown extra keys", () => {
+    it("parses location even with extra keys (only skill, path, kind used)", () => {
+      const raw = {
+        output: {
+          type: "string",
+          location: { skill: "review", path: "out.md", kind: "artifact", extra: "ignored" },
+        },
+      };
+      const schema = parseState(raw, SOME_SKILLS);
+      assert.deepEqual(schema.fields["output"]!.location, {
+        skill: "review",
+        path: "out.md",
+        kind: "artifact",
+      });
+    });
+  });
 });


### PR DESCRIPTION
**[engineer]**

## Summary

- Add 33 net new tests (328 -> 361) covering under-tested edge cases across 5 test modules
- Update CLAUDE.md test counts to reflect new totals (361 tests, 70 suites)

### Tests added by module

**remote.test.ts (+7 tests)**
- `parseGitHubUrl`: tree URL with no path after ref, bare GitHub domain, HTTP (non-HTTPS) URL, ref with dots (tag format)
- `fetchRemoteSkill`: GitHub URL with owner/repo but no tree segment
- `fetchRemoteConfig`: non-GitHub URL rejection, malformed GitHub URL rejection

**config.test.ts (+5 tests)**
- Composed skill missing `compose` field
- Composed skill with empty description string
- Empty YAML file
- Non-object skills section
- Skill name ending with hyphen

**graph.test.ts (+15 tests)**
- Parse edge cases: empty conditional then array, map with non-object value, step with non-object value, array-as-element
- Map over state with no state schema declared
- Writes to state path with no state schema declared
- When-clause with dotted path and no state
- When-clause parsing: `!=` with boolean, unquoted string value, negative number, zero, empty path
- When-clause validation: valid/invalid custom type sub-fields, path with no dot

**state.test.ts (+4 tests)**
- `list<string>` rejection (element must be custom type)
- Object without `type` key treated as custom type definition
- Non-string field value in custom type definition
- Location with extra keys (silently ignored)

**list.test.ts (+2 tests)**
- State with list type fields rendering
- Implicit fall-through in team flow rendering

## Test plan

- [x] All 361 tests pass locally (`npm test`)
- [ ] CI passes on Node 20 and Node 22

Closes #213