### PR TITLE
Improve compiler error messages with actionable context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Located in `library/examples/`:
 - `--target claude-code` output mode generating `.claude/agents/*.md`, `.claude/skills/{name}/SKILL.md`, and `.claude/commands/run-pipeline.md`
 - `skillfold plugin` command for packaging pipelines as distributable Claude Code plugins
 - `skillfold adopt` command for adopting existing Claude Code agents into a pipeline
-- Test suite with 328 tests across 59 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, and e2e modules
+- Test suite with 363 tests across 65 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, errors, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -118,7 +118,7 @@ skills:
 `);
     assert.throws(() => readConfig(configPath), (err: unknown) => {
       assert.ok(err instanceof ConfigError);
-      assert.match(err.message, /composed skills must have a description/);
+      assert.match(err.message, /composed skills must have a "description" field/);
       return true;
     });
   });
@@ -917,6 +917,151 @@ skills:
     await assert.rejects(() => loadConfig(configPath), (err: unknown) => {
       assert.ok(err instanceof ConfigError);
       assert.match(err.message, /Imports must be an array of strings/);
+      return true;
+    });
+  });
+});
+
+describe("error message improvements", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("includes file path in config parsing errors", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, "just a string");
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.ok(err.message.includes(configPath), "error should contain file path");
+      return true;
+    });
+  });
+
+  it("includes file path when skill validation fails", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  composed:
+    quality:
+      compose:
+        - nonexistent
+      description: "A quality skill."
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.ok(err.message.includes(configPath), "error should contain file path");
+      return true;
+    });
+  });
+
+  it("suggests close match for composed skill referencing unknown skill", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    review: ./skills/review
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - reveiw
+      description: "A quality skill."
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /composes unknown skill "reveiw"/);
+      assert.match(err.message, /Did you mean "review"\?/);
+      return true;
+    });
+  });
+
+  it("omits suggestion when no close match exists for composed skill", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    review: ./skills/review
+  composed:
+    quality:
+      compose:
+        - zzzzzzz
+      description: "A quality skill."
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /composes unknown skill "zzzzzzz"/);
+      assert.ok(!err.message.includes("Did you mean"), "should not suggest when no close match");
+      return true;
+    });
+  });
+
+  it("suggests close match for orchestrator referencing unknown skill", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    strategy: ./skills/strategy
+    lead: ./skills/lead
+state:
+  goal:
+    type: string
+team:
+  orchestrator: startegy
+  flow:
+    - strategy:
+        writes: [state.goal]
+      then: lead
+    - lead:
+        reads: [state.goal]
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /Orchestrator references unknown skill "startegy"/);
+      assert.match(err.message, /Did you mean "strategy"\?/);
+      return true;
+    });
+  });
+
+  it("actionable guidance for missing compose field", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  composed:
+    quality:
+      description: "A quality skill."
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /Add a "compose" list of skill names/);
+      return true;
+    });
+  });
+
+  it("actionable guidance for missing description field", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /Add a description explaining what this composed skill does/);
       return true;
     });
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import { parse } from "yaml";
 const __pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const SELF_IMPORT_PREFIX = "node_modules/skillfold/";
 
-import { ConfigError } from "./errors.js";
+import { ConfigError, didYouMean } from "./errors.js";
 import { Graph, parseGraph, validateGraph } from "./graph.js";
 import { fetchRemoteConfig } from "./remote.js";
 import { parseState, StateSchema } from "./state.js";
@@ -94,7 +94,7 @@ function normalizeComposedSkills(
       !("compose" in value)
     ) {
       throw new ConfigError(
-        `Skill "${name}": composed skills must have a "compose" field`
+        `Skill "${name}": composed skills must have a "compose" field. Add a "compose" list of skill names to this skill definition`
       );
     }
     const compose = (value as { compose: unknown }).compose;
@@ -106,7 +106,7 @@ function normalizeComposedSkills(
     const description = (value as { description?: unknown }).description;
     if (typeof description !== "string" || description.length === 0 || description.length > 1024) {
       throw new ConfigError(
-        `Skill "${name}": composed skills must have a description`
+        `Skill "${name}": composed skills must have a "description" field (non-empty string, max 1024 chars). Add a description explaining what this composed skill does`
       );
     }
     skills[name] = { compose, description };
@@ -132,12 +132,14 @@ function validateNames(skills: Record<string, SkillEntry>): void {
 }
 
 function validateReferences(skills: Record<string, SkillEntry>): void {
+  const allNames = Object.keys(skills);
   for (const [name, skill] of Object.entries(skills)) {
     if (isComposed(skill)) {
       for (const ref of skill.compose) {
         if (!(ref in skills)) {
+          const hint = didYouMean(ref, allNames);
           throw new ConfigError(
-            `Skill "${name}" composes unknown skill "${ref}"`
+            `Skill "${name}" composes unknown skill "${ref}"${hint}`
           );
         }
       }
@@ -297,8 +299,9 @@ export function validateAndBuild(raw: RawConfig): Config {
 
     if (raw.rawTeam.orchestrator !== undefined) {
       if (!(raw.rawTeam.orchestrator in raw.skills)) {
+        const hint = didYouMean(raw.rawTeam.orchestrator, Object.keys(raw.skills));
         throw new ConfigError(
-          `Orchestrator references unknown skill "${raw.rawTeam.orchestrator}"`
+          `Orchestrator references unknown skill "${raw.rawTeam.orchestrator}"${hint}`
         );
       }
       team.orchestrator = raw.rawTeam.orchestrator;
@@ -415,8 +418,15 @@ export function readConfig(configPath: string): Config {
     throw new ConfigError(`Cannot read config file: ${configPath}`);
   }
 
-  const raw = parseRawConfig(content);
-  return validateAndBuild(raw);
+  try {
+    const raw = parseRawConfig(content);
+    return validateAndBuild(raw);
+  } catch (err) {
+    if (err instanceof ConfigError && !err.message.includes(configPath)) {
+      throw new ConfigError(`${configPath}: ${err.message}`);
+    }
+    throw err;
+  }
 }
 
 // Async entry point that resolves imports before validation
@@ -428,7 +438,14 @@ export async function loadConfig(configPath: string): Promise<Config> {
     throw new ConfigError(`Cannot read config file: ${configPath}`);
   }
 
-  const raw = parseRawConfig(content);
-  const merged = await resolveImports(raw, dirname(configPath));
-  return validateAndBuild(merged);
+  try {
+    const raw = parseRawConfig(content);
+    const merged = await resolveImports(raw, dirname(configPath));
+    return validateAndBuild(merged);
+  } catch (err) {
+    if (err instanceof ConfigError && !err.message.includes(configPath)) {
+      throw new ConfigError(`${configPath}: ${err.message}`);
+    }
+    throw err;
+  }
 }

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { didYouMean, levenshtein, suggest } from "./errors.js";
+
+describe("levenshtein", () => {
+  it("returns 0 for identical strings", () => {
+    assert.equal(levenshtein("abc", "abc"), 0);
+  });
+
+  it("returns length of other string when one is empty", () => {
+    assert.equal(levenshtein("", "abc"), 3);
+    assert.equal(levenshtein("abc", ""), 3);
+  });
+
+  it("returns 0 for two empty strings", () => {
+    assert.equal(levenshtein("", ""), 0);
+  });
+
+  it("returns 1 for single-character substitution", () => {
+    assert.equal(levenshtein("cat", "car"), 1);
+  });
+
+  it("returns 1 for single-character insertion", () => {
+    assert.equal(levenshtein("lint", "lints"), 1);
+  });
+
+  it("returns 1 for single-character deletion", () => {
+    assert.equal(levenshtein("lints", "lint"), 1);
+  });
+
+  it("handles transpositions as 2 edits", () => {
+    assert.equal(levenshtein("ab", "ba"), 2);
+  });
+
+  it("computes distance for completely different strings", () => {
+    assert.equal(levenshtein("abc", "xyz"), 3);
+  });
+
+  it("computes distance for a realistic typo", () => {
+    // "reveiw" vs "review" - 2 edits (transpose e and i)
+    assert.equal(levenshtein("reveiw", "review"), 2);
+  });
+});
+
+describe("suggest", () => {
+  const candidates = ["review", "lint", "format", "testing", "planning"];
+
+  it("finds exact match with distance 0", () => {
+    assert.equal(suggest("review", candidates), "review");
+  });
+
+  it("finds close match within default max distance", () => {
+    assert.equal(suggest("reveiw", candidates), "review");
+  });
+
+  it("returns undefined when no match is close enough", () => {
+    assert.equal(suggest("zzzzzzzzz", candidates), undefined);
+  });
+
+  it("respects custom max distance", () => {
+    // "lnt" -> "lint" is distance 1, should match with maxDistance 1
+    assert.equal(suggest("lnt", candidates, 1), "lint");
+    // "reveiw" -> "review" is distance 2, should not match with maxDistance 1
+    assert.equal(suggest("reveiw", candidates, 1), undefined);
+  });
+
+  it("returns undefined for empty candidates", () => {
+    assert.equal(suggest("review", []), undefined);
+  });
+
+  it("picks the closest among multiple candidates", () => {
+    assert.equal(suggest("formatt", candidates), "format");
+  });
+});
+
+describe("didYouMean", () => {
+  const candidates = ["review", "lint", "format"];
+
+  it("returns suggestion suffix for close match", () => {
+    const result = didYouMean("reveiw", candidates);
+    assert.equal(result, '. Did you mean "review"?');
+  });
+
+  it("returns empty string when no match is close", () => {
+    const result = didYouMean("zzzzzzzzz", candidates);
+    assert.equal(result, "");
+  });
+
+  it("returns empty string for empty candidates", () => {
+    const result = didYouMean("anything", []);
+    assert.equal(result, "");
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -25,3 +25,71 @@ export class GraphError extends Error {
     this.name = "GraphError";
   }
 }
+
+/**
+ * Compute Levenshtein distance between two strings.
+ * Used to power "Did you mean..." suggestions in error messages.
+ */
+export function levenshtein(a: string, b: string): number {
+  const la = a.length;
+  const lb = b.length;
+
+  // Short-circuit: if either string is empty, the distance is the other's length
+  if (la === 0) return lb;
+  if (lb === 0) return la;
+
+  // Use a single-row DP approach for space efficiency
+  const prev = new Array<number>(lb + 1);
+  for (let j = 0; j <= lb; j++) prev[j] = j;
+
+  for (let i = 1; i <= la; i++) {
+    let prevDiag = prev[0];
+    prev[0] = i;
+    for (let j = 1; j <= lb; j++) {
+      const temp = prev[j];
+      if (a[i - 1] === b[j - 1]) {
+        prev[j] = prevDiag;
+      } else {
+        prev[j] = 1 + Math.min(prevDiag, prev[j - 1], prev[j]);
+      }
+      prevDiag = temp;
+    }
+  }
+
+  return prev[lb];
+}
+
+/**
+ * Find the closest match from a list of candidates.
+ * Returns the best match if its Levenshtein distance is at most `maxDistance`
+ * (default: 3), or undefined if no match is close enough.
+ */
+export function suggest(
+  input: string,
+  candidates: Iterable<string>,
+  maxDistance = 3,
+): string | undefined {
+  let best: string | undefined;
+  let bestDist = maxDistance + 1;
+
+  for (const candidate of candidates) {
+    const dist = levenshtein(input, candidate);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = candidate;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Format a "Did you mean ..." suffix. Returns an empty string if no suggestion.
+ */
+export function didYouMean(
+  input: string,
+  candidates: Iterable<string>,
+): string {
+  const match = suggest(input, candidates);
+  return match ? `. Did you mean "${match}"?` : "";
+}

--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -1197,3 +1197,99 @@ describe("type guards", () => {
     assert.equal(isConditionalThen("next"), false);
   });
 });
+
+describe("error message improvements", () => {
+  it("suggests close match for unknown skill in graph node", () => {
+    const graph = parseGraph([{ "reveiw": { writes: ["state.output"] } }]);
+    const skills = makeSkills("review", "lint");
+    assert.throws(
+      () => validateGraph(graph, skills, undefined),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /skill "reveiw" is not declared/);
+        assert.match(err.message, /Did you mean "review"\?/);
+        return true;
+      },
+    );
+  });
+
+  it("omits suggestion when no close skill match exists", () => {
+    const graph = parseGraph([{ "zzzzz": { writes: [] } }]);
+    const skills = makeSkills("review", "lint");
+    assert.throws(
+      () => validateGraph(graph, skills, undefined),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /skill "zzzzz" is not declared/);
+        assert.ok(!err.message.includes("Did you mean"), "should not suggest when no close match");
+        return true;
+      },
+    );
+  });
+
+  it("suggests close match for unknown transition target", () => {
+    const graph = parseGraph([
+      { review: { writes: [] }, then: "lnt" },
+      { lint: null },
+    ]);
+    const skills = makeSkills("review", "lint");
+    assert.throws(
+      () => validateGraph(graph, skills, undefined),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /transition target "lnt"/);
+        assert.match(err.message, /Did you mean "lint"\?/);
+        return true;
+      },
+    );
+  });
+
+  it("includes actionable guidance for missing state section", () => {
+    const graph = parseGraph([{ review: { reads: ["state.output"] } }]);
+    const skills = makeSkills("review");
+    assert.throws(
+      () => validateGraph(graph, skills, undefined),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /Add a top-level "state" section to your config/);
+        return true;
+      },
+    );
+  });
+
+  it("suggests close match for undeclared state field in reads", () => {
+    const state = makeState({
+      output: { kind: "primitive", value: "string" },
+      status: { kind: "primitive", value: "string" },
+    });
+    const graph = parseGraph([{ review: { reads: ["state.outpt"] } }]);
+    const skills = makeSkills("review");
+    assert.throws(
+      () => validateGraph(graph, skills, state),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /reads state field "state.outpt" which is not declared/);
+        assert.match(err.message, /Did you mean "output"\?/);
+        return true;
+      },
+    );
+  });
+
+  it("suggests close match for undeclared state field in writes", () => {
+    const state = makeState({
+      output: { kind: "primitive", value: "string" },
+      status: { kind: "primitive", value: "string" },
+    });
+    const graph = parseGraph([{ review: { writes: ["state.staus"] } }]);
+    const skills = makeSkills("review");
+    assert.throws(
+      () => validateGraph(graph, skills, state),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /writes state field "state.staus" which is not declared/);
+        assert.match(err.message, /Did you mean "status"\?/);
+        return true;
+      },
+    );
+  });
+});

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,5 +1,5 @@
 import { SkillEntry } from "./config.js";
-import { GraphError } from "./errors.js";
+import { didYouMean, GraphError } from "./errors.js";
 import { CustomType, StateSchema } from "./state.js";
 
 export interface WhenClause {
@@ -259,11 +259,13 @@ function validateNodes(
   const nodeLabels = new Set(collectNodeLabels(nodes));
 
   // Rule 1: Skill references
+  const skillNames = Object.keys(skills);
   for (const node of nodes) {
     if (!isMapNode(node)) {
       if (!(node.skill in skills)) {
+        const hint = didYouMean(node.skill, skillNames);
         throw new GraphError(
-          `Graph node "${node.skill}": skill "${node.skill}" is not declared`
+          `Graph node "${node.skill}": skill "${node.skill}" is not declared${hint}`
         );
       }
     }
@@ -276,14 +278,16 @@ function validateNodes(
     for (const target of targets) {
       if (target === "end") continue;
       if (!nodeLabels.has(target)) {
+        const hint = didYouMean(target, [...nodeLabels, "end"]);
         throw new GraphError(
-          `Graph node "${label}": transition target "${target}" is not a declared skill or "end"`
+          `Graph node "${label}": transition target "${target}" is not a declared skill or "end"${hint}`
         );
       }
     }
   }
 
   // Rule 3: State path validation
+  const stateFieldNames = state ? Object.keys(state.fields) : [];
   for (const node of nodes) {
     if (isMapNode(node)) continue;
     const label = node.skill;
@@ -292,13 +296,14 @@ function validateNodes(
       if (path.startsWith("state.")) {
         if (!state) {
           throw new GraphError(
-            `Graph node "${label}": reads state field "${path}" but no state is declared`
+            `Graph node "${label}": reads state field "${path}" but no state is declared. Add a top-level "state" section to your config`
           );
         }
         const fieldName = path.slice("state.".length);
         if (!(fieldName in state.fields)) {
+          const hint = didYouMean(fieldName, stateFieldNames);
           throw new GraphError(
-            `Graph node "${label}": reads state field "${path}" which is not declared`
+            `Graph node "${label}": reads state field "${path}" which is not declared${hint}`
           );
         }
       } else if (mapCtx && path.startsWith(mapCtx.as + ".")) {
@@ -315,13 +320,14 @@ function validateNodes(
       if (path.startsWith("state.")) {
         if (!state) {
           throw new GraphError(
-            `Graph node "${label}": writes state field "${path}" but no state is declared`
+            `Graph node "${label}": writes state field "${path}" but no state is declared. Add a top-level "state" section to your config`
           );
         }
         const fieldName = path.slice("state.".length);
         if (!(fieldName in state.fields)) {
+          const hint = didYouMean(fieldName, stateFieldNames);
           throw new GraphError(
-            `Graph node "${label}": writes state field "${path}" which is not declared`
+            `Graph node "${label}": writes state field "${path}" which is not declared${hint}`
           );
         }
       } else if (mapCtx && path.startsWith(mapCtx.as + ".")) {

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -411,4 +411,68 @@ describe("parseState", () => {
       assert.deepEqual(schema.fields, {});
     });
   });
+
+  describe("did-you-mean suggestions", () => {
+    it("suggests close match for unknown custom type reference", () => {
+      const raw = {
+        FileInfo: { name: "string", size: "number" },
+        currentFile: { type: "FileInf" },
+      };
+      assert.throws(
+        () => parseState(raw, NO_SKILLS),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /unknown type "FileInf"/);
+          assert.match(err.message, /Did you mean "FileInfo"\?/);
+          return true;
+        }
+      );
+    });
+
+    it("suggests close match for unknown list element type", () => {
+      const raw = {
+        Issue: { title: "string", priority: "number" },
+        items: { type: "list<Issu>" },
+      };
+      assert.throws(
+        () => parseState(raw, NO_SKILLS),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /unknown type "Issu"/);
+          assert.match(err.message, /Did you mean "Issue"\?/);
+          return true;
+        }
+      );
+    });
+
+    it("suggests primitive type for close misspelling", () => {
+      const raw = {
+        count: { type: "nubmer" },
+      };
+      assert.throws(
+        () => parseState(raw, NO_SKILLS),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /unknown type "nubmer"/);
+          assert.match(err.message, /Did you mean "number"\?/);
+          return true;
+        }
+      );
+    });
+
+    it("omits suggestion when no close match exists", () => {
+      const raw = {
+        data: { type: "CompletelyWrong" },
+      };
+      assert.throws(
+        () => parseState(raw, NO_SKILLS),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /unknown type "CompletelyWrong"/);
+          assert.ok(!err.message.includes("Did you mean"), "should not suggest when no close match");
+          return true;
+        }
+      );
+    });
+  });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,4 @@
-import { ConfigError } from "./errors.js";
+import { ConfigError, didYouMean } from "./errors.js";
 
 export type PrimitiveType = "string" | "bool" | "number";
 
@@ -51,8 +51,9 @@ function parseTypeString(
       );
     }
     if (!definedTypes.has(element)) {
+      const hint = didYouMean(element, definedTypes);
       throw new ConfigError(
-        `State field "${fieldName}": unknown type "${element}"`
+        `State field "${fieldName}": unknown type "${element}"${hint}`
       );
     }
     return { kind: "list", element };
@@ -62,8 +63,10 @@ function parseTypeString(
     return { kind: "custom", name: raw };
   }
 
+  const allCandidates = [...definedTypes, ...PRIMITIVES];
+  const hint = didYouMean(raw, allCandidates);
   throw new ConfigError(
-    `State field "${fieldName}": unknown type "${raw}"`
+    `State field "${fieldName}": unknown type "${raw}"${hint}`
   );
 }
 


### PR DESCRIPTION
**[engineer]**

## Summary

- Add Levenshtein distance-based "Did you mean..." suggestions to error messages for typos in skill names, type names, state fields, and transition targets
- Include file path context in errors thrown during config loading (`readConfig`/`loadConfig`)
- Add actionable guidance to validation errors (e.g., "Add a 'compose' list of skill names" instead of just "must have a compose field")
- Implement `levenshtein`, `suggest`, and `didYouMean` utilities in `errors.ts` with no new dependencies

## "Did you mean..." coverage

| Error site | Example |
|---|---|
| Composed skill references unknown atomic | `composes unknown skill "reveiw". Did you mean "review"?` |
| Flow step references unknown skill | `skill "reveiw" is not declared. Did you mean "review"?` |
| Flow transition targets unknown node | `transition target "lnt" is not ... Did you mean "lint"?` |
| State field references unknown type | `unknown type "nubmer". Did you mean "number"?` |
| State list element unknown type | `unknown type "Issu". Did you mean "Issue"?` |
| Orchestrator references unknown skill | `unknown skill "startegy". Did you mean "strategy"?` |
| Graph reads/writes undeclared state field | `state field "state.outpt" ... Did you mean "output"?` |

## Test plan

- [x] 35 new tests across 6 suites (errors, config, state, graph)
- [x] All 363 tests pass (was 328)
- [x] TypeScript strict mode type check passes
- [x] No new dependencies added

Closes #212

---
Generated with [Claude Code](https://claude.com/claude-code)