### PR TITLE
Update stale test counts from 328/59 to 396/76

### DIFF
--- a/docs/awesome-claude-code-submission.md
+++ b/docs/awesome-claude-code-submission.md
@@ -70,7 +70,7 @@ Self-hosting: skillfold's own dev team pipeline is compiled by skillfold itself 
 
 CI integration: ships a reusable GitHub Action (`action.yml`) that verifies compiled output is up-to-date via `--check`, so stale agent files fail the build.
 
-Single dependency (`yaml`), 328 tests across 59 suites, Node 20+.
+Single dependency (`yaml`), 396 tests across 76 suites, Node 20+.
 
 ---
 
@@ -84,7 +84,7 @@ pre-runs that evaluation against skillfold and documents the results.
 
 | Dimension | What it checks | Assessment |
 |---|---|---|
-| Code quality | Structure, readability, correctness, consistency | Pass - TypeScript strict mode, ESM, consistent conventions, 328 tests |
+| Code quality | Structure, readability, correctness, consistency | Pass - TypeScript strict mode, ESM, consistent conventions, 396 tests |
 | Security / safety | Implicit execution, file/network access, credentials | Pass - Pure compiler, no hooks, no persistent state, no credential storage |
 | Documentation / transparency | Docs match implementation, side effects disclosed | Pass - README, getting-started guide, integration guide, JSON Schema |
 | Functionality / scope | Does what it claims, breadth of features | Pass - Compiles YAML to SKILL.md and Claude Code agents as advertised |
@@ -150,7 +150,7 @@ and the documentation accurately describes what the tool does.
   stored or logged.
 - **Single dependency** - The only runtime dependency is `yaml` (YAML parser).
   No transitive dependency tree to audit.
-- **328 tests** across 59 suites, run with `node:test` (zero test framework
+- **396 tests** across 76 suites, run with `node:test` (zero test framework
   dependencies).
 - **MIT license**, clearly stated in LICENSE and package.json.
 - **CI on Node 20 + 22** via GitHub Actions, with `--check` flag for verifying

--- a/skills/skillfold-context/SKILL.md
+++ b/skills/skillfold-context/SKILL.md
@@ -51,7 +51,7 @@ The codebase is TypeScript (strict, ESM modules). Key modules:
 
 ## What's Implemented
 
-All compiler features are working: skill composition with atomic/composed sub-sections, state schema, flow validation, map subgraph validation, when-clause parsing, orchestrator generation, spec-compliant output, URL-based skill references (with private repo auth via GITHUB_TOKEN), pipeline imports, graph visualization with full composition lineage, `skillfold init`, `skillfold adopt`, `skillfold validate`, `skillfold list`, and `--check` for CI integration. Published on npm as `skillfold`. 328 tests, CI on GitHub Actions. The project self-hosts its own dev team via `skillfold.yaml`.
+All compiler features are working: skill composition with atomic/composed sub-sections, state schema, flow validation, map subgraph validation, when-clause parsing, orchestrator generation, spec-compliant output, URL-based skill references (with private repo auth via GITHUB_TOKEN), pipeline imports, graph visualization with full composition lineage, `skillfold init`, `skillfold adopt`, `skillfold validate`, `skillfold list`, and `--check` for CI integration. Published on npm as `skillfold`. 396 tests across 76 suites, CI on GitHub Actions. The project self-hosts its own dev team via `skillfold.yaml`.
 
 ## What's Next
 


### PR DESCRIPTION
**[engineer]**

## Summary

- Updated all references to old test counts (328 tests, 59 suites) to current counts (396 tests, 76 suites)
- Changes span 2 files with 4 total occurrences updated:
  - `docs/awesome-claude-code-submission.md` (3 occurrences)
  - `skills/skillfold-context/SKILL.md` (1 occurrence)
- Verified no other files outside `node_modules` reference the old counts

## Test plan

- [ ] Grep the repo for "328 tests", "328/59", and "59 suites" to confirm no stale references remain
- [ ] Verify the new counts (396/76) match `npm test` output

Closes #222