### PR TITLE
Mark internal skills for skills.sh library discovery

### DIFF
--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: design
 description: Designs the visual structure and presentation of text-based content for clarity and impact.
+metadata:
+  internal: true
 ---
 
 # Design

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: github
 description: Work with GitHub for branches, PRs, code review, issues, projects, and discussions.
+metadata:
+  internal: true
 ---
 
 # GitHub

--- a/skills/moltbook/SKILL.md
+++ b/skills/moltbook/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: moltbook
 description: Post, comment, upvote, and engage with other agents on Moltbook.
+metadata:
+  internal: true
 ---
 
 # Moltbook


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `metadata.internal: true` frontmatter to 3 project-specific skills (`design`, `github`, `moltbook`) so the skills.sh CLI skips them during discovery
- This allows the recursive fallback in `vercel-labs/skills` to find the 11 reusable library skills in `library/skills/` instead

## How it works

The `skills` CLI (`vercel-labs/skills`) discovers skills by:
1. Checking priority directories (including `skills/`) for SKILL.md files with `name` and `description` frontmatter
2. If any skills are found in the priority pass, it stops - no recursive search
3. If zero skills are found, it falls back to a recursive search (up to 5 levels deep)

Previously, `design`, `github`, and `moltbook` in `skills/` had frontmatter, so the CLI found those 3 and stopped. The 11 library skills in `library/skills/` were never reached.

The `skills` CLI supports a `metadata.internal: true` flag that causes `parseSkillMd` to return `null`, effectively hiding the skill. With all 3 internal skills marked, the priority pass finds zero results, triggering the recursive fallback which discovers all 11 library skills.

## Test plan

- [x] `npx tsx src/cli.ts` compiles with no changes to output (7 agents, 11 skills)
- [x] `npx tsx src/cli.ts --check` confirms output is up-to-date
- [x] `npm test` passes all 396 tests
- [x] Compiled output contains no metadata leakage (frontmatter is stripped by `stripFrontmatter`)

Closes #226

Generated with [Claude Code](https://claude.com/claude-code)