### PR TITLE
Mark all project-internal skills as internal for skills.sh

### DIFF
--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: architecture
+description: Design simple, maintainable systems without over-engineering.
+metadata:
+  internal: true
+---
+
 # Architecture
 
 You are a software architect. Your role is to design systems that are simple, maintainable, and solve the problem at hand without over-engineering.

--- a/skills/code-generation/SKILL.md
+++ b/skills/code-generation/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: code-generation
+description: Write clean, correct, production-quality TypeScript code.
+metadata:
+  internal: true
+---
+
 # Code Generation
 
 You write clean, correct, production-quality TypeScript code.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: code-review
+description: Review code for correctness, clarity, and maintainability.
+metadata:
+  internal: true
+---
+
 # Code Review
 
 You review code for correctness, clarity, and maintainability.

--- a/skills/product-strategy/SKILL.md
+++ b/skills/product-strategy/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: product-strategy
+description: Think about what a product needs to succeed beyond its technical implementation.
+metadata:
+  internal: true
+---
+
 # Product Strategy
 
 You think about what a product needs to succeed beyond its technical implementation. Your focus is adoption, positioning, and making the right thing easy to find and use.

--- a/skills/skillfold-context/SKILL.md
+++ b/skills/skillfold-context/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: skillfold-context
+description: Context about the Skillfold project, its architecture, and design principles.
+metadata:
+  internal: true
+---
+
 # Skillfold Project Context
 
 You are working on Skillfold, a configuration language and compiler for building multi-agent AI pipelines. The vision is a widely adopted, agent-first tool where agents author the config, agents consume the output, and humans provide direction.

--- a/skills/task-decomposition/SKILL.md
+++ b/skills/task-decomposition/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: task-decomposition
+description: Break down complex work into well-scoped, actionable tasks.
+metadata:
+  internal: true
+---
+
 # Task Decomposition
 
 You break down complex work into well-scoped, actionable tasks.

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: testing
+description: Write and reason about tests that verify code correctness.
+metadata:
+  internal: true
+---
+
 # Testing
 
 You write and reason about tests that verify code correctness.

--- a/test/fixtures/imports/main/skills/local/SKILL.md
+++ b/test/fixtures/imports/main/skills/local/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: local
 description: A local skill.
+metadata:
+  internal: true
 ---
 # Local Skill
 Defined locally.

--- a/test/fixtures/imports/override/skills/common/SKILL.md
+++ b/test/fixtures/imports/override/skills/common/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: common
 description: Overridden common skill.
+metadata:
+  internal: true
 ---
 # Overridden Common Skill
 This replaces the shared version.

--- a/test/fixtures/imports/shared/skills/common/SKILL.md
+++ b/test/fixtures/imports/shared/skills/common/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: common
 description: A shared skill.
+metadata:
+  internal: true
 ---
 # Common Skill
 Shared across pipelines.


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `name`, `description`, and `metadata.internal: true` YAML frontmatter to the 7 project skills that previously had no frontmatter (architecture, code-generation, code-review, testing, task-decomposition, product-strategy, skillfold-context)
- Add `metadata.internal: true` to 3 test fixture skills to prevent them from appearing in skills.sh results
- The previous fix (#237) only marked the 3 skills that already had frontmatter. The remaining 7 project skills were still discoverable by the skills CLI via recursive search.

With all 10 project skills marked `internal`, the skills CLI's priority search returns zero results, triggering the recursive fallback that discovers the 11 library skills in `library/skills/`. The `metadata.internal: true` flag tells the skills CLI to skip these skills during discovery.

The skillfold compiler strips frontmatter before composition, so compiled output is unchanged. All 396 tests pass.

Closes #226

## Test plan

- [x] `npx tsx src/cli.ts` compiles with identical output (7 agents, 11 skills, ~883 lines)
- [x] `npm test` passes all 396 tests across 76 suites
- [x] All 10 project skills in `skills/` have `metadata.internal: true`
- [x] All 11 library skills in `library/skills/` have no `internal` flag
- [x] Test fixtures marked internal to avoid polluting discovery results

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>