### PR TITLE
Prepare submission drafts for awesome-claude-code and marketplace

### DIFF
--- a/docs/awesome-claude-code-submission.md
+++ b/docs/awesome-claude-code-submission.md
@@ -44,7 +44,7 @@ Two prior violations pushed the earliest submission date back:
 
 **Description:**
 
-Configuration language and compiler for multi-agent AI pipelines. The only compile-time tool in the Orchestrators category - every other entry is a runtime coordinator. Compiles YAML skill definitions into standard SKILL.md files and Claude Code agent layouts at build time, complementing runtime tools like Agent Teams (skillfold owns the config, Agent Teams owns the execution). No runtime, no SDK, no daemon. Ships with a shared skills library, a slash command plugin, and an adopt command that converts existing Claude Code agents into managed pipelines.
+Configuration language and compiler for multi-agent AI pipelines. Compiles YAML config into standard SKILL.md files and Claude Code agent layouts at build time, with validation of skill references, state types, and write conflicts. Ships with 11 reusable library skills, a Claude Code plugin, and example pipeline templates.
 
 **Validate Claims:**
 

--- a/docs/submissions/marketplace.md
+++ b/docs/submissions/marketplace.md
@@ -1,0 +1,138 @@
+# Anthropic Plugin Marketplace Submission
+
+## Status: Ready to publish as self-hosted marketplace
+
+There is no centralized Anthropic plugin submission portal. Claude Code uses a
+decentralized plugin marketplace system where anyone can create and host their
+own marketplace. Users add marketplaces with `/plugin marketplace add`.
+
+## Our Plugin Structure
+
+The `plugin/` directory already contains a valid Claude Code plugin:
+
+```
+plugin/
+  .claude-plugin/
+    plugin.json          - Plugin manifest (name, version, description)
+  commands/
+    skillfold.md         - /skillfold slash command
+  skills/
+    code-review/SKILL.md
+    code-writing/SKILL.md
+    decision-making/SKILL.md
+    file-management/SKILL.md
+    github-workflow/SKILL.md
+    planning/SKILL.md
+    research/SKILL.md
+    skillfold-cli/SKILL.md
+    summarization/SKILL.md
+    testing/SKILL.md
+    writing/SKILL.md
+```
+
+The `plugin.json` manifest is valid and contains required fields (name,
+version, description, author, repository).
+
+## What's Needed to Be a Marketplace
+
+To make skillfold a discoverable marketplace (not just a standalone plugin),
+we need to add a `marketplace.json` file:
+
+### Option A: Add marketplace.json to the existing plugin directory
+
+Create `plugin/.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "skillfold",
+  "owner": {
+    "name": "byronxlg",
+    "email": null
+  },
+  "metadata": {
+    "description": "Multi-agent pipeline compiler with reusable skills library",
+    "version": "1.5.0"
+  },
+  "plugins": [
+    {
+      "name": "skillfold",
+      "source": ".",
+      "description": "Multi-agent pipeline compiler. Compose skills, wire team flows, generate orchestrators.",
+      "version": "1.5.0",
+      "author": {
+        "name": "byronxlg"
+      },
+      "homepage": "https://github.com/byronxlg/skillfold",
+      "repository": "https://github.com/byronxlg/skillfold",
+      "license": "MIT",
+      "keywords": ["pipeline", "compiler", "multi-agent", "skills", "orchestrator"],
+      "category": "productivity"
+    }
+  ]
+}
+```
+
+### Option B: Create a separate marketplace repository
+
+For a more scalable approach, create a dedicated marketplace repo
+(e.g., `byronxlg/claude-plugins`) that references the skillfold plugin:
+
+```json
+{
+  "name": "byronxlg-plugins",
+  "owner": {
+    "name": "byronxlg"
+  },
+  "plugins": [
+    {
+      "name": "skillfold",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/byronxlg/skillfold.git",
+        "path": "plugin"
+      },
+      "description": "Multi-agent pipeline compiler with 11 reusable skills and a /skillfold command.",
+      "license": "MIT",
+      "keywords": ["pipeline", "compiler", "multi-agent", "skills"]
+    }
+  ]
+}
+```
+
+## Installation Commands (for users)
+
+Once the marketplace is set up, users install with:
+
+```
+/plugin marketplace add byronxlg/skillfold
+/plugin install skillfold@skillfold
+```
+
+Or for Option B:
+
+```
+/plugin marketplace add byronxlg/claude-plugins
+/plugin install skillfold@byronxlg-plugins
+```
+
+## Version Alignment
+
+The `plugin.json` currently declares version `1.3.0` while the npm package is
+at `1.5.0`. This should be updated to match before publishing the marketplace.
+
+## Compatibility with skills.sh
+
+The `skills` CLI (from Vercel) also discovers plugins via
+`.claude-plugin/marketplace.json`. Adding the marketplace file to our plugin
+directory would make the skills installable via both:
+
+- `npx skills add byronxlg/skillfold` (Agent Skills standard)
+- `/plugin marketplace add byronxlg/skillfold` (Claude Code marketplace)
+
+## Next Steps
+
+1. Update `plugin/.claude-plugin/plugin.json` version to match npm package
+2. Add `plugin/.claude-plugin/marketplace.json`
+3. Test with `/plugin marketplace add ./plugin` locally
+4. Validate with `claude plugin validate plugin/`
+5. Document marketplace installation in the README

--- a/docs/submissions/skills-sh.md
+++ b/docs/submissions/skills-sh.md
@@ -1,0 +1,73 @@
+# skills.sh Listing Status
+
+## Current Status: Discoverable but not listed on leaderboard
+
+### Discovery Works
+
+Running `npx skills@latest add byronxlg/skillfold --list` finds all 11 library
+skills:
+
+- code-review
+- code-writing
+- decision-making
+- file-management
+- github-workflow
+- planning
+- research
+- skillfold-cli
+- summarization
+- testing
+- writing
+
+The project-internal skills (in `skills/`) are correctly hidden because they
+have `metadata.internal: true` in their SKILL.md frontmatter.
+
+### Why We're Not on the Leaderboard
+
+The skills.sh leaderboard at https://skills.sh ranks skills by installation
+count, tracked via anonymous telemetry from the `skills` CLI. Our skills have
+zero installations because:
+
+1. The project is new (first commit March 19, 2026)
+2. Nobody has run `npx skills add byronxlg/skillfold` yet
+
+There is no submission process for skills.sh. Listing is automatic once skills
+accumulate enough installations to appear on the leaderboard (which currently
+shows 89,460+ skills, so the bar for appearing at all may be just one install).
+
+### How the CLI Discovers Our Skills
+
+The Vercel `skills` CLI (npm package `skills`, currently v1.4.5) clones the
+repo and searches standard directories for SKILL.md files. It finds our skills
+via these discovery paths:
+
+- `skills/` - found, but all 10 skills here have `metadata.internal: true`
+- `library/skills/` - not a standard path, but found via recursive fallback
+- `plugin/skills/` - found via the `.claude-plugin/plugin.json` manifest
+- `.claude/skills/` - standard Claude Code path, also searched
+
+The recursive search fallback ensures all our public skills are discovered even
+though `library/skills/` is not a standard discovery directory.
+
+### What Would Help
+
+1. **Installations**: Anyone running `npx skills add byronxlg/skillfold` would
+   register telemetry and contribute to leaderboard presence. Mentioning this
+   install command in the README and docs would help.
+
+2. **Marketplace JSON**: Adding `.claude-plugin/marketplace.json` to the plugin
+   directory would give the CLI an explicit skill manifest to read, rather than
+   relying on directory scanning. This also enables compatibility with the
+   Claude Code plugin marketplace system.
+
+3. **README badge/install command**: Prominently showing the install command
+   in the README would drive organic installations:
+   ```
+   npx skills add byronxlg/skillfold
+   ```
+
+### No Action Required for Listing
+
+There is nothing to "submit" to skills.sh. The skills are already discoverable.
+Leaderboard presence will come naturally as users install them. The main
+leverage is making the install command visible in documentation and marketing.


### PR DESCRIPTION
**[marketer]**

Prepares submission content for #249 and #250, plus documents skills.sh listing status for #226.

## Summary

- Tightens the awesome-claude-code submission description to 3 sentences (was a long promotional paragraph)
- Adds `docs/submissions/marketplace.md` documenting the Claude Code plugin marketplace process and what we need to do
- Adds `docs/submissions/skills-sh.md` documenting why we're not on the skills.sh leaderboard and what to do about it

## Key Findings

**awesome-claude-code (#249)**
- Earliest submission date is **April 3, 2026** (14-day cooldown from prior PR violations on March 20)
- Must be submitted via web UI issue form by a human - the `gh` CLI is explicitly banned
- Draft is in `docs/awesome-claude-code-submission.md` with all form fields pre-filled

**Plugin marketplace (#250)**
- There is no centralized Anthropic marketplace submission portal
- Claude Code uses a decentralized system where anyone hosts their own `marketplace.json`
- Our `plugin/` directory is a valid plugin but needs a `marketplace.json` to be a discoverable marketplace
- The `plugin.json` version (1.3.0) is behind the npm package version (1.5.0)

**skills.sh (#226)**
- Our 11 library skills ARE discoverable via `npx skills add byronxlg/skillfold`
- Internal skills are correctly hidden (metadata.internal: true)
- We're not on the leaderboard because nobody has installed yet - there is no submission process, it's telemetry-driven
