### PR TITLE
Fix skills.sh library skill discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "plugins": [
+    {
+      "source": "./library",
+      "name": "skillfold-library",
+      "skills": [
+        "./skills/code-review",
+        "./skills/code-writing",
+        "./skills/decision-making",
+        "./skills/file-management",
+        "./skills/github-workflow",
+        "./skills/planning",
+        "./skills/research",
+        "./skills/skillfold-cli",
+        "./skills/summarization",
+        "./skills/testing",
+        "./skills/writing"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `.claude-plugin/marketplace.json` that registers `./library` as a plugin source, making the skills CLI discover all 11 library skills through its priority search paths
- Library skills are now consistently found by `npx skills install byronxlg/skillfold -l` and the skills.sh indexer

## Root Cause

The skills CLI (vercel-labs/skills) searches a fixed list of priority directories (`skills/`, `.claude/skills/`, `.github/skills/`, etc.) but not `library/skills/`. Since all 10 project skills in `skills/` have `internal: true` frontmatter, the priority search yields zero public skills. The recursive fallback search can find `library/skills/` but only triggers when zero skills are found in priority paths - behavior that is version-dependent and unreliable.

The fix uses the skills CLI's plugin manifest system: a `.claude-plugin/marketplace.json` file at the repo root declares `./library` as a plugin source. The CLI reads this manifest and adds `library/skills/` to its priority search paths, making all 11 library skills discoverable without relying on the recursive fallback.

## Test plan

- [x] `npx skills@latest install /path/to/skillfold -l` shows all 11 library skills
- [x] Internal skills (with `internal: true`) are excluded from the listing
- [x] All 404 tests pass (`npm test`)
- [x] Compiled output unchanged (`npx tsx src/cli.ts --check`)
- [ ] After merge, `npx skills install byronxlg/skillfold -l` discovers 11 skills from remote

Closes #255