### PR TITLE
feat: add plugin marketplace catalog for Claude Code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,21 +1,22 @@
 {
+  "name": "skillfold",
+  "owner": {
+    "name": "byronxlg"
+  },
+  "metadata": {
+    "description": "Compiler for multi-agent AI pipelines. Ships 11 reusable skills and a /skillfold slash command."
+  },
   "plugins": [
     {
-      "source": "./library",
-      "name": "skillfold-library",
-      "skills": [
-        "./skills/code-review",
-        "./skills/code-writing",
-        "./skills/decision-making",
-        "./skills/file-management",
-        "./skills/github-workflow",
-        "./skills/planning",
-        "./skills/research",
-        "./skills/skillfold-cli",
-        "./skills/summarization",
-        "./skills/testing",
-        "./skills/writing"
-      ]
+      "name": "skillfold",
+      "source": {
+        "source": "npm",
+        "package": "skillfold"
+      },
+      "description": "11 reusable skills for AI agents (planning, code-writing, testing, etc.) plus a /skillfold compiler command",
+      "version": "1.5.0",
+      "license": "MIT",
+      "keywords": ["pipeline", "skills", "agents", "compiler"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -485,6 +485,13 @@ npx skillfold               # or run directly
 
 Requires Node.js 20+. Single dependency: `yaml`.
 
+**Claude Code plugin marketplace:** Install the skills library and `/skillfold` command directly in Claude Code:
+
+```
+/plugin marketplace add byronxlg/skillfold
+/plugin install skillfold@skillfold
+```
+
 ### CLI
 
 ```

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -56,6 +56,17 @@ This produces a `plugin/` directory with `.claude-plugin/plugin.json`, agents, s
 
 Skillfold also ships a built-in plugin at `node_modules/skillfold/plugin/` with 11 generic skills and a `/skillfold` slash command.
 
+### Option 4: Marketplace installation
+
+Install the skillfold plugin directly from the Claude Code plugin marketplace:
+
+```
+/plugin marketplace add byronxlg/skillfold
+/plugin install skillfold@skillfold
+```
+
+This installs the same 11 skills and `/skillfold` slash command from the npm package. No local config or compilation needed.
+
 Skills and agents are auto-discovered at session start. No additional configuration needed.
 
 ## Cursor


### PR DESCRIPTION
## Summary

- Replace the local plugin manifest in `.claude-plugin/marketplace.json` with a marketplace catalog following the Claude Code marketplace schema
- Marketplace lists skillfold as an npm-sourced plugin (v1.5.0) so users can install via `/plugin marketplace add byronxlg/skillfold`
- Document marketplace installation in `docs/integrations.md` (Option 4) and `README.md` (Install section)

Closes #251

## Test plan

- [x] All 414 tests pass (no test changes needed - marketplace.json is a static config file)
- [ ] Verify marketplace schema is valid with `claude plugin validate .`
- [ ] Test installation flow: `/plugin marketplace add byronxlg/skillfold` then `/plugin install skillfold@skillfold`

Generated with [Claude Code](https://claude.com/claude-code)