### PR TITLE
feat: add config-level frontmatter overrides for composed skills

### DIFF
--- a/skillfold.schema.json
+++ b/skillfold.schema.json
@@ -74,8 +74,55 @@
               },
               "frontmatter": {
                 "type": "object",
-                "description": "Extra YAML frontmatter fields emitted in --target claude-code output. Passthrough key-value pairs such as tools, permissionMode, isolation, maxTurns, etc.",
+                "description": "Extra YAML frontmatter fields emitted in --target claude-code output. Passthrough key-value pairs. Prefer the named fields (tools, permissionMode, etc.) for validated overrides.",
                 "additionalProperties": true
+              },
+              "tools": {
+                "type": "array",
+                "description": "Claude Code tools available to this agent (e.g., Read, Edit, Write, Bash, Grep, Glob).",
+                "items": { "type": "string" }
+              },
+              "disallowedTools": {
+                "type": "array",
+                "description": "Claude Code tools explicitly denied to this agent.",
+                "items": { "type": "string" }
+              },
+              "permissionMode": {
+                "type": "string",
+                "description": "Claude Code permission mode for this agent.",
+                "enum": ["default", "acceptEdits", "bypassPermissions", "plan"]
+              },
+              "model": {
+                "type": "string",
+                "description": "Model override for this agent (e.g., sonnet, opus, haiku). Replaces the default 'inherit'."
+              },
+              "memory": {
+                "type": "boolean",
+                "description": "Whether this agent has memory enabled."
+              },
+              "hooks": {
+                "type": "object",
+                "description": "Claude Code lifecycle hooks for this agent.",
+                "additionalProperties": true
+              },
+              "isolation": {
+                "type": "string",
+                "description": "Isolation mode for this agent.",
+                "enum": ["worktree", "none"]
+              },
+              "effort": {
+                "type": "string",
+                "description": "Reasoning effort level for this agent.",
+                "enum": ["low", "medium", "high"]
+              },
+              "maxTurns": {
+                "type": "integer",
+                "description": "Maximum number of turns for this agent.",
+                "minimum": 1
+              },
+              "background": {
+                "type": "boolean",
+                "description": "Whether this agent runs in the background."
               }
             }
           }

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -443,6 +443,176 @@ describe("generateAgents with claude-code target", () => {
   });
 });
 
+describe("generateAgents with agentConfig overrides", () => {
+  it("emits named agentConfig fields in claude-code target", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+          agentConfig: {
+            tools: ["Read", "Edit", "Write", "Bash"],
+            permissionMode: "acceptEdits",
+            isolation: "worktree",
+            effort: "high",
+          },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("engineer", "Write code.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "claude-code");
+    const engineer = results.find((r) => r.name === "engineer");
+    assert.ok(engineer);
+
+    assert.ok(engineer.content.includes("permissionMode: acceptEdits"));
+    assert.ok(engineer.content.includes("isolation: worktree"));
+    assert.ok(engineer.content.includes("effort: high"));
+    assert.ok(engineer.content.includes("tools:"));
+    assert.ok(engineer.content.includes("- Read"));
+    assert.ok(engineer.content.includes("- Edit"));
+  });
+
+  it("agentConfig fields are ignored in skill target", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+          agentConfig: {
+            tools: ["Read", "Edit"],
+            permissionMode: "acceptEdits",
+            isolation: "worktree",
+          },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("engineer", "Write code.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "skill");
+    const engineer = results.find((r) => r.name === "engineer");
+    assert.ok(engineer);
+
+    // Named fields should not appear in skill target output
+    assert.ok(!engineer.content.includes("permissionMode:"));
+    assert.ok(!engineer.content.includes("isolation:"));
+    assert.ok(!engineer.content.includes("tools:"));
+  });
+
+  it("agentConfig model overrides default inherit", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        planner: {
+          compose: ["planning"],
+          description: "Plans.",
+          agentConfig: { model: "sonnet" },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("planner", "Plan.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "claude-code");
+    const planner = results.find((r) => r.name === "planner");
+    assert.ok(planner);
+
+    assert.ok(planner.content.includes("model: sonnet"));
+    assert.ok(!planner.content.includes("model: inherit"));
+  });
+
+  it("agentConfig tools on orchestrator override auto-generated tools", () => {
+    const config = makeConfig({
+      skills: {
+        ...makeConfig().skills,
+        orchestrator: {
+          compose: ["planning"],
+          description: "Coordinates.",
+          agentConfig: {
+            tools: ["Agent", "Read", "Bash"],
+          },
+        },
+      },
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("orchestrator", "Orchestrate.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "claude-code");
+    const orch = results.find((r) => r.name === "orchestrator");
+    assert.ok(orch);
+
+    // User-specified tools should be used, not the auto-generated ones
+    assert.ok(orch.content.includes("- Agent"));
+    assert.ok(orch.content.includes("- Read"));
+    assert.ok(orch.content.includes("- Bash"));
+    // Should NOT have auto-generated Agent(worker, ...) format
+    assert.ok(!orch.content.includes("Agent(planner"));
+  });
+
+  it("agentConfig boolean and number fields emit correctly", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        planner: {
+          compose: ["planning"],
+          description: "Plans.",
+          agentConfig: {
+            memory: true,
+            maxTurns: 50,
+            background: false,
+          },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("planner", "Plan.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "claude-code");
+    const planner = results.find((r) => r.name === "planner");
+    assert.ok(planner);
+
+    assert.ok(planner.content.includes("memory: true"));
+    assert.ok(planner.content.includes("maxTurns: 50"));
+    assert.ok(planner.content.includes("background: false"));
+  });
+
+  it("agentConfig overrides legacy frontmatter when both present", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        planner: {
+          compose: ["planning"],
+          description: "Plans.",
+          frontmatter: { permissionMode: "default", customField: "value" },
+          agentConfig: { permissionMode: "plan" },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("planner", "Plan.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "claude-code");
+    const planner = results.find((r) => r.name === "planner");
+    assert.ok(planner);
+
+    // agentConfig should win over legacy frontmatter for the same key
+    assert.ok(planner.content.includes("permissionMode: plan"));
+    // Legacy custom field should still be present
+    assert.ok(planner.content.includes("customField: value"));
+  });
+});
+
 describe("generateRunCommand with orchestrator", () => {
   it("delegates to orchestrator agent when one is configured", () => {
     const config = makeConfig();

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -128,16 +128,23 @@ function serializeExtraFrontmatter(extra: Record<string, unknown>): string[] {
 
 /** Format agent markdown with frontmatter. */
 function formatAgentMarkdown(agent: AgentDefinition): string {
+  // Use model from extra frontmatter if provided, otherwise default to inherit
+  const model = agent.frontmatter?.model ?? "inherit";
+
   const frontmatter: string[] = [
     "---",
     `name: ${agent.name}`,
     `description: ${agent.description}`,
-    "model: inherit",
+    `model: ${model}`,
     `color: ${agent.color}`,
   ];
 
   if (agent.frontmatter) {
-    frontmatter.push(...serializeExtraFrontmatter(agent.frontmatter));
+    // Filter out model since it's already emitted as a core field
+    const { model: _model, ...rest } = agent.frontmatter;
+    if (Object.keys(rest).length > 0) {
+      frontmatter.push(...serializeExtraFrontmatter(rest));
+    }
   }
 
   frontmatter.push("---");
@@ -229,19 +236,31 @@ export function generateAgents(
     const isOrchestrator = name === orchestratorName;
     const color = assignColor(name, writes, isOrchestrator, config);
 
-    // Build frontmatter, starting with any user-specified fields
+    // Build frontmatter, starting with any legacy passthrough fields
     const frontmatter: Record<string, unknown> = skill.frontmatter
       ? { ...skill.frontmatter }
       : {};
 
+    // Layer named agentConfig fields on top (overrides legacy frontmatter)
+    if (isClaudeCode && skill.agentConfig) {
+      for (const [key, val] of Object.entries(skill.agentConfig)) {
+        if (val !== undefined) {
+          frontmatter[key] = val;
+        }
+      }
+    }
+
     // In claude-code mode, orchestrator gets Agent tool in frontmatter and
     // the execution plan appended to its body
     if (isClaudeCode && isOrchestrator && config.team) {
-      const workerNames = collectWorkerNames(config);
-      const agentList = workerNames.length > 0
-        ? `Agent(${workerNames.join(", ")})`
-        : "Agent";
-      frontmatter.tools = [agentList, "Read", "Write", "Bash", "Grep", "Glob"];
+      // Only set tools if the user hasn't explicitly configured them
+      if (!frontmatter.tools) {
+        const workerNames = collectWorkerNames(config);
+        const agentList = workerNames.length > 0
+          ? `Agent(${workerNames.join(", ")})`
+          : "Agent";
+        frontmatter.tools = [agentList, "Read", "Write", "Bash", "Grep", "Glob"];
+      }
 
       // Append the execution plan with Agent tool language
       const orchestratorPlan = generateOrchestrator(config, true);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1231,6 +1231,352 @@ skills:
   });
 });
 
+describe("readConfig agent frontmatter overrides", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("parses named agent frontmatter fields on composed skills", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      tools:
+        - Read
+        - Edit
+        - Bash
+      permissionMode: acceptEdits
+      isolation: worktree
+      model: sonnet
+      effort: high
+      maxTurns: 30
+      memory: true
+      background: false
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["quality"];
+    assert.ok(isComposed(skill));
+    assert.ok(skill.agentConfig);
+    assert.deepEqual(skill.agentConfig.tools, ["Read", "Edit", "Bash"]);
+    assert.equal(skill.agentConfig.permissionMode, "acceptEdits");
+    assert.equal(skill.agentConfig.isolation, "worktree");
+    assert.equal(skill.agentConfig.model, "sonnet");
+    assert.equal(skill.agentConfig.effort, "high");
+    assert.equal(skill.agentConfig.maxTurns, 30);
+    assert.equal(skill.agentConfig.memory, true);
+    assert.equal(skill.agentConfig.background, false);
+  });
+
+  it("composed skill without agent config fields has undefined agentConfig", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["quality"];
+    assert.ok(isComposed(skill));
+    assert.equal(skill.agentConfig, undefined);
+  });
+
+  it("parses disallowedTools field", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      disallowedTools:
+        - Bash
+        - Write
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["quality"];
+    assert.ok(isComposed(skill));
+    assert.deepEqual(skill.agentConfig?.disallowedTools, ["Bash", "Write"]);
+  });
+
+  it("parses hooks field", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      hooks:
+        preToolCall:
+          command: "echo hook"
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["quality"];
+    assert.ok(isComposed(skill));
+    assert.deepEqual(skill.agentConfig?.hooks, { preToolCall: { command: "echo hook" } });
+  });
+
+  it("rejects invalid permissionMode value", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      permissionMode: invalid
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /permissionMode must be one of/);
+      return true;
+    });
+  });
+
+  it("rejects invalid isolation value", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      isolation: sandbox
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /isolation must be one of/);
+      return true;
+    });
+  });
+
+  it("rejects invalid effort value", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      effort: extreme
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /effort must be one of/);
+      return true;
+    });
+  });
+
+  it("rejects non-integer maxTurns", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      maxTurns: 3.5
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /maxTurns must be a positive integer/);
+      return true;
+    });
+  });
+
+  it("rejects zero maxTurns", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      maxTurns: 0
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /maxTurns must be a positive integer/);
+      return true;
+    });
+  });
+
+  it("rejects non-boolean memory", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      memory: "yes"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /memory must be a boolean/);
+      return true;
+    });
+  });
+
+  it("rejects non-boolean background", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      background: 1
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /background must be a boolean/);
+      return true;
+    });
+  });
+
+  it("rejects non-string model", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      model: 42
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /model must be a string/);
+      return true;
+    });
+  });
+
+  it("rejects non-array tools", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      tools: "Read"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /tools must be an array of strings/);
+      return true;
+    });
+  });
+
+  it("rejects non-object hooks", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      hooks: "not a map"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /hooks must be a YAML map/);
+      return true;
+    });
+  });
+
+  it("accepts all four permissionMode values", () => {
+    for (const mode of ["default", "acceptEdits", "bypassPermissions", "plan"]) {
+      tmpDir = makeTmpDir();
+      const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      permissionMode: ${mode}
+`);
+      const config = readConfig(configPath);
+      const skill = config.skills["quality"];
+      assert.ok(isComposed(skill));
+      assert.equal(skill.agentConfig?.permissionMode, mode);
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+});
+
 describe("type guards", () => {
   it("isAtomic returns true for AtomicSkill", () => {
     assert.equal(isAtomic({ path: "./skills/review" }), true);

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,10 +16,44 @@ export interface AtomicSkill {
   path: string;
 }
 
+/** Known Claude Code subagent frontmatter fields that can be set on composed skills. */
+export interface AgentFrontmatter {
+  tools?: string[];
+  disallowedTools?: string[];
+  permissionMode?: "default" | "acceptEdits" | "bypassPermissions" | "plan";
+  model?: string;
+  memory?: boolean;
+  hooks?: Record<string, unknown>;
+  isolation?: "worktree" | "none";
+  effort?: "low" | "medium" | "high";
+  maxTurns?: number;
+  background?: boolean;
+}
+
+export const VALID_PERMISSION_MODES = ["default", "acceptEdits", "bypassPermissions", "plan"] as const;
+export const VALID_ISOLATION_VALUES = ["worktree", "none"] as const;
+export const VALID_EFFORT_VALUES = ["low", "medium", "high"] as const;
+
+/** Keys that are recognized as AgentFrontmatter fields on composed skills. */
+export const AGENT_FRONTMATTER_KEYS = new Set<string>([
+  "tools",
+  "disallowedTools",
+  "permissionMode",
+  "model",
+  "memory",
+  "hooks",
+  "isolation",
+  "effort",
+  "maxTurns",
+  "background",
+]);
+
 export interface ComposedSkill {
   compose: string[];
   description: string;
+  /** @deprecated Use named agent frontmatter fields (tools, permissionMode, etc.) instead. */
   frontmatter?: Record<string, unknown>;
+  agentConfig?: AgentFrontmatter;
 }
 
 export type SkillEntry = AtomicSkill | ComposedSkill;
@@ -83,6 +117,110 @@ function normalizeAtomicSkills(
   return skills;
 }
 
+function validateStringArray(name: string, field: string, value: unknown): string[] {
+  if (!Array.isArray(value) || !value.every((v) => typeof v === "string")) {
+    throw new ConfigError(
+      `Skill "${name}": ${field} must be an array of strings`
+    );
+  }
+  return value;
+}
+
+function parseAgentFrontmatter(
+  name: string,
+  raw: Record<string, unknown>,
+): AgentFrontmatter | undefined {
+  const config: AgentFrontmatter = {};
+  let hasFields = false;
+
+  if ("tools" in raw) {
+    config.tools = validateStringArray(name, "tools", raw.tools);
+    hasFields = true;
+  }
+
+  if ("disallowedTools" in raw) {
+    config.disallowedTools = validateStringArray(name, "disallowedTools", raw.disallowedTools);
+    hasFields = true;
+  }
+
+  if ("permissionMode" in raw) {
+    const v = raw.permissionMode;
+    if (typeof v !== "string" || !(VALID_PERMISSION_MODES as readonly string[]).includes(v)) {
+      throw new ConfigError(
+        `Skill "${name}": permissionMode must be one of: ${VALID_PERMISSION_MODES.join(", ")}`
+      );
+    }
+    config.permissionMode = v as AgentFrontmatter["permissionMode"];
+    hasFields = true;
+  }
+
+  if ("model" in raw) {
+    if (typeof raw.model !== "string") {
+      throw new ConfigError(`Skill "${name}": model must be a string`);
+    }
+    config.model = raw.model;
+    hasFields = true;
+  }
+
+  if ("memory" in raw) {
+    if (typeof raw.memory !== "boolean") {
+      throw new ConfigError(`Skill "${name}": memory must be a boolean`);
+    }
+    config.memory = raw.memory;
+    hasFields = true;
+  }
+
+  if ("hooks" in raw) {
+    if (typeof raw.hooks !== "object" || raw.hooks === null || Array.isArray(raw.hooks)) {
+      throw new ConfigError(`Skill "${name}": hooks must be a YAML map`);
+    }
+    config.hooks = raw.hooks as Record<string, unknown>;
+    hasFields = true;
+  }
+
+  if ("isolation" in raw) {
+    const v = raw.isolation;
+    if (typeof v !== "string" || !(VALID_ISOLATION_VALUES as readonly string[]).includes(v)) {
+      throw new ConfigError(
+        `Skill "${name}": isolation must be one of: ${VALID_ISOLATION_VALUES.join(", ")}`
+      );
+    }
+    config.isolation = v as AgentFrontmatter["isolation"];
+    hasFields = true;
+  }
+
+  if ("effort" in raw) {
+    const v = raw.effort;
+    if (typeof v !== "string" || !(VALID_EFFORT_VALUES as readonly string[]).includes(v)) {
+      throw new ConfigError(
+        `Skill "${name}": effort must be one of: ${VALID_EFFORT_VALUES.join(", ")}`
+      );
+    }
+    config.effort = v as AgentFrontmatter["effort"];
+    hasFields = true;
+  }
+
+  if ("maxTurns" in raw) {
+    if (typeof raw.maxTurns !== "number" || !Number.isInteger(raw.maxTurns) || raw.maxTurns < 1) {
+      throw new ConfigError(
+        `Skill "${name}": maxTurns must be a positive integer`
+      );
+    }
+    config.maxTurns = raw.maxTurns;
+    hasFields = true;
+  }
+
+  if ("background" in raw) {
+    if (typeof raw.background !== "boolean") {
+      throw new ConfigError(`Skill "${name}": background must be a boolean`);
+    }
+    config.background = raw.background;
+    hasFields = true;
+  }
+
+  return hasFields ? config : undefined;
+}
+
 function normalizeComposedSkills(
   raw: Record<string, unknown>
 ): Record<string, ComposedSkill> {
@@ -120,6 +258,12 @@ function normalizeComposedSkills(
         );
       }
       entry.frontmatter = frontmatter as Record<string, unknown>;
+    }
+
+    // Parse named agent frontmatter fields
+    const agentConfig = parseAgentFrontmatter(name, value as Record<string, unknown>);
+    if (agentConfig) {
+      entry.agentConfig = agentConfig;
     }
 
     skills[name] = entry;


### PR DESCRIPTION
## Summary

- Add named agent frontmatter fields (`tools`, `disallowedTools`, `permissionMode`, `model`, `memory`, `hooks`, `isolation`, `effort`, `maxTurns`, `background`) directly on composed skill definitions in `skillfold.yaml`
- Validate each field during config parsing with type-appropriate checks and enum constraints (e.g., `permissionMode` must be one of `default`, `acceptEdits`, `bypassPermissions`, `plan`)
- Emit validated fields in `--target claude-code` output, overriding compiler-inferred defaults; fields are ignored in `--target skill` output
- Update JSON Schema with the new optional fields for IDE autocompletion

Closes #248

## Test plan

- [x] Config parsing tests: all 10 named fields are parsed correctly from YAML
- [x] Validation tests: invalid `permissionMode`, `isolation`, `effort`, non-integer `maxTurns`, non-boolean `memory`/`background`, non-string `model`, non-array `tools`, non-object `hooks` all rejected with clear errors
- [x] Agent output tests: named fields emitted in `claude-code` target, ignored in `skill` target
- [x] Model override test: `model` in agentConfig replaces default `model: inherit`
- [x] Orchestrator tools override test: user-specified `tools` on orchestrator prevents auto-generated Agent tool list
- [x] Legacy compatibility test: `agentConfig` overrides `frontmatter` when both present for the same key
- [x] Full test suite passes (435 tests, 0 failures)
- [x] Type check passes (`npx tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)