### PR TITLE
fix: restore skills.sh discovery manifest in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,23 @@
   },
   "plugins": [
     {
+      "source": "./library",
+      "name": "skillfold-library",
+      "skills": [
+        "./skills/code-review",
+        "./skills/code-writing",
+        "./skills/decision-making",
+        "./skills/file-management",
+        "./skills/github-workflow",
+        "./skills/planning",
+        "./skills/research",
+        "./skills/skillfold-cli",
+        "./skills/summarization",
+        "./skills/testing",
+        "./skills/writing"
+      ]
+    },
+    {
       "name": "skillfold",
       "source": {
         "source": "npm",


### PR DESCRIPTION
## Summary

- Restore the skills.sh discovery plugin entry that PR #266 overwrote when adding the Claude Code marketplace catalog
- Merge both schemas into a single `marketplace.json` with two entries in the `plugins` array:
  1. **skillfold-library** - skills.sh discovery manifest with individual skill paths (from PR #261)
  2. **skillfold** - Claude Code marketplace catalog with npm source metadata (from PR #266)
- Top-level marketplace fields (`name`, `owner`, `metadata`) are preserved for Claude Code

Fixes the review feedback on #266.

## Test plan

- [x] All 435 tests pass
- [x] JSON validates cleanly
- [ ] Verify `npx skills add byronxlg/skillfold` still discovers all 11 library skills
- [ ] Verify `/plugin marketplace add byronxlg/skillfold` still works for Claude Code

Generated with [Claude Code](https://claude.com/claude-code)