### PR TITLE
feat: state location resolution with resource namespace declarations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ BRIEF.md               - Full design brief
 
 Three top-level sections: `skills`, `state`, `team`.
 
-- **skills.atomic**: Path references to atomic skill directories
+- **skills.atomic**: Path references to atomic skill directories, with optional `resources` map for namespace declarations
 - **skills.composed**: Composition declarations combining atomic skills into agents
 - **state**: Typed state schema (top-level, importable independently)
 - **team.orchestrator**: Optional skill name to append generated plan to
@@ -82,7 +82,7 @@ Read BRIEF.md for full context. Key points:
 
 - **Skill composition**: Atomic skills define reusable fragments. Composed skills concatenate atomic skill bodies in declared order. Composition is recursive.
 - **Team flow**: Agents wired into typed execution graphs with conditional routing, loops, and parallel map. Parsed and validated.
-- **State schema**: Typed state schema with custom types, primitives, lists, and external locations. Reads/writes validated against team flow.
+- **State schema**: Typed state schema with custom types, primitives, lists, and external locations. Reads/writes validated against team flow. Location paths validated against skill resource declarations when available.
 - **Orchestrator generation**: Generated from the team flow definition. Produces structured execution plan with step numbering, state table, and conditional/map rendering.
 
 ## Shared Skills Library
@@ -156,7 +156,8 @@ Located in `library/examples/`:
 - `skillfold plugin` command for packaging pipelines as distributable Claude Code plugins
 - `skillfold adopt` command for adopting existing Claude Code agents into a pipeline
 - Async flow nodes for external agents (humans, CI, other teams) with `async: true` and policy options (block, skip, use-latest)
-- Test suite with 469 tests across 85 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, errors, and e2e modules
+- State location resolution: atomic skills declare `resources` namespaces with base URL templates, location paths validated against declared namespaces, orchestrator renders resolved URLs in state table
+- Test suite with 493 tests across 90 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, errors, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -227,7 +227,48 @@ The `owner` node is async - it does not invoke an agent. Instead, the orchestrat
 
 Async nodes participate in the flow graph like regular nodes - they have reads, writes, and transitions. But they are excluded from skill compilation (no SKILL.md is generated) and from the Agent tool list in the orchestrator.
 
-## 7. Start from a template
+## 7. Declare resource namespaces on skills
+
+When state fields have external locations (like GitHub issues or discussions), the location path references a namespace on the skill. You can declare these namespaces explicitly with `resources`, giving the compiler enough information to validate paths and render resolved URLs in the orchestrator output.
+
+```yaml
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        discussions: "https://github.com/{owner}/{repo}/discussions"
+        issues: "https://github.com/{owner}/{repo}/issues"
+        pull-requests: "https://github.com/{owner}/{repo}/pulls"
+
+state:
+  direction:
+    type: string
+    location:
+      skill: github
+      path: discussions/general
+
+  tasks:
+    type: list<Task>
+    location:
+      skill: github
+      path: issues
+```
+
+With resources declared, the compiler validates that each location path starts with a declared namespace (e.g. `discussions`, `issues`). Typos like `path: discussons/general` produce a clear error with a "Did you mean" suggestion.
+
+The orchestrator state table renders resolved URLs instead of abstract references:
+
+| Field | Type | Location |
+|-------|------|----------|
+| direction | string | https://github.com/{owner}/{repo}/discussions/general |
+| tasks | list\<Task\> | https://github.com/{owner}/{repo}/issues |
+
+Template variables like `{owner}` are preserved as-is - they are opaque strings that the orchestrator agent interprets at runtime.
+
+Skills without `resources` continue to work. The compiler emits a warning suggesting you add resource declarations for compile-time path validation, but the config remains valid.
+
+## 8. Start from a template
 
 If you prefer starting from a real-world pattern instead of the minimal starter:
 
@@ -245,7 +286,7 @@ Available templates:
 
 Templates use library skills via imports, so they work out of the box with no local skill directories needed.
 
-## 8. Deploy to your platform
+## 9. Deploy to your platform
 
 Compile directly to where your platform reads skills. See the [Integration Guide](integrations.md) for all platforms.
 
@@ -262,7 +303,7 @@ For Claude Code, `--target claude-code` generates agent markdown files alongside
 
 Skillfold also ships a built-in plugin with 11 generic skills. Install it by referencing `node_modules/skillfold/plugin/` from your Claude Code configuration.
 
-## 9. Next steps
+## 10. Next steps
 
 - Read the full config specification in [BRIEF.md](../BRIEF.md)
 - Explore the [shared library examples](../library/examples/) for real pipeline patterns

--- a/skillfold.schema.json
+++ b/skillfold.schema.json
@@ -44,6 +44,12 @@
                   "path": {
                     "type": "string",
                     "description": "Path to the skill directory."
+                  },
+                  "resources": {
+                    "type": "object",
+                    "description": "Resource namespaces this skill exposes, with base URL templates.",
+                    "additionalProperties": { "type": "string" },
+                    "propertyNames": { "pattern": "^[a-z0-9][a-z0-9-]*$" }
                   }
                 }
               }

--- a/skillfold.yaml
+++ b/skillfold.yaml
@@ -12,7 +12,12 @@ skills:
     security-best-practices: https://github.com/openai/skills/tree/main/skills/.curated/security-best-practices
 
     # Project-specific skills
-    github: ./skills/github
+    github:
+      path: ./skills/github
+      resources:
+        discussions: "https://github.com/byronxlg/skillfold/discussions"
+        issues: "https://github.com/byronxlg/skillfold/issues"
+        pull-requests: "https://github.com/byronxlg/skillfold/pulls"
     moltbook: ./skills/moltbook
     product-strategy: ./skills/product-strategy
     skillfold-context: ./skills/skillfold-context

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1594,3 +1594,137 @@ describe("type guards", () => {
     assert.equal(isComposed({ path: "./skills/review" }), false);
   });
 });
+
+describe("readConfig resource declarations (#276)", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("atomic skill with valid resources map parses correctly", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        discussions: "https://github.com/owner/repo/discussions"
+        issues: "https://github.com/owner/repo/issues"
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["github"];
+    assert.ok(isAtomic(skill));
+    assert.deepEqual(skill.resources, {
+      discussions: "https://github.com/owner/repo/discussions",
+      issues: "https://github.com/owner/repo/issues",
+    });
+  });
+
+  it("atomic skill with empty resources map has no resources", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources: {}
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["github"];
+    assert.ok(isAtomic(skill));
+    assert.equal(skill.resources, undefined);
+  });
+
+  it("string shorthand still works (no resources)", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github: ./skills/github
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["github"];
+    assert.ok(isAtomic(skill));
+    assert.equal(skill.resources, undefined);
+  });
+
+  it("rejects resources with uppercase key", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        Issues: "https://example.com"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /resource name "Issues" must be lowercase/);
+      return true;
+    });
+  });
+
+  it("rejects resources with non-string value", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        issues: 42
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /resource "issues" must be a non-empty string/);
+      return true;
+    });
+  });
+
+  it("rejects resources that is not an object", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources: "not-an-object"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /resources must be a YAML map/);
+      return true;
+    });
+  });
+
+  it("rejects resources that is an array", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        - issues
+        - pulls
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /resources must be a YAML map/);
+      return true;
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ import { parseState, StateSchema } from "./state.js";
 
 export interface AtomicSkill {
   path: string;
+  resources?: Record<string, string>;
 }
 
 /** Known Claude Code subagent frontmatter fields that can be set on composed skills. */
@@ -89,6 +90,35 @@ export function isComposed(skill: SkillEntry): skill is ComposedSkill {
   return "compose" in skill;
 }
 
+const RESOURCE_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+function validateResources(
+  skillName: string,
+  raw: unknown,
+): Record<string, string> | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new ConfigError(
+      `Skill "${skillName}": resources must be a YAML map`
+    );
+  }
+  const resources: Record<string, string> = {};
+  for (const [key, val] of Object.entries(raw as Record<string, unknown>)) {
+    if (!RESOURCE_NAME_RE.test(key)) {
+      throw new ConfigError(
+        `Skill "${skillName}": resource name "${key}" must be lowercase alphanumeric with hyphens`
+      );
+    }
+    if (typeof val !== "string" || val.length === 0) {
+      throw new ConfigError(
+        `Skill "${skillName}": resource "${key}" must be a non-empty string`
+      );
+    }
+    resources[key] = val;
+  }
+  return Object.keys(resources).length > 0 ? resources : undefined;
+}
+
 function normalizeAtomicSkills(
   raw: Record<string, unknown>
 ): Record<string, AtomicSkill> {
@@ -106,7 +136,15 @@ function normalizeAtomicSkills(
       if (typeof path !== "string") {
         throw new ConfigError(`Skill "${name}": path must be a string`);
       }
-      skills[name] = { path };
+      const skill: AtomicSkill = { path };
+      const resources = validateResources(
+        name,
+        (value as Record<string, unknown>).resources,
+      );
+      if (resources) {
+        skill.resources = resources;
+      }
+      skills[name] = skill;
     } else {
       throw new ConfigError(
         `Skill "${name}": must be a path string, or an object with "path"`
@@ -445,8 +483,11 @@ export function validateAndBuild(raw: RawConfig): Config {
   const config: Config = { name: raw.name, skills: raw.skills };
 
   if (raw.rawState !== undefined) {
-    const skillNames = new Set(Object.keys(raw.skills));
-    config.state = parseState(raw.rawState, skillNames);
+    const skillsForState: Record<string, { resources?: Record<string, string> }> = {};
+    for (const [name, skill] of Object.entries(raw.skills)) {
+      skillsForState[name] = isAtomic(skill) ? { resources: skill.resources } : {};
+    }
+    config.state = parseState(raw.rawState, skillsForState);
   }
 
   if (raw.rawTeam !== undefined) {
@@ -482,7 +523,11 @@ function rebaseSkillPaths(
     if (isAtomic(skill) && !skill.path.startsWith("https://")) {
       const abs = resolve(importDir, skill.path);
       const rebased = relative(targetDir, abs);
-      result[name] = { path: rebased };
+      const rebasedSkill: AtomicSkill = { path: rebased };
+      if (skill.resources) {
+        rebasedSkill.resources = skill.resources;
+      }
+      result[name] = rebasedSkill;
     } else {
       result[name] = skill;
     }

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -195,16 +195,17 @@ describe("e2e: dev-pipeline", () => {
 
     assert.ok(content.includes("## State"));
     assert.ok(content.includes("| Field | Type | Location |"));
+    // With resources declared, locations resolve to full URLs
     assert.ok(
-      content.includes("| goal | string | slack: dev-pipeline-channel |")
+      content.includes("| goal | string | https://slack.com/archives/C0123 |")
     );
     assert.ok(
       content.includes(
-        "| plan | string | slack: dev-pipeline-channel (reply) |"
+        "| plan | string | https://slack.com/archives/C0123 (reply) |"
       )
     );
     assert.ok(
-      content.includes("| tasks | list<Task> | jira: DEV/dev-board |")
+      content.includes("| tasks | list<Task> | https://jira.example.com/project/DEV/dev-board |")
     );
   });
 

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import type { Config } from "./config.js";
-import { generateOrchestrator } from "./orchestrator.js";
+import { formatLocation, generateOrchestrator } from "./orchestrator.js";
 
 describe("generateOrchestrator", () => {
   it("linear graph - 3 steps with correct numbering, reads/writes, transitions", () => {
@@ -735,5 +735,180 @@ describe("generateOrchestrator: async nodes", () => {
     assert.ok(!asyncSection.includes("Agent tool"));
     // But the step node should
     assert.ok(output.includes("Invoke **worker** using the Agent tool."));
+  });
+});
+
+describe("generateOrchestrator: resolved location URLs (#279)", () => {
+  it("renders resolved URL when skill has resources", () => {
+    const config: Config = {
+      name: "resolved-test",
+      skills: {
+        github: {
+          path: "./skills/github",
+          resources: {
+            discussions: "https://github.com/{owner}/{repo}/discussions",
+            issues: "https://github.com/{owner}/{repo}/issues",
+            "pull-requests": "https://github.com/{owner}/{repo}/pulls",
+          },
+        },
+      },
+      state: {
+        types: {},
+        fields: {
+          direction: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "github", path: "discussions/general" },
+          },
+          tasks: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "github", path: "issues" },
+          },
+          review: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "github", path: "pull-requests", kind: "review" },
+          },
+        },
+      },
+      team: {
+        flow: {
+          nodes: [
+            { skill: "github", reads: [], writes: [] },
+          ],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+
+    assert.ok(
+      output.includes("| direction | string | https://github.com/{owner}/{repo}/discussions/general |"),
+      "should render resolved URL with sub-path"
+    );
+    assert.ok(
+      output.includes("| tasks | string | https://github.com/{owner}/{repo}/issues |"),
+      "should render resolved URL without sub-path"
+    );
+    assert.ok(
+      output.includes("| review | string | https://github.com/{owner}/{repo}/pulls (review) |"),
+      "should render resolved URL with kind"
+    );
+  });
+
+  it("falls back to abstract format when skill has no resources", () => {
+    const config: Config = {
+      name: "fallback-test",
+      skills: {
+        slack: { path: "./skills/slack" },
+      },
+      state: {
+        types: {},
+        fields: {
+          goal: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "slack", path: "channel" },
+          },
+          plan: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "slack", path: "channel", kind: "reply" },
+          },
+        },
+      },
+      team: {
+        flow: {
+          nodes: [
+            { skill: "slack", reads: [], writes: [] },
+          ],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+
+    assert.ok(
+      output.includes("| goal | string | slack: channel |"),
+      "should use abstract format without resources"
+    );
+    assert.ok(
+      output.includes("| plan | string | slack: channel (reply) |"),
+      "should use abstract format with kind"
+    );
+  });
+
+  it("falls back for composed skill (not atomic, no resources)", () => {
+    const config: Config = {
+      name: "composed-test",
+      skills: {
+        base: { path: "./skills/base" },
+        agent: { compose: ["base"], description: "An agent." },
+      },
+      state: {
+        types: {},
+        fields: {
+          data: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "agent", path: "output" },
+          },
+        },
+      },
+      team: {
+        flow: {
+          nodes: [
+            { skill: "agent", reads: [], writes: [] },
+          ],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+    assert.ok(
+      output.includes("| data | string | agent: output |"),
+      "should fall back for composed skill"
+    );
+  });
+});
+
+describe("formatLocation unit tests (#279)", () => {
+  it("returns empty string when no location", () => {
+    const result = formatLocation({ type: { kind: "primitive", value: "string" } });
+    assert.equal(result, "");
+  });
+
+  it("resolves URL with sub-path", () => {
+    const result = formatLocation(
+      { type: { kind: "primitive", value: "string" }, location: { skill: "github", path: "discussions/general" } },
+      { discussions: "https://github.com/o/r/discussions" },
+    );
+    assert.equal(result, "https://github.com/o/r/discussions/general");
+  });
+
+  it("resolves URL without sub-path", () => {
+    const result = formatLocation(
+      { type: { kind: "primitive", value: "string" }, location: { skill: "github", path: "issues" } },
+      { issues: "https://github.com/o/r/issues" },
+    );
+    assert.equal(result, "https://github.com/o/r/issues");
+  });
+
+  it("resolves URL with kind", () => {
+    const result = formatLocation(
+      { type: { kind: "primitive", value: "string" }, location: { skill: "github", path: "pull-requests", kind: "review" } },
+      { "pull-requests": "https://github.com/o/r/pulls" },
+    );
+    assert.equal(result, "https://github.com/o/r/pulls (review)");
+  });
+
+  it("falls back when no resources provided", () => {
+    const result = formatLocation(
+      { type: { kind: "primitive", value: "string" }, location: { skill: "slack", path: "channel" } },
+    );
+    assert.equal(result, "slack: channel");
+  });
+
+  it("falls back when namespace not in resources", () => {
+    const result = formatLocation(
+      { type: { kind: "primitive", value: "string" }, location: { skill: "github", path: "wiki/page" } },
+      { issues: "https://github.com/o/r/issues" },
+    );
+    assert.equal(result, "github: wiki/page");
   });
 });

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,4 +1,5 @@
-import type { Config } from "./config.js";
+import type { Config, SkillEntry } from "./config.js";
+import { isAtomic } from "./config.js";
 import { isAsyncNode, isConditionalThen, isMapNode } from "./graph.js";
 import type { AsyncNode, GraphNode, Then } from "./graph.js";
 import type { StateField, StateType } from "./state.js";
@@ -19,9 +20,33 @@ export function formatType(type: StateType): string {
   }
 }
 
-export function formatLocation(field: StateField): string {
+function getSkillResources(
+  skills: Record<string, SkillEntry>,
+  skillName: string,
+): Record<string, string> | undefined {
+  const skill = skills[skillName];
+  if (skill && isAtomic(skill)) return skill.resources;
+  return undefined;
+}
+
+export function formatLocation(
+  field: StateField,
+  skillResources?: Record<string, string>,
+): string {
   if (!field.location) return "";
   const { skill, path, kind } = field.location;
+
+  if (skillResources) {
+    const slashIdx = path.indexOf("/");
+    const namespace = slashIdx === -1 ? path : path.slice(0, slashIdx);
+    const subPath = slashIdx === -1 ? "" : path.slice(slashIdx + 1);
+    const baseUrl = skillResources[namespace];
+    if (baseUrl) {
+      const resolved = subPath ? `${baseUrl}/${subPath}` : baseUrl;
+      return kind ? `${resolved} (${kind})` : resolved;
+    }
+  }
+
   if (kind) {
     return `${skill}: ${path} (${kind})`;
   }
@@ -267,7 +292,10 @@ export function generateOrchestrator(
 
     for (const [name, field] of Object.entries(config.state.fields)) {
       const typeStr = formatType(field.type);
-      const locStr = formatLocation(field);
+      const resources = field.location
+        ? getSkillResources(config.skills, field.location.skill)
+        : undefined;
+      const locStr = formatLocation(field, resources);
       lines.push(`| ${name} | ${typeStr} | ${locStr} |`);
     }
   }

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -2,10 +2,11 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import { parseState } from "./state.js";
+import type { SkillInfo } from "./state.js";
 import { ConfigError } from "./errors.js";
 
-const NO_SKILLS = new Set<string>();
-const SOME_SKILLS = new Set(["review", "lint", "format"]);
+const NO_SKILLS: Record<string, SkillInfo> = {};
+const SOME_SKILLS: Record<string, SkillInfo> = { review: {}, lint: {}, format: {} };
 
 describe("parseState", () => {
   describe("custom type definitions", () => {
@@ -378,9 +379,6 @@ describe("parseState", () => {
 
   describe("ambiguous entries", () => {
     it("entry with non-object non-null value is ignored (no types or fields)", () => {
-      // Scalar values at top level are not objects, so they are skipped
-      // by both passes in parseState. This is an edge case - the YAML
-      // parser would produce a string value for something like `foo: bar`.
       const raw = {
         something: "not-an-object",
       };
@@ -532,6 +530,177 @@ describe("parseState", () => {
           return true;
         }
       );
+    });
+  });
+
+  describe("resource namespace validation (#277)", () => {
+    it("accepts location path matching a declared namespace", () => {
+      const skills: Record<string, SkillInfo> = {
+        github: {
+          resources: {
+            discussions: "https://github.com/owner/repo/discussions",
+            issues: "https://github.com/owner/repo/issues",
+          },
+        },
+      };
+      const raw = {
+        direction: {
+          type: "string",
+          location: { skill: "github", path: "discussions/general" },
+        },
+      };
+      const schema = parseState(raw, skills);
+      assert.deepEqual(schema.fields["direction"]!.location, {
+        skill: "github",
+        path: "discussions/general",
+      });
+    });
+
+    it("accepts location path that is just a namespace with no sub-path", () => {
+      const skills: Record<string, SkillInfo> = {
+        github: {
+          resources: {
+            issues: "https://github.com/owner/repo/issues",
+          },
+        },
+      };
+      const raw = {
+        tasks: {
+          type: "string",
+          location: { skill: "github", path: "issues" },
+        },
+      };
+      const schema = parseState(raw, skills);
+      assert.deepEqual(schema.fields["tasks"]!.location, {
+        skill: "github",
+        path: "issues",
+      });
+    });
+
+    it("rejects location path not matching any declared namespace", () => {
+      const skills: Record<string, SkillInfo> = {
+        github: {
+          resources: {
+            discussions: "https://github.com/owner/repo/discussions",
+            issues: "https://github.com/owner/repo/issues",
+          },
+        },
+      };
+      const raw = {
+        data: {
+          type: "string",
+          location: { skill: "github", path: "wiki/page" },
+        },
+      };
+      assert.throws(
+        () => parseState(raw, skills),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /location path "wiki\/page" references namespace "wiki"/);
+          assert.match(err.message, /not declared by skill "github"/);
+          assert.match(err.message, /Declared namespaces: discussions, issues/);
+          return true;
+        }
+      );
+    });
+
+    it("includes didYouMean hint for close namespace name", () => {
+      const skills: Record<string, SkillInfo> = {
+        github: {
+          resources: {
+            discussions: "https://github.com/owner/repo/discussions",
+            issues: "https://github.com/owner/repo/issues",
+          },
+        },
+      };
+      const raw = {
+        data: {
+          type: "string",
+          location: { skill: "github", path: "discussons/general" },
+        },
+      };
+      assert.throws(
+        () => parseState(raw, skills),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /namespace "discussons"/);
+          assert.match(err.message, /Did you mean "discussions"\?/);
+          return true;
+        }
+      );
+    });
+
+    it("skill with no resources accepts any path (backward compat)", () => {
+      const skills: Record<string, SkillInfo> = {
+        slack: {},
+      };
+      const raw = {
+        goal: {
+          type: "string",
+          location: { skill: "slack", path: "any/path/here" },
+        },
+      };
+      const schema = parseState(raw, skills);
+      assert.deepEqual(schema.fields["goal"]!.location, {
+        skill: "slack",
+        path: "any/path/here",
+      });
+    });
+
+    it("skill with undefined resources accepts any path (backward compat)", () => {
+      const skills: Record<string, SkillInfo> = {
+        slack: { resources: undefined },
+      };
+      const raw = {
+        goal: {
+          type: "string",
+          location: { skill: "slack", path: "channel/general" },
+        },
+      };
+      const schema = parseState(raw, skills);
+      assert.deepEqual(schema.fields["goal"]!.location, {
+        skill: "slack",
+        path: "channel/general",
+      });
+    });
+  });
+
+  describe("implicit location warning (#278)", () => {
+    it("emits warning for skill with no resources but config remains valid", () => {
+      const skills: Record<string, SkillInfo> = {
+        slack: {},
+      };
+      const raw = {
+        goal: {
+          type: "string",
+          location: { skill: "slack", path: "channel" },
+        },
+      };
+      // The config should still parse without error
+      const schema = parseState(raw, skills);
+      assert.deepEqual(schema.fields["goal"]!.location, {
+        skill: "slack",
+        path: "channel",
+      });
+    });
+
+    it("does not emit warning for skill with resources", () => {
+      const skills: Record<string, SkillInfo> = {
+        github: {
+          resources: {
+            issues: "https://github.com/owner/repo/issues",
+          },
+        },
+      };
+      const raw = {
+        tasks: {
+          type: "string",
+          location: { skill: "github", path: "issues" },
+        },
+      };
+      // Should parse without warning (resources declared)
+      const schema = parseState(raw, skills);
+      assert.ok(schema.fields["tasks"]!.location);
     });
   });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -100,10 +100,15 @@ function parseCustomType(
   return { fields };
 }
 
+/** Minimal skill info needed for location validation. */
+export interface SkillInfo {
+  resources?: Record<string, string>;
+}
+
 function validateLocation(
   fieldName: string,
   location: unknown,
-  skillNames: Set<string>
+  skills: Record<string, SkillInfo>,
 ): StateLocation {
   if (typeof location !== "object" || location === null) {
     throw new ConfigError(
@@ -125,9 +130,27 @@ function validateLocation(
     );
   }
 
-  if (!skillNames.has(loc.skill)) {
+  if (!(loc.skill in skills)) {
     throw new ConfigError(
       `State field "${fieldName}": location references unknown skill "${loc.skill}"`
+    );
+  }
+
+  const skill = skills[loc.skill];
+  if (skill.resources && Object.keys(skill.resources).length > 0) {
+    // Validate namespace against declared resources
+    const namespace = loc.path.split("/")[0];
+    if (!(namespace in skill.resources)) {
+      const declared = Object.keys(skill.resources);
+      const hint = didYouMean(namespace, declared);
+      throw new ConfigError(
+        `State field "${fieldName}": location path "${loc.path}" references namespace "${namespace}" which is not declared by skill "${loc.skill}". Declared namespaces: ${declared.join(", ")}${hint}`
+      );
+    }
+  } else {
+    // Emit warning for implicit location (skill has no resources)
+    process.stderr.write(
+      `Warning: state field "${fieldName}" has a location referencing skill "${loc.skill}" which has no resource declarations. Consider adding a "resources" map to the "${loc.skill}" skill definition for compile-time path validation.\n`
     );
   }
 
@@ -141,7 +164,7 @@ function validateLocation(
 
 export function parseState(
   raw: Record<string, unknown>,
-  skillNames: Set<string>
+  skills: Record<string, SkillInfo>,
 ): StateSchema {
   const types: Record<string, CustomType> = {};
   const fields: Record<string, StateField> = {};
@@ -180,7 +203,7 @@ export function parseState(
     const field: StateField = { type: stateType };
 
     if ("location" in obj) {
-      field.location = validateLocation(name, obj.location, skillNames);
+      field.location = validateLocation(name, obj.location, skills);
     }
 
     fields[name] = field;

--- a/test/fixtures/dev-pipeline/skillfold.yaml
+++ b/test/fixtures/dev-pipeline/skillfold.yaml
@@ -6,9 +6,15 @@ skills:
     task-decomposition: ./skills/task-decomposition
     code-generation: ./skills/code-generation
     code-review: ./skills/code-review
-    slack: ./skills/slack
+    slack:
+      path: ./skills/slack
+      resources:
+        dev-pipeline-channel: "https://slack.com/archives/C0123"
     confluence: ./skills/confluence
-    jira: ./skills/jira
+    jira:
+      path: ./skills/jira
+      resources:
+        dev: "https://jira.example.com/project/DEV"
 
   composed:
     strategy:
@@ -54,7 +60,7 @@ state:
     type: "list<Task>"
     location:
       skill: jira
-      path: DEV/dev-board
+      path: dev/dev-board
 
 team:
   orchestrator: orchestrator


### PR DESCRIPTION
**[engineer]**

## Summary

- Atomic skills can now declare `resources` - a map of namespace names to base URL templates (e.g. `discussions: "https://github.com/{owner}/{repo}/discussions"`)
- State location paths are validated at compile time against declared resource namespaces, with `didYouMean` suggestions for typos
- The orchestrator state table renders resolved URLs when resources are available, falling back to the abstract `skill: path` format for skills without resources
- Skills without `resources` emit a stderr warning suggesting resource declarations, but remain fully valid (backward compatible)
- Updated the project's own `skillfold.yaml` to declare resources on the `github` skill as a reference example

## Changes

- `src/config.ts` - Added optional `resources: Record<string, string>` to `AtomicSkill`, parsing and validation in `normalizeAtomicSkills`, preservation in `rebaseSkillPaths`
- `src/state.ts` - Changed `parseState` signature from `skillNames: Set<string>` to `skills: Record<string, SkillInfo>`, added namespace validation and implicit location warning
- `src/orchestrator.ts` - Updated `formatLocation` to resolve URLs against skill resources, added `getSkillResources` helper
- `skillfold.schema.json` - Added `resources` property to atomic skill object schema
- `skillfold.yaml` - Added resource declarations to the `github` skill
- `CLAUDE.md` - Updated Config Structure, Design Brief Summary, and What's Implemented sections
- `docs/getting-started.md` - Added section 7 on resource namespace declarations
- `test/fixtures/dev-pipeline/skillfold.yaml` - Added resources to `slack` and `jira` skills
- `src/config.test.ts` - 7 new tests for resource parsing and validation
- `src/state.test.ts` - 7 new tests for namespace validation and implicit warnings
- `src/orchestrator.test.ts` - 10 new tests for resolved URL rendering and formatLocation
- `src/e2e.test.ts` - Updated state table assertions for resolved URLs

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (493 tests across 90 suites, up from 469/85)
- [x] `npx tsx src/cli.ts validate` validates the project config without warnings
- [x] Existing configs without `resources` continue to work (backward compatible)
- [x] E2e test verifies resolved URLs in orchestrator output

Closes #179, closes #276, closes #277, closes #278, closes #279, closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)