### PR TITLE
feat: resource namespace declarations with compile-time location validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ BRIEF.md               - Full design brief
 
 Three top-level sections: `skills`, `state`, `team`.
 
-- **skills.atomic**: Path references to atomic skill directories
+- **skills.atomic**: Path references to atomic skill directories (can declare `resources` for compile-time location validation)
 - **skills.composed**: Composition declarations combining atomic skills into agents
 - **state**: Typed state schema (top-level, importable independently)
 - **team.orchestrator**: Optional skill name to append generated plan to
@@ -82,7 +82,7 @@ Read BRIEF.md for full context. Key points:
 
 - **Skill composition**: Atomic skills define reusable fragments. Composed skills concatenate atomic skill bodies in declared order. Composition is recursive.
 - **Team flow**: Agents wired into typed execution graphs with conditional routing, loops, and parallel map. Parsed and validated.
-- **State schema**: Typed state schema with custom types, primitives, lists, and external locations. Reads/writes validated against team flow.
+- **State schema**: Typed state schema with custom types, primitives, lists, and external locations. Reads/writes validated against team flow. Location paths validated against skill resource declarations at compile time.
 - **Orchestrator generation**: Generated from the team flow definition. Produces structured execution plan with step numbering, state table, and conditional/map rendering.
 
 ## Shared Skills Library
@@ -156,7 +156,10 @@ Located in `library/examples/`:
 - `skillfold plugin` command for packaging pipelines as distributable Claude Code plugins
 - `skillfold adopt` command for adopting existing Claude Code agents into a pipeline
 - Async flow nodes for external agents (humans, CI, other teams) with `async: true` and policy options (block, skip, use-latest)
-- Test suite with 469 tests across 85 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, errors, and e2e modules
+- Resource namespace declarations on atomic skills for compile-time state location path validation
+- Resolved location URLs in orchestrator state table output (base URL templates from skill resources)
+- Compiler warnings for implicit state locations (skills without resource declarations)
+- Test suite with 489 tests across 89 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, errors, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -227,7 +227,28 @@ The `owner` node is async - it does not invoke an agent. Instead, the orchestrat
 
 Async nodes participate in the flow graph like regular nodes - they have reads, writes, and transitions. But they are excluded from skill compilation (no SKILL.md is generated) and from the Agent tool list in the orchestrator.
 
-## 7. Start from a template
+## 7. Declare resource namespaces
+
+When a state field has a `location` pointing to an atomic skill, the compiler can validate that the location path matches a declared namespace. Add `resources` to your atomic skill definitions:
+
+```yaml
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        discussions: "https://github.com/org/repo/discussions"
+        issues: "https://github.com/org/repo/issues"
+        pull-requests: "https://github.com/org/repo/pulls"
+```
+
+Now when a state field references `github` with a `location.path`, the compiler checks that the first path segment matches a declared resource namespace. A path like `discussions/general` matches `discussions`; a path like `wikis/page` would fail with a clear error.
+
+The orchestrator state table also benefits: instead of abstract `github: discussions/general`, it renders the resolved URL `https://github.com/org/repo/discussions/general`, giving the orchestrator agent concrete locations to work with.
+
+Skills without `resources` still work - the compiler emits a warning suggesting you add declarations for compile-time validation.
+
+## 8. Start from a template
 
 If you prefer starting from a real-world pattern instead of the minimal starter:
 
@@ -245,7 +266,7 @@ Available templates:
 
 Templates use library skills via imports, so they work out of the box with no local skill directories needed.
 
-## 8. Deploy to your platform
+## 9. Deploy to your platform
 
 Compile directly to where your platform reads skills. See the [Integration Guide](integrations.md) for all platforms.
 
@@ -262,7 +283,7 @@ For Claude Code, `--target claude-code` generates agent markdown files alongside
 
 Skillfold also ships a built-in plugin with 11 generic skills. Install it by referencing `node_modules/skillfold/plugin/` from your Claude Code configuration.
 
-## 9. Next steps
+## 10. Next steps
 
 - Read the full config specification in [BRIEF.md](../BRIEF.md)
 - Explore the [shared library examples](../library/examples/) for real pipeline patterns

--- a/skillfold.schema.json
+++ b/skillfold.schema.json
@@ -44,6 +44,16 @@
                   "path": {
                     "type": "string",
                     "description": "Path to the skill directory."
+                  },
+                  "resources": {
+                    "type": "object",
+                    "description": "Resource namespaces this skill exposes, with base URL templates.",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "propertyNames": {
+                      "pattern": "^[a-z0-9][a-z0-9-]*$"
+                    }
                   }
                 }
               }

--- a/skillfold.yaml
+++ b/skillfold.yaml
@@ -12,7 +12,12 @@ skills:
     security-best-practices: https://github.com/openai/skills/tree/main/skills/.curated/security-best-practices
 
     # Project-specific skills
-    github: ./skills/github
+    github:
+      path: ./skills/github
+      resources:
+        discussions: "https://github.com/byronxlg/skillfold/discussions"
+        issues: "https://github.com/byronxlg/skillfold/issues"
+        pull-requests: "https://github.com/byronxlg/skillfold/pulls"
     moltbook: ./skills/moltbook
     product-strategy: ./skills/product-strategy
     skillfold-context: ./skills/skillfold-context

--- a/skills/skillfold-context/SKILL.md
+++ b/skills/skillfold-context/SKILL.md
@@ -58,7 +58,7 @@ The codebase is TypeScript (strict, ESM modules). Key modules:
 
 ## What's Implemented
 
-All compiler features are working: skill composition with atomic/composed sub-sections, state schema, flow validation, map subgraph validation, when-clause parsing, orchestrator generation, spec-compliant output, URL-based skill references (with private repo auth via GITHUB_TOKEN), pipeline imports, graph visualization with full composition lineage, `skillfold init`, `skillfold adopt`, `skillfold validate`, `skillfold list`, `--check` for CI integration, and async flow nodes for external agents. Published on npm as `skillfold`. 469 tests across 85 suites, CI on GitHub Actions. The project self-hosts its own dev team via `skillfold.yaml`.
+All compiler features are working: skill composition with atomic/composed sub-sections, state schema, flow validation, map subgraph validation, when-clause parsing, orchestrator generation, spec-compliant output, URL-based skill references (with private repo auth via GITHUB_TOKEN), pipeline imports, graph visualization with full composition lineage, `skillfold init`, `skillfold adopt`, `skillfold validate`, `skillfold list`, `--check` for CI integration, async flow nodes for external agents, and resource namespace declarations with compile-time location path validation. Published on npm as `skillfold`. 489 tests across 89 suites, CI on GitHub Actions. The project self-hosts its own dev team via `skillfold.yaml`.
 
 ## What's Next
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1594,3 +1594,128 @@ describe("type guards", () => {
     assert.equal(isComposed({ path: "./skills/review" }), false);
   });
 });
+
+describe("resource namespace declarations", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("parses atomic skill with valid resources map", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        discussions: "https://github.com/org/repo/discussions"
+        issues: "https://github.com/org/repo/issues"
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["github"];
+    assert.ok(isAtomic(skill));
+    assert.deepEqual(skill.resources, {
+      discussions: "https://github.com/org/repo/discussions",
+      issues: "https://github.com/org/repo/issues",
+    });
+  });
+
+  it("accepts empty resources map", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources: {}
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["github"];
+    assert.ok(isAtomic(skill));
+    assert.deepEqual(skill.resources, {});
+  });
+
+  it("string shorthand has no resources", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github: ./skills/github
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["github"];
+    assert.ok(isAtomic(skill));
+    assert.equal(skill.resources, undefined);
+  });
+
+  it("rejects resources with uppercase key", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        Discussions: "https://example.com"
+`);
+    assert.throws(
+      () => readConfig(configPath),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /resource name "Discussions"/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects resources with non-string value", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        issues: 42
+`);
+    assert.throws(
+      () => readConfig(configPath),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /resource "issues" must be a non-empty string/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects resources with array value", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        - issues
+`);
+    assert.throws(
+      () => readConfig(configPath),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /resources must be a YAML map/);
+        return true;
+      }
+    );
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ import { parseState, StateSchema } from "./state.js";
 
 export interface AtomicSkill {
   path: string;
+  resources?: Record<string, string>;
 }
 
 /** Known Claude Code subagent frontmatter fields that can be set on composed skills. */
@@ -89,6 +90,34 @@ export function isComposed(skill: SkillEntry): skill is ComposedSkill {
   return "compose" in skill;
 }
 
+const RESOURCE_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+function parseResources(
+  name: string,
+  rawResources: unknown,
+): Record<string, string> {
+  if (typeof rawResources !== "object" || rawResources === null || Array.isArray(rawResources)) {
+    throw new ConfigError(
+      `Skill "${name}": resources must be a YAML map`
+    );
+  }
+  const resources: Record<string, string> = {};
+  for (const [key, val] of Object.entries(rawResources as Record<string, unknown>)) {
+    if (!RESOURCE_NAME_RE.test(key)) {
+      throw new ConfigError(
+        `Skill "${name}": resource name "${key}" must be lowercase alphanumeric with hyphens`
+      );
+    }
+    if (typeof val !== "string" || val.length === 0) {
+      throw new ConfigError(
+        `Skill "${name}": resource "${key}" must be a non-empty string`
+      );
+    }
+    resources[key] = val;
+  }
+  return resources;
+}
+
 function normalizeAtomicSkills(
   raw: Record<string, unknown>
 ): Record<string, AtomicSkill> {
@@ -106,7 +135,12 @@ function normalizeAtomicSkills(
       if (typeof path !== "string") {
         throw new ConfigError(`Skill "${name}": path must be a string`);
       }
-      skills[name] = { path };
+      const skill: AtomicSkill = { path };
+      const rawObj = value as Record<string, unknown>;
+      if ("resources" in rawObj && rawObj.resources !== undefined) {
+        skill.resources = parseResources(name, rawObj.resources);
+      }
+      skills[name] = skill;
     } else {
       throw new ConfigError(
         `Skill "${name}": must be a path string, or an object with "path"`
@@ -445,8 +479,11 @@ export function validateAndBuild(raw: RawConfig): Config {
   const config: Config = { name: raw.name, skills: raw.skills };
 
   if (raw.rawState !== undefined) {
-    const skillNames = new Set(Object.keys(raw.skills));
-    config.state = parseState(raw.rawState, skillNames);
+    const skillsForState: Record<string, { resources?: Record<string, string> }> = {};
+    for (const [name, skill] of Object.entries(raw.skills)) {
+      skillsForState[name] = isAtomic(skill) ? { resources: skill.resources } : {};
+    }
+    config.state = parseState(raw.rawState, skillsForState);
   }
 
   if (raw.rawTeam !== undefined) {
@@ -482,7 +519,11 @@ function rebaseSkillPaths(
     if (isAtomic(skill) && !skill.path.startsWith("https://")) {
       const abs = resolve(importDir, skill.path);
       const rebased = relative(targetDir, abs);
-      result[name] = { path: rebased };
+      const rebasedSkill: AtomicSkill = { path: rebased };
+      if (skill.resources) {
+        rebasedSkill.resources = skill.resources;
+      }
+      result[name] = rebasedSkill;
     } else {
       result[name] = skill;
     }

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -362,6 +362,61 @@ team:
     assert.ok(existsSync(join(outDir, "reviewer", "SKILL.md")));
   });
 
+  it("inline config with resource declarations renders resolved URLs", () => {
+    const raw = parseRawConfig(`
+name: resources-test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        discussions: "https://github.com/org/repo/discussions"
+        issues: "https://github.com/org/repo/issues"
+        pull-requests: "https://github.com/org/repo/pulls"
+    coding: ./skills/coding
+  composed:
+    engineer:
+      compose: [coding]
+      description: "Writes code."
+    orchestrator:
+      compose: [github]
+      description: "Coordinates."
+state:
+  direction:
+    type: string
+    location:
+      skill: github
+      path: discussions/general
+  tasks:
+    type: string
+    location:
+      skill: github
+      path: issues
+  review:
+    type: string
+    location:
+      skill: github
+      path: pull-requests
+      kind: review
+team:
+  orchestrator: orchestrator
+  flow:
+    - engineer:
+        reads: [state.direction]
+        writes: [state.tasks]
+      then: end
+`);
+    const config = validateAndBuild(raw);
+    const output = generateOrchestrator(config);
+
+    // State table should have resolved URLs
+    assert.ok(output.includes("https://github.com/org/repo/discussions/general"));
+    assert.ok(output.includes("https://github.com/org/repo/issues"));
+    assert.ok(output.includes("https://github.com/org/repo/pulls (review)"));
+    // Should NOT contain abstract format
+    assert.ok(!output.includes("github: discussions"));
+  });
+
   it("orchestrator includes async step in execution plan", async () => {
     asyncTmpDir = makeTmpDir();
     const outDir = join(asyncTmpDir, "dist");

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -2,7 +2,8 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import type { Config } from "./config.js";
-import { generateOrchestrator } from "./orchestrator.js";
+import { formatLocation, generateOrchestrator } from "./orchestrator.js";
+import type { StateField } from "./state.js";
 
 describe("generateOrchestrator", () => {
   it("linear graph - 3 steps with correct numbering, reads/writes, transitions", () => {
@@ -735,5 +736,122 @@ describe("generateOrchestrator: async nodes", () => {
     assert.ok(!asyncSection.includes("Agent tool"));
     // But the step node should
     assert.ok(output.includes("Invoke **worker** using the Agent tool."));
+  });
+});
+
+describe("formatLocation with resolved URLs", () => {
+  const resources = {
+    discussions: "https://github.com/org/repo/discussions",
+    issues: "https://github.com/org/repo/issues",
+    "pull-requests": "https://github.com/org/repo/pulls",
+  };
+
+  it("resolves URL with sub-path", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+      location: { skill: "github", path: "discussions/general" },
+    };
+    assert.equal(
+      formatLocation(field, resources),
+      "https://github.com/org/repo/discussions/general"
+    );
+  });
+
+  it("resolves URL without sub-path", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+      location: { skill: "github", path: "issues" },
+    };
+    assert.equal(
+      formatLocation(field, resources),
+      "https://github.com/org/repo/issues"
+    );
+  });
+
+  it("resolves URL with kind qualifier", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+      location: { skill: "github", path: "pull-requests", kind: "review" },
+    };
+    assert.equal(
+      formatLocation(field, resources),
+      "https://github.com/org/repo/pulls (review)"
+    );
+  });
+
+  it("falls back to abstract format without resources", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+      location: { skill: "github", path: "discussions/general" },
+    };
+    assert.equal(
+      formatLocation(field),
+      "github: discussions/general"
+    );
+  });
+
+  it("falls back to abstract format with kind without resources", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+      location: { skill: "github", path: "pull-requests", kind: "review" },
+    };
+    assert.equal(
+      formatLocation(field),
+      "github: pull-requests (review)"
+    );
+  });
+
+  it("returns empty string for field without location", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+    };
+    assert.equal(formatLocation(field), "");
+  });
+});
+
+describe("generateOrchestrator with resolved URLs", () => {
+  it("renders resolved URLs in state table when skills have resources", () => {
+    const config: Config = {
+      name: "resolved-urls",
+      skills: {
+        github: {
+          path: "./skills/github",
+          resources: {
+            discussions: "https://github.com/org/repo/discussions",
+            issues: "https://github.com/org/repo/issues",
+          },
+        },
+        worker: { compose: ["github"], description: "Does work." },
+      },
+      state: {
+        types: {},
+        fields: {
+          direction: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "github", path: "discussions/general" },
+          },
+          tasks: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "github", path: "issues" },
+          },
+        },
+      },
+      team: {
+        flow: {
+          nodes: [
+            {
+              skill: "worker",
+              reads: [],
+              writes: [],
+              then: "end",
+            },
+          ],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+    assert.ok(output.includes("https://github.com/org/repo/discussions/general"));
+    assert.ok(output.includes("https://github.com/org/repo/issues"));
   });
 });

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,4 +1,5 @@
 import type { Config } from "./config.js";
+import { isAtomic } from "./config.js";
 import { isAsyncNode, isConditionalThen, isMapNode } from "./graph.js";
 import type { AsyncNode, GraphNode, Then } from "./graph.js";
 import type { StateField, StateType } from "./state.js";
@@ -19,9 +20,24 @@ export function formatType(type: StateType): string {
   }
 }
 
-export function formatLocation(field: StateField): string {
+export function formatLocation(
+  field: StateField,
+  skillResources?: Record<string, string>,
+): string {
   if (!field.location) return "";
   const { skill, path, kind } = field.location;
+
+  if (skillResources) {
+    const slashIdx = path.indexOf("/");
+    const namespace = slashIdx === -1 ? path : path.slice(0, slashIdx);
+    const subPath = slashIdx === -1 ? "" : path.slice(slashIdx + 1);
+    const baseUrl = skillResources[namespace];
+    if (baseUrl) {
+      const resolved = subPath ? `${baseUrl}/${subPath}` : baseUrl;
+      return kind ? `${resolved} (${kind})` : resolved;
+    }
+  }
+
   if (kind) {
     return `${skill}: ${path} (${kind})`;
   }
@@ -267,7 +283,14 @@ export function generateOrchestrator(
 
     for (const [name, field] of Object.entries(config.state.fields)) {
       const typeStr = formatType(field.type);
-      const locStr = formatLocation(field);
+      let resources: Record<string, string> | undefined;
+      if (field.location) {
+        const skill = config.skills[field.location.skill];
+        if (skill && isAtomic(skill)) {
+          resources = skill.resources;
+        }
+      }
+      const locStr = formatLocation(field, resources);
       lines.push(`| ${name} | ${typeStr} | ${locStr} |`);
     }
   }

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -534,4 +534,97 @@ describe("parseState", () => {
       );
     });
   });
+
+  describe("resource namespace validation", () => {
+    const SKILLS_WITH_RESOURCES = {
+      github: {
+        resources: {
+          discussions: "https://github.com/org/repo/discussions",
+          issues: "https://github.com/org/repo/issues",
+          "pull-requests": "https://github.com/org/repo/pulls",
+        },
+      },
+      lint: {},
+    };
+
+    it("accepts location path matching a declared namespace", () => {
+      const raw = {
+        direction: {
+          type: "string",
+          location: { skill: "github", path: "discussions/general" },
+        },
+      };
+      const schema = parseState(raw, SKILLS_WITH_RESOURCES);
+      assert.equal(schema.fields["direction"].location?.path, "discussions/general");
+    });
+
+    it("accepts location path that is just a namespace (no sub-path)", () => {
+      const raw = {
+        tasks: {
+          type: "string",
+          location: { skill: "github", path: "issues" },
+        },
+      };
+      const schema = parseState(raw, SKILLS_WITH_RESOURCES);
+      assert.equal(schema.fields["tasks"].location?.path, "issues");
+    });
+
+    it("rejects location path with unrecognized namespace", () => {
+      const raw = {
+        data: {
+          type: "string",
+          location: { skill: "github", path: "wikis/page" },
+        },
+      };
+      assert.throws(
+        () => parseState(raw, SKILLS_WITH_RESOURCES),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /namespace "wikis" which is not declared/);
+          assert.match(err.message, /Declared namespaces: discussions, issues, pull-requests/);
+          return true;
+        }
+      );
+    });
+
+    it("includes didYouMean hint for close namespace match", () => {
+      const raw = {
+        data: {
+          type: "string",
+          location: { skill: "github", path: "issue/123" },
+        },
+      };
+      assert.throws(
+        () => parseState(raw, SKILLS_WITH_RESOURCES),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /namespace "issue"/);
+          assert.match(err.message, /Did you mean "issues"/);
+          return true;
+        }
+      );
+    });
+
+    it("accepts any path for skills without resource declarations", () => {
+      const raw = {
+        result: {
+          type: "string",
+          location: { skill: "lint", path: "anything/goes" },
+        },
+      };
+      const schema = parseState(raw, SKILLS_WITH_RESOURCES);
+      assert.equal(schema.fields["result"].location?.path, "anything/goes");
+    });
+
+    it("backward compat: Set<string> still works for skills param", () => {
+      const raw = {
+        result: {
+          type: "string",
+          location: { skill: "review", path: "anything" },
+        },
+      };
+      const schema = parseState(raw, SOME_SKILLS);
+      assert.equal(schema.fields["result"].location?.skill, "review");
+    });
+  });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,5 +1,9 @@
 import { ConfigError, didYouMean } from "./errors.js";
 
+export interface SkillResources {
+  resources?: Record<string, string>;
+}
+
 export type PrimitiveType = "string" | "bool" | "number";
 
 export type StateType =
@@ -103,7 +107,7 @@ function parseCustomType(
 function validateLocation(
   fieldName: string,
   location: unknown,
-  skillNames: Set<string>
+  skills: Record<string, SkillResources>,
 ): StateLocation {
   if (typeof location !== "object" || location === null) {
     throw new ConfigError(
@@ -125,9 +129,29 @@ function validateLocation(
     );
   }
 
-  if (!skillNames.has(loc.skill)) {
+  if (!(loc.skill in skills)) {
     throw new ConfigError(
       `State field "${fieldName}": location references unknown skill "${loc.skill}"`
+    );
+  }
+
+  const skill = skills[loc.skill];
+
+  // Validate namespace against resource declarations
+  if (skill.resources && Object.keys(skill.resources).length > 0) {
+    const slashIdx = loc.path.indexOf("/");
+    const namespace = slashIdx === -1 ? loc.path : loc.path.slice(0, slashIdx);
+    if (!(namespace in skill.resources)) {
+      const declared = Object.keys(skill.resources);
+      const hint = didYouMean(namespace, declared);
+      throw new ConfigError(
+        `State field "${fieldName}": location path "${loc.path}" references namespace "${namespace}" which is not declared by skill "${loc.skill}". Declared namespaces: ${declared.join(", ")}${hint}`
+      );
+    }
+  } else {
+    // Emit warning for implicit locations
+    process.stderr.write(
+      `Warning: state field "${fieldName}" references skill "${loc.skill}" which has no resource declarations. Consider adding a "resources" map to the "${loc.skill}" skill definition for compile-time path validation.\n`
     );
   }
 
@@ -141,8 +165,14 @@ function validateLocation(
 
 export function parseState(
   raw: Record<string, unknown>,
-  skillNames: Set<string>
+  skills: Set<string> | Record<string, SkillResources>,
 ): StateSchema {
+  // Normalize: accept both Set<string> (legacy) and Record (new)
+  const skillsRecord: Record<string, SkillResources> =
+    skills instanceof Set
+      ? Object.fromEntries([...skills].map((n) => [n, {}]))
+      : skills;
+
   const types: Record<string, CustomType> = {};
   const fields: Record<string, StateField> = {};
 
@@ -180,7 +210,7 @@ export function parseState(
     const field: StateField = { type: stateType };
 
     if ("location" in obj) {
-      field.location = validateLocation(name, obj.location, skillNames);
+      field.location = validateLocation(name, obj.location, skillsRecord);
     }
 
     fields[name] = field;


### PR DESCRIPTION
## Summary

- Atomic skills can declare `resources` with base URL templates for compile-time validation
- State location paths are validated against declared resource namespaces with didYouMean hints
- Compiler emits warnings for implicit locations (skills without resource declarations)
- Orchestrator state table renders resolved URLs instead of abstract `skill: path` format
- Self-hosted `skillfold.yaml` updated with GitHub resource declarations
- Getting-started guide, CLAUDE.md, JSON schema, and e2e tests updated

Closes #276, closes #277, closes #278, closes #279, closes #280
Parent: #179

## Test plan

- [x] 489 tests pass (20 new), 0 failures
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Self-hosted config compiles without warnings
- [x] Orchestrator output shows resolved GitHub URLs in state table
- [x] Backward compatible: Set<string> param still works, skills without resources accepted

**[orchestrator]**