### PR TITLE
feat: sub-flow imports for nested pipeline composition

### DIFF
--- a/BRIEF.md
+++ b/BRIEF.md
@@ -234,6 +234,6 @@ These are intentionally left open — the right answers depend on implementation
 - How are external state backends handled at runtime?
 - How does the orchestrator communicate with individual agents in practice?
 - How are errors and failures handled mid-pipeline?
-- Should the language support importing or extending other pipeline configs?
+- ~~Should the language support importing or extending other pipeline configs?~~ (Done: pipeline imports and sub-flow imports)
 - How does versioning work for skills referenced by URL?
 - Should there be a package registry for shared skills?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Three top-level sections: `skills`, `state`, `team`.
 - **skills.composed**: Composition declarations combining atomic skills into agents
 - **state**: Typed state schema (top-level, importable independently)
 - **team.orchestrator**: Optional skill name to append generated plan to
-- **team.flow**: Directed execution graph with conditional routing, loops, and parallel map
+- **team.flow**: Directed execution graph with conditional routing, loops, parallel map, and sub-flow imports
 
 Imports pull in `skills` and `state`, ignore `team`.
 
@@ -159,11 +159,11 @@ Located in `library/examples/`:
 - Resource namespace declarations on atomic skills for compile-time state location path validation
 - Resolved location URLs in orchestrator state table output (base URL templates from skill resources)
 - Compiler warnings for implicit state locations (skills without resource declarations)
-- Test suite with 489 tests across 89 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, errors, and e2e modules
+- Sub-flow imports: flow nodes can reference external pipeline configs via `flow:` field, with recursive resolution, skill/state merging, circular reference detection, orchestrator rendering with hierarchical steps, and Mermaid visualization as subgraphs
+- Test suite with 508 tests across 95 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, errors, subflow, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next
 
 See BRIEF.md "Open Questions" section. Potential next work:
 1. Package registry for shared skills
-2. Sub-flow imports (flow nodes referencing imported flows as single nodes)

--- a/skillfold.schema.json
+++ b/skillfold.schema.json
@@ -255,7 +255,7 @@
     },
     "stepBody": {
       "type": ["object", "null"],
-      "description": "Step node body with optional reads, writes, async flag, and policy.",
+      "description": "Step node body with optional reads, writes, async flag, policy, and flow reference.",
       "additionalProperties": false,
       "properties": {
         "reads": {
@@ -276,6 +276,10 @@
           "type": "string",
           "description": "How to handle unavailable async data. Only valid when async is true.",
           "enum": ["block", "skip", "use-latest"]
+        },
+        "flow": {
+          "type": "string",
+          "description": "Path to a sub-flow pipeline config. When set, this node runs the referenced pipeline as a nested flow instead of invoking a single skill."
         }
       }
     },

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -4,7 +4,7 @@ import { stringify } from "yaml";
 
 import { type Config, isComposed } from "./config.js";
 import type { GraphNode, StepNode } from "./graph.js";
-import { isAsyncNode, isMapNode } from "./graph.js";
+import { isAsyncNode, isMapNode, isSubFlowNode } from "./graph.js";
 import {
   buildStepMap,
   formatLocation,
@@ -32,12 +32,16 @@ export interface AgentResult {
   content: string;
 }
 
-/** Collect all step nodes from a graph, recursing into map subgraphs. Skips async nodes. */
+/** Collect all step nodes from a graph, recursing into map and sub-flow subgraphs. Skips async and sub-flow nodes themselves. */
 function collectStepNodes(nodes: GraphNode[]): StepNode[] {
   const steps: StepNode[] = [];
   for (const node of nodes) {
     if (isMapNode(node)) {
       steps.push(...collectStepNodes(node.graph));
+    } else if (isSubFlowNode(node)) {
+      if (node.graph) {
+        steps.push(...collectStepNodes(node.graph));
+      }
     } else if (!isAsyncNode(node)) {
       steps.push(node);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ const __pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const SELF_IMPORT_PREFIX = "node_modules/skillfold/";
 
 import { ConfigError, didYouMean } from "./errors.js";
-import { Graph, parseGraph, validateGraph } from "./graph.js";
+import { type Graph, type GraphNode, type SubFlowNode, isMapNode, isSubFlowNode, parseGraph, validateGraph } from "./graph.js";
 import { fetchRemoteConfig } from "./remote.js";
 import { parseState, StateSchema } from "./state.js";
 
@@ -80,6 +80,8 @@ export interface RawConfig {
     rawFlow: unknown[];
   };
   imports?: string[];
+  /** Pre-parsed graph with resolved sub-flow nodes (set by resolveSubFlows). */
+  _resolvedGraph?: Graph;
 }
 
 export function isAtomic(skill: SkillEntry): skill is AtomicSkill {
@@ -487,7 +489,9 @@ export function validateAndBuild(raw: RawConfig): Config {
   }
 
   if (raw.rawTeam !== undefined) {
-    const graph = parseGraph(raw.rawTeam.rawFlow);
+    // Use the pre-resolved graph (with sub-flow data) if available,
+    // otherwise parse from the raw flow YAML.
+    const graph = raw._resolvedGraph ?? parseGraph(raw.rawTeam.rawFlow);
     validateGraph(graph, raw.skills, config.state);
     const team: TeamConfig = { flow: graph };
 
@@ -607,6 +611,106 @@ async function resolveImports(
   };
 }
 
+// Collect all SubFlowNode references from a graph node list (non-recursive into sub-flows).
+function collectSubFlowNodes(nodes: GraphNode[]): SubFlowNode[] {
+  const result: SubFlowNode[] = [];
+  for (const node of nodes) {
+    if (isSubFlowNode(node)) {
+      result.push(node);
+    } else if (isMapNode(node)) {
+      result.push(...collectSubFlowNodes(node.graph));
+    }
+  }
+  return result;
+}
+
+// Resolve sub-flow references: load each referenced config, merge its skills/state
+// into the parent, and populate the SubFlowNode.graph with the referenced flow.
+async function resolveSubFlows(
+  raw: RawConfig,
+  baseDir: string,
+  visited?: Set<string>,
+): Promise<RawConfig> {
+  if (!raw.rawTeam) return raw;
+
+  // Parse the flow to find sub-flow nodes (will be re-parsed in validateAndBuild,
+  // but we need it here to discover flow: references)
+  const graph = parseGraph(raw.rawTeam.rawFlow);
+  const subFlowNodes = collectSubFlowNodes(graph.nodes);
+
+  if (subFlowNodes.length === 0) return raw;
+
+  const resolvedPaths = visited ?? new Set<string>();
+  let mergedSkills = { ...raw.skills };
+  let mergedState = raw.rawState ? { ...raw.rawState } : undefined;
+
+  for (const sfNode of subFlowNodes) {
+    const configPath = resolve(baseDir, sfNode.flow);
+
+    // Circular sub-flow detection
+    if (resolvedPaths.has(configPath)) {
+      throw new ConfigError(
+        `Circular sub-flow reference: "${sfNode.flow}" has already been resolved in the import chain`
+      );
+    }
+
+    let content: string;
+    try {
+      content = readFileSync(configPath, "utf-8");
+    } catch {
+      throw new ConfigError(
+        `Sub-flow node "${sfNode.name}": cannot read config file "${sfNode.flow}"`
+      );
+    }
+
+    const subRaw = parseRawConfig(content);
+
+    // The sub-flow config must have a team.flow section
+    if (!subRaw.rawTeam) {
+      throw new ConfigError(
+        `Sub-flow node "${sfNode.name}": referenced config "${sfNode.flow}" has no team.flow`
+      );
+    }
+
+    // Recursively resolve imports and sub-flows in the sub-config
+    const subDir = dirname(configPath);
+    const subMerged = await resolveImports(subRaw, subDir);
+    const nextVisited = new Set(resolvedPaths);
+    nextVisited.add(configPath);
+    const subResolved = await resolveSubFlows(subMerged, subDir, nextVisited);
+
+    // Rebase and merge skills from the sub-flow config
+    const rebasedSkills = rebaseSkillPaths(subResolved.skills, subDir, baseDir);
+    mergedSkills = mergeSkills(mergedSkills, rebasedSkills);
+
+    // Merge state from the sub-flow config
+    if (subResolved.rawState) {
+      mergedState = mergeRawState(mergedState, subResolved.rawState);
+    }
+
+    // Parse the sub-flow's flow graph and attach it to the node.
+    // We mutate the sfNode.graph here; this is safe because parseGraph
+    // created fresh objects from the raw YAML.
+    const subGraph = parseGraph(subResolved.rawTeam!.rawFlow);
+    sfNode.graph = subGraph.nodes;
+  }
+
+  // Rebuild the rawFlow from the now-populated graph nodes so that
+  // validateAndBuild re-parses with sub-flow data intact.
+  // Instead, we store the parsed graph directly and re-parse from rawFlow.
+  // The trick: we need the raw team flow to carry the sub-flow data through.
+  // Since rawTeam.rawFlow is re-parsed in validateAndBuild, we need a different
+  // approach: store the pre-parsed graph on the RawConfig.
+
+  return {
+    name: raw.name,
+    skills: mergedSkills,
+    rawState: mergedState,
+    rawTeam: raw.rawTeam,
+    _resolvedGraph: graph,
+  };
+}
+
 // Original synchronous entry point (unchanged API)
 export function readConfig(configPath: string): Config {
   let content: string;
@@ -639,7 +743,8 @@ export async function loadConfig(configPath: string): Promise<Config> {
   try {
     const raw = parseRawConfig(content);
     const merged = await resolveImports(raw, dirname(configPath));
-    return validateAndBuild(merged);
+    const resolved = await resolveSubFlows(merged, dirname(configPath));
+    return validateAndBuild(resolved);
   } catch (err) {
     if (err instanceof ConfigError && !err.message.includes(configPath)) {
       throw new ConfigError(`${configPath}: ${err.message}`);

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -38,7 +38,17 @@ export interface MapNode {
   then?: Then;
 }
 
-export type GraphNode = StepNode | AsyncNode | MapNode;
+export interface SubFlowNode {
+  name: string;
+  flow: string;
+  reads: string[];
+  writes: string[];
+  /** Populated after config resolution loads the referenced pipeline. */
+  graph?: GraphNode[];
+  then?: Then;
+}
+
+export type GraphNode = StepNode | AsyncNode | MapNode | SubFlowNode;
 
 export interface Graph {
   nodes: GraphNode[];
@@ -50,6 +60,10 @@ export function isAsyncNode(node: GraphNode): node is AsyncNode {
 
 export function isMapNode(node: GraphNode): node is MapNode {
   return "over" in node;
+}
+
+export function isSubFlowNode(node: GraphNode): node is SubFlowNode {
+  return "flow" in node;
 }
 
 export function isConditionalThen(then: Then): then is ConditionalBranch[] {
@@ -191,6 +205,7 @@ function parseGraphNodes(raw: unknown[], insideMap = false): GraphNode[] {
       const writes: string[] = [];
       let isAsync = false;
       let policy: "block" | "skip" | "use-latest" = "block";
+      let flowPath: string | undefined;
 
       if (typeof value === "object" && value !== null && !Array.isArray(value)) {
         const stepObj = value as Record<string, unknown>;
@@ -211,6 +226,20 @@ function parseGraphNodes(raw: unknown[], insideMap = false): GraphNode[] {
             );
           }
           writes.push(...(stepObj.writes as string[]));
+        }
+
+        if (stepObj.flow !== undefined) {
+          if (typeof stepObj.flow !== "string" || stepObj.flow.length === 0) {
+            throw new GraphError(
+              `Graph element "${primaryKey}": flow must be a non-empty string (path to a pipeline config)`
+            );
+          }
+          if (insideMap) {
+            throw new GraphError(
+              `Graph element "${primaryKey}": sub-flow nodes are not allowed inside map subgraphs`
+            );
+          }
+          flowPath = stepObj.flow;
         }
 
         if (stepObj.async === true) {
@@ -236,7 +265,15 @@ function parseGraphNodes(raw: unknown[], insideMap = false): GraphNode[] {
         );
       }
 
-      if (isAsync) {
+      if (flowPath !== undefined) {
+        nodes.push({
+          name: primaryKey,
+          flow: flowPath,
+          reads,
+          writes,
+          ...(then !== undefined ? { then } : {}),
+        });
+      } else if (isAsync) {
         nodes.push({
           name: primaryKey,
           async: true,
@@ -272,10 +309,11 @@ export function parseGraph(raw: unknown): Graph {
   return { nodes };
 }
 
-// Collect all node labels (skill names for steps, async node names, "map" for map nodes)
+// Collect all node labels (skill names for steps, async node names, sub-flow names, "map" for map nodes)
 function collectNodeLabels(nodes: GraphNode[]): string[] {
   return nodes.map((node) => {
     if (isMapNode(node)) return "map";
+    if (isSubFlowNode(node)) return node.name;
     if (isAsyncNode(node)) return node.name;
     return node.skill;
   });
@@ -288,9 +326,10 @@ function getThenTargets(then: Then | undefined): string[] {
   return then.map((b) => b.to);
 }
 
-// Get a label for a node (skill name, async name, or "map")
+// Get a label for a node (skill name, async name, sub-flow name, or "map")
 function nodeLabel(node: GraphNode): string {
   if (isMapNode(node)) return "map";
+  if (isSubFlowNode(node)) return node.name;
   if (isAsyncNode(node)) return node.name;
   return node.skill;
 }
@@ -310,10 +349,10 @@ function validateNodes(
 ): void {
   const nodeLabels = new Set(collectNodeLabels(nodes));
 
-  // Rule 1: Skill references (async nodes skip this check)
+  // Rule 1: Skill references (async and sub-flow nodes skip this check)
   const skillNames = Object.keys(skills);
   for (const node of nodes) {
-    if (!isMapNode(node) && !isAsyncNode(node)) {
+    if (!isMapNode(node) && !isAsyncNode(node) && !isSubFlowNode(node)) {
       if (!(node.skill in skills)) {
         const hint = didYouMean(node.skill, skillNames);
         throw new GraphError(
@@ -338,11 +377,11 @@ function validateNodes(
     }
   }
 
-  // Rule 3: State path validation (applies identically to step and async nodes)
+  // Rule 3: State path validation (applies to step, async, and sub-flow nodes)
   const stateFieldNames = state ? Object.keys(state.fields) : [];
   for (const node of nodes) {
     if (isMapNode(node)) continue;
-    const label = isAsyncNode(node) ? node.name : node.skill;
+    const label = (isAsyncNode(node) || isSubFlowNode(node)) ? node.name : node.skill;
 
     for (const path of node.reads) {
       if (path.startsWith("state.")) {
@@ -457,7 +496,7 @@ function validateNodes(
   const writeOwners = new Map<string, { label: string; isAsync: boolean }>();
   for (const node of nodes) {
     if (isMapNode(node)) continue;
-    const label = isAsyncNode(node) ? node.name : node.skill;
+    const label = (isAsyncNode(node) || isSubFlowNode(node)) ? node.name : node.skill;
     const nodeIsAsync = isAsyncNode(node);
     for (const path of node.writes) {
       if (!path.startsWith("state.")) continue;
@@ -525,6 +564,16 @@ function validateNodes(
 
     // Recursively validate the subgraph
     validateNodes(node.graph, skills, state, subMapCtx);
+  }
+
+  // Rule 9: Sub-flow inner graph validation (after resolution populates graph)
+  for (const node of nodes) {
+    if (!isSubFlowNode(node)) continue;
+    if (node.graph) {
+      // The inner graph was resolved from the referenced config;
+      // validate it with the merged skills and state.
+      validateNodes(node.graph, skills, state);
+    }
   }
 
   // Build index: node label -> position in this level's node list

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,5 +1,5 @@
 import { type Config, type SkillEntry, isAtomic, isComposed } from "./config.js";
-import { type GraphNode, isAsyncNode, isConditionalThen, isMapNode } from "./graph.js";
+import { type GraphNode, isAsyncNode, isConditionalThen, isMapNode, isSubFlowNode } from "./graph.js";
 import { type StateField, type StateSchema } from "./state.js";
 
 function formatStateType(field: StateField): string {
@@ -75,6 +75,7 @@ function renderState(state: StateSchema): string[] {
 
 function nodeLabel(node: GraphNode): string {
   if (isMapNode(node)) return "map";
+  if (isSubFlowNode(node)) return `${node.name} (sub-flow)`;
   if (isAsyncNode(node)) return `${node.name} (async)`;
   return node.skill;
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,6 +1,6 @@
 import type { Config } from "./config.js";
 import { isAtomic } from "./config.js";
-import { isAsyncNode, isConditionalThen, isMapNode } from "./graph.js";
+import { isAsyncNode, isConditionalThen, isMapNode, isSubFlowNode } from "./graph.js";
 import type { AsyncNode, GraphNode, Then } from "./graph.js";
 import type { StateField, StateType } from "./state.js";
 
@@ -59,6 +59,8 @@ export function buildStepMap(
     let label: string;
     if (isMapNode(node)) {
       label = "map";
+    } else if (isSubFlowNode(node)) {
+      label = node.name;
     } else if (isAsyncNode(node)) {
       label = node.name;
     } else {
@@ -196,6 +198,59 @@ export function renderNodes(
         lines.push(
           `Writes: ${node.writes.map((w) => `\`${w}\``).join(", ")}`
         );
+      }
+
+      lines.push("");
+
+      if (node.then !== undefined) {
+        lines.push(renderThen(node.then, stepMap, isLast));
+      } else if (isLast) {
+        lines.push(renderThen(undefined, stepMap, true));
+      } else {
+        const nextStep = stepMap[i + 1];
+        if (nextStep) {
+          lines.push(`Then: proceed to step ${nextStep.number}.`);
+        } else {
+          lines.push("Then: end");
+        }
+      }
+
+      sections.push(lines.join("\n"));
+    } else if (isSubFlowNode(node)) {
+      const lines: string[] = [];
+      lines.push(`${headingLevel} Step ${stepNum}: ${node.name} (sub-flow)`);
+      lines.push("");
+      lines.push(
+        `Run the **${node.name}** sub-flow (${node.flow}).`
+      );
+
+      if (node.reads.length > 0) {
+        lines.push("");
+        lines.push(`Reads: ${node.reads.map((r) => `\`${r}\``).join(", ")}`);
+      }
+
+      if (node.writes.length > 0) {
+        lines.push("");
+        lines.push(
+          `Writes: ${node.writes.map((w) => `\`${w}\``).join(", ")}`
+        );
+      }
+
+      // Render inner graph if resolved
+      if (node.graph && node.graph.length > 0) {
+        lines.push("");
+        lines.push("Sub-flow steps:");
+
+        const subMap = buildStepMap(node.graph, stepNum);
+        const subHeading = headingLevel + "#";
+        const subSections = renderNodes(
+          node.graph,
+          subMap,
+          stepNum,
+          subHeading,
+          useAgentTool,
+        );
+        lines.push(...subSections);
       }
 
       lines.push("");

--- a/src/subflow.test.ts
+++ b/src/subflow.test.ts
@@ -1,0 +1,631 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import { loadConfig, parseRawConfig, readConfig, validateAndBuild } from "./config.js";
+import { compile } from "./compiler.js";
+import { ConfigError, GraphError } from "./errors.js";
+import {
+  isSubFlowNode,
+  parseGraph,
+  SubFlowNode,
+  validateGraph,
+} from "./graph.js";
+import { generateOrchestrator } from "./orchestrator.js";
+import { resolveSkills } from "./resolver.js";
+import { generateMermaid } from "./visualize.js";
+
+import type { Config } from "./config.js";
+import type { StepNode } from "./graph.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixtureDir = join(__dirname, "..", "test", "fixtures", "subflow-pipeline");
+const configPath = join(fixtureDir, "skillfold.yaml");
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `skillfold-subflow-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeSkill(dir: string, name: string, body: string): void {
+  const skillDir = join(dir, "skills", name);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, "SKILL.md"), body, "utf-8");
+}
+
+function writeYaml(dir: string, filename: string, content: string): string {
+  const filePath = join(dir, filename);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+describe("parseGraph: sub-flow nodes", () => {
+  it("parses a sub-flow node with flow path, reads, and writes", () => {
+    const raw = [
+      {
+        "dev-cycle": {
+          flow: "./subflow/skillfold.yaml",
+          reads: ["state.plan"],
+          writes: ["state.result"],
+        },
+        then: "end",
+      },
+    ];
+    const graph = parseGraph(raw);
+    assert.equal(graph.nodes.length, 1);
+    const node = graph.nodes[0];
+    assert.ok(isSubFlowNode(node));
+    assert.equal(node.name, "dev-cycle");
+    assert.equal(node.flow, "./subflow/skillfold.yaml");
+    assert.deepEqual(node.reads, ["state.plan"]);
+    assert.deepEqual(node.writes, ["state.result"]);
+    assert.equal(node.then, "end");
+    assert.equal(node.graph, undefined);
+  });
+
+  it("parses a sub-flow node with no reads/writes", () => {
+    const raw = [
+      {
+        "sub": { flow: "./other.yaml" },
+      },
+    ];
+    const graph = parseGraph(raw);
+    const node = graph.nodes[0];
+    assert.ok(isSubFlowNode(node));
+    assert.deepEqual(node.reads, []);
+    assert.deepEqual(node.writes, []);
+  });
+
+  it("rejects empty flow path", () => {
+    const raw = [
+      {
+        "sub": { flow: "" },
+      },
+    ];
+    assert.throws(
+      () => parseGraph(raw),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /flow must be a non-empty string/);
+        return true;
+      },
+    );
+  });
+
+  it("rejects non-string flow path", () => {
+    const raw = [
+      {
+        "sub": { flow: 42 },
+      },
+    ];
+    assert.throws(
+      () => parseGraph(raw),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /flow must be a non-empty string/);
+        return true;
+      },
+    );
+  });
+
+  it("rejects sub-flow inside map subgraph", () => {
+    const raw = [
+      {
+        map: {
+          over: "state.items",
+          as: "item",
+          graph: [
+            {
+              "nested-flow": { flow: "./nested.yaml" },
+            },
+          ],
+        },
+      },
+    ];
+    assert.throws(
+      () => parseGraph(raw),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /sub-flow nodes are not allowed inside map subgraphs/);
+        return true;
+      },
+    );
+  });
+
+  it("sub-flow node is distinct from step and async nodes", () => {
+    const raw = [
+      {
+        planner: { writes: ["state.plan"] },
+        then: "cycle",
+      },
+      {
+        cycle: { flow: "./sub.yaml", reads: ["state.plan"] },
+        then: "end",
+      },
+    ];
+    const graph = parseGraph(raw);
+    assert.equal(graph.nodes.length, 2);
+    assert.ok(!isSubFlowNode(graph.nodes[0]));
+    assert.ok(isSubFlowNode(graph.nodes[1]));
+  });
+});
+
+describe("validateGraph: sub-flow nodes", () => {
+  it("validates sub-flow node reads/writes against state", () => {
+    const graph = {
+      nodes: [
+        {
+          name: "sub",
+          flow: "./sub.yaml",
+          reads: ["state.missing"],
+          writes: [],
+        } as SubFlowNode,
+      ],
+    };
+    const skills = { worker: { path: "./skills/worker" } };
+    const state = {
+      types: {},
+      fields: {
+        plan: { type: { kind: "primitive" as const, value: "string" as const } },
+      },
+    };
+    assert.throws(
+      () => validateGraph(graph, skills, state),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /reads state field "state.missing" which is not declared/);
+        return true;
+      },
+    );
+  });
+
+  it("sub-flow nodes skip skill reference validation", () => {
+    const graph = {
+      nodes: [
+        {
+          name: "external-flow",
+          flow: "./other.yaml",
+          reads: [],
+          writes: [],
+        } as SubFlowNode,
+      ],
+    };
+    const skills = {};
+    // Should NOT throw about "external-flow" not being a declared skill
+    validateGraph(graph, skills, undefined);
+  });
+
+  it("validates inner graph of resolved sub-flow", () => {
+    const graph = {
+      nodes: [
+        {
+          name: "sub",
+          flow: "./sub.yaml",
+          reads: [],
+          writes: [],
+          graph: [
+            {
+              skill: "unknown-skill",
+              reads: [],
+              writes: [],
+            } as StepNode,
+          ],
+        } as SubFlowNode,
+      ],
+    };
+    const skills = { worker: { path: "./skills/worker" } };
+    assert.throws(
+      () => validateGraph(graph, skills, undefined),
+      (err: unknown) => {
+        assert.ok(err instanceof GraphError);
+        assert.match(err.message, /skill "unknown-skill" is not declared/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("loadConfig: sub-flow resolution", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("loads config with sub-flow and resolves the inner graph", async () => {
+    const config = await loadConfig(configPath);
+
+    // Parent skills should be present
+    assert.ok("planner" in config.skills);
+    assert.ok("coordinator" in config.skills);
+    assert.ok("orchestrator" in config.skills);
+
+    // Sub-flow skills should be merged in
+    assert.ok("coder" in config.skills);
+    assert.ok("tester" in config.skills);
+    assert.ok("engineer" in config.skills);
+    assert.ok("qa" in config.skills);
+
+    // Sub-flow state should be merged in
+    assert.ok(config.state);
+    assert.ok("plan" in config.state.fields);
+    assert.ok("result" in config.state.fields);
+    assert.ok("code" in config.state.fields);
+    assert.ok("tests-pass" in config.state.fields);
+
+    // The flow should have the sub-flow node with its inner graph
+    assert.ok(config.team);
+    assert.equal(config.team.flow.nodes.length, 2);
+    const subFlowNode = config.team.flow.nodes[1];
+    assert.ok(isSubFlowNode(subFlowNode));
+    assert.equal(subFlowNode.name, "dev-cycle");
+    assert.ok(subFlowNode.graph);
+    assert.equal(subFlowNode.graph.length, 2);
+  });
+
+  it("errors on missing sub-flow config file", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "worker", "# Worker\nDoes work.");
+    const configContent = `
+name: test
+skills:
+  atomic:
+    worker: ./skills/worker
+  composed:
+    agent:
+      compose: [worker]
+      description: "Test agent."
+team:
+  flow:
+    - sub:
+        flow: ./nonexistent/skillfold.yaml
+      then: end
+`;
+    const path = writeYaml(tmpDir, "skillfold.yaml", configContent);
+    await assert.rejects(
+      () => loadConfig(path),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /cannot read config file/);
+        return true;
+      },
+    );
+  });
+
+  it("errors when sub-flow config has no team.flow", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "worker", "# Worker\nDoes work.");
+    writeSkill(tmpDir, "inner", "# Inner\nInner work.");
+    const subContent = `
+name: inner-config
+skills:
+  atomic:
+    inner: ./skills/inner
+`;
+    writeYaml(tmpDir, "sub/skillfold.yaml", subContent);
+
+    const configContent = `
+name: test
+skills:
+  atomic:
+    worker: ./skills/worker
+  composed:
+    agent:
+      compose: [worker]
+      description: "Test agent."
+team:
+  flow:
+    - sub:
+        flow: ./sub/skillfold.yaml
+      then: end
+`;
+    const path = writeYaml(tmpDir, "skillfold.yaml", configContent);
+    await assert.rejects(
+      () => loadConfig(path),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /has no team\.flow/);
+        return true;
+      },
+    );
+  });
+
+  it("errors on circular sub-flow reference", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "worker", "# Worker\nDoes work.");
+
+    // Config A references config B as a sub-flow
+    const configA = `
+name: config-a
+skills:
+  atomic:
+    worker: ./skills/worker
+  composed:
+    agent:
+      compose: [worker]
+      description: "Agent A."
+team:
+  flow:
+    - sub:
+        flow: ./sub/skillfold.yaml
+      then: end
+`;
+    // Config B references config A back as a sub-flow (circular)
+    const configB = `
+name: config-b
+skills:
+  atomic:
+    worker: ../skills/worker
+  composed:
+    agent:
+      compose: [worker]
+      description: "Agent B."
+team:
+  flow:
+    - sub:
+        flow: ../skillfold.yaml
+      then: end
+`;
+    writeYaml(tmpDir, "skillfold.yaml", configA);
+    writeYaml(tmpDir, "sub/skillfold.yaml", configB);
+
+    const path = join(tmpDir, "skillfold.yaml");
+    await assert.rejects(
+      () => loadConfig(path),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /[Cc]ircular sub-flow/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("generateOrchestrator: sub-flow nodes", () => {
+  it("renders sub-flow with hierarchical step numbers", () => {
+    const config: Config = {
+      name: "subflow-pipeline",
+      skills: {
+        planner: { path: "./skills/planner" },
+        coder: { path: "./skills/coder" },
+        tester: { path: "./skills/tester" },
+      },
+      state: {
+        types: {},
+        fields: {
+          plan: { type: { kind: "primitive", value: "string" } },
+          code: { type: { kind: "primitive", value: "string" } },
+          result: { type: { kind: "primitive", value: "string" } },
+        },
+      },
+      team: {
+        flow: {
+          nodes: [
+            {
+              skill: "planner",
+              reads: [],
+              writes: ["state.plan"],
+              then: "dev-cycle",
+            },
+            {
+              name: "dev-cycle",
+              flow: "./subflow/skillfold.yaml",
+              reads: ["state.plan"],
+              writes: ["state.result"],
+              graph: [
+                {
+                  skill: "coder",
+                  reads: [],
+                  writes: ["state.code"],
+                  then: "tester",
+                },
+                {
+                  skill: "tester",
+                  reads: ["state.code"],
+                  writes: [],
+                },
+              ],
+            } as SubFlowNode,
+          ],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+
+    // Step 1: planner
+    assert.ok(output.includes("### Step 1: planner"));
+    assert.ok(output.includes("Then: proceed to step 2."));
+
+    // Step 2: sub-flow
+    assert.ok(output.includes("### Step 2: dev-cycle (sub-flow)"));
+    assert.ok(output.includes("Run the **dev-cycle** sub-flow"));
+    assert.ok(output.includes("Reads: `state.plan`"));
+    assert.ok(output.includes("Writes: `state.result`"));
+
+    // Sub-flow inner steps
+    assert.ok(output.includes("Sub-flow steps:"));
+    assert.ok(output.includes("#### Step 2.1: coder"));
+    assert.ok(output.includes("#### Step 2.2: tester"));
+  });
+
+  it("renders sub-flow without inner graph when not resolved", () => {
+    const config: Config = {
+      name: "unresolved",
+      skills: {},
+      team: {
+        flow: {
+          nodes: [
+            {
+              name: "sub",
+              flow: "./sub.yaml",
+              reads: [],
+              writes: ["state.result"],
+            } as SubFlowNode,
+          ],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+    assert.ok(output.includes("### Step 1: sub (sub-flow)"));
+    assert.ok(!output.includes("Sub-flow steps:"));
+  });
+});
+
+describe("generateMermaid: sub-flow nodes", () => {
+  it("renders sub-flow as a subgraph with inner nodes", () => {
+    const config: Config = {
+      name: "test",
+      skills: {
+        planner: { path: "./skills/planner" },
+        coder: { path: "./skills/coder" },
+        tester: { path: "./skills/tester" },
+      },
+      team: {
+        flow: {
+          nodes: [
+            {
+              skill: "planner",
+              reads: [],
+              writes: [],
+              then: "dev-cycle",
+            },
+            {
+              name: "dev-cycle",
+              flow: "./sub.yaml",
+              reads: [],
+              writes: [],
+              graph: [
+                {
+                  skill: "coder",
+                  reads: [],
+                  writes: [],
+                  then: "tester",
+                },
+                {
+                  skill: "tester",
+                  reads: [],
+                  writes: [],
+                },
+              ],
+            } as SubFlowNode,
+          ],
+        },
+      },
+    };
+
+    const output = generateMermaid(config);
+    assert.ok(output.includes('subgraph subflow_dev_cycle["sub-flow: dev-cycle"]'));
+    assert.ok(output.includes("coder --> tester"));
+    assert.ok(output.includes("end"));
+    assert.ok(output.includes("planner --> subflow_dev_cycle"));
+  });
+
+  it("renders sub-flow with writes as edge label", () => {
+    const config: Config = {
+      name: "test",
+      skills: {
+        coder: { path: "./skills/coder" },
+      },
+      team: {
+        flow: {
+          nodes: [
+            {
+              name: "cycle",
+              flow: "./sub.yaml",
+              reads: [],
+              writes: ["state.result"],
+              graph: [
+                {
+                  skill: "coder",
+                  reads: [],
+                  writes: [],
+                },
+              ],
+            } as SubFlowNode,
+          ],
+        },
+      },
+    };
+
+    const output = generateMermaid(config);
+    assert.ok(output.includes('subflow_cycle'));
+    assert.ok(output.includes('"result"'));
+  });
+
+  it("renders empty sub-flow subgraph when graph is not resolved", () => {
+    const config: Config = {
+      name: "test",
+      skills: {},
+      team: {
+        flow: {
+          nodes: [
+            {
+              name: "sub",
+              flow: "./sub.yaml",
+              reads: [],
+              writes: [],
+            } as SubFlowNode,
+          ],
+        },
+      },
+    };
+
+    const output = generateMermaid(config);
+    assert.ok(output.includes('subgraph subflow_sub["sub-flow: sub"]'));
+    assert.ok(output.includes("end"));
+  });
+});
+
+describe("e2e: subflow-pipeline", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("loads, resolves, compiles, and generates orchestrator for sub-flow pipeline", async () => {
+    tmpDir = makeTmpDir();
+    const outDir = join(tmpDir, "dist");
+
+    const config = await loadConfig(configPath);
+
+    // Verify sub-flow node has its inner graph populated
+    assert.ok(config.team);
+    const sfNode = config.team.flow.nodes[1];
+    assert.ok(isSubFlowNode(sfNode));
+    assert.ok(sfNode.graph);
+    assert.ok(sfNode.graph.length > 0);
+
+    // Resolve skills and compile
+    const bodies = await resolveSkills(config, fixtureDir);
+    const results = compile(config, bodies, outDir, "0.0.0", "skillfold.yaml");
+
+    // Should produce composed skill outputs
+    assert.ok(results.length > 0);
+
+    // Orchestrator output should include sub-flow rendering
+    const orchestrator = generateOrchestrator(config);
+    assert.ok(orchestrator.includes("sub-flow"));
+    assert.ok(orchestrator.includes("dev-cycle"));
+
+    // Mermaid output should include sub-flow subgraph
+    const mermaid = generateMermaid(config);
+    assert.ok(mermaid.includes("subflow_dev_cycle"));
+  });
+});

--- a/src/visualize.ts
+++ b/src/visualize.ts
@@ -1,5 +1,5 @@
 import { type Config, type SkillEntry, isComposed } from "./config.js";
-import { type GraphNode, isAsyncNode, isConditionalThen, isMapNode } from "./graph.js";
+import { type GraphNode, isAsyncNode, isConditionalThen, isMapNode, isSubFlowNode } from "./graph.js";
 
 // Sanitize a name into a valid Mermaid node ID by replacing non-alphanumeric
 // characters with underscores.
@@ -47,6 +47,8 @@ function buildIdMap(nodes: GraphNode[]): Map<string, string> {
   for (const node of nodes) {
     if (isMapNode(node)) {
       ids.set("map", `map_${sanitizeId(node.over)}`);
+    } else if (isSubFlowNode(node)) {
+      ids.set(node.name, `subflow_${sanitizeId(node.name)}`);
     } else if (isAsyncNode(node)) {
       ids.set(node.name, sanitizeId(node.name));
     } else {
@@ -106,6 +108,7 @@ function renderThen(
 // Get the Mermaid ID for a node when it's the target of a fall-through edge.
 function getNextTarget(node: GraphNode): string {
   if (isMapNode(node)) return `map_${sanitizeId(node.over)}`;
+  if (isSubFlowNode(node)) return `subflow_${sanitizeId(node.name)}`;
   if (isAsyncNode(node)) return sanitizeId(node.name);
   return sanitizeId(node.skill);
 }
@@ -166,6 +169,37 @@ function renderNodes(
             lines,
             indent,
             currentId,
+            `${endNodeId}([end])`,
+            node.writes,
+          );
+        }
+      }
+    } else if (isSubFlowNode(node)) {
+      // Sub-flow nodes render as subgraphs containing their inner flow
+      const subgraphId = `subflow_${sanitizeId(node.name)}`;
+      const subgraphLabel = `sub-flow: ${node.name}`;
+      lines.push(`${indent}subgraph ${subgraphId}["${subgraphLabel}"]`);
+
+      if (node.graph && node.graph.length > 0) {
+        const innerIndent = indent + "    ";
+        const innerEndId = `end_${subgraphId}`;
+        renderNodes(node.graph, lines, innerIndent, innerEndId, skills);
+      }
+
+      lines.push(`${indent}end`);
+
+      if (node.then !== undefined) {
+        renderThen(lines, indent, subgraphId, node.then, endNodeId, idMap, node.writes);
+      } else {
+        const nextNode = nodes[i + 1];
+        if (nextNode) {
+          const nextId = getNextTarget(nextNode);
+          renderEdge(lines, indent, subgraphId, nextId, node.writes);
+        } else {
+          renderEdge(
+            lines,
+            indent,
+            subgraphId,
             `${endNodeId}([end])`,
             node.writes,
           );

--- a/test/fixtures/subflow-pipeline/skillfold.yaml
+++ b/test/fixtures/subflow-pipeline/skillfold.yaml
@@ -1,0 +1,32 @@
+name: parent-pipeline
+
+skills:
+  atomic:
+    planner: ./skills/planner
+    coordinator: ./skills/coordinator
+
+  composed:
+    orchestrator:
+      compose: [planner, coordinator]
+      description: "Orchestrates the pipeline."
+
+state:
+  plan:
+    type: string
+
+  result:
+    type: string
+
+team:
+  orchestrator: orchestrator
+
+  flow:
+    - planner:
+        writes: [state.plan]
+      then: dev-cycle
+
+    - dev-cycle:
+        flow: ./subflow/skillfold.yaml
+        reads: [state.plan]
+        writes: [state.result]
+      then: end

--- a/test/fixtures/subflow-pipeline/skills/coordinator/SKILL.md
+++ b/test/fixtures/subflow-pipeline/skills/coordinator/SKILL.md
@@ -1,0 +1,3 @@
+# Coordinator
+
+You coordinate work across teams and track progress.

--- a/test/fixtures/subflow-pipeline/skills/planner/SKILL.md
+++ b/test/fixtures/subflow-pipeline/skills/planner/SKILL.md
@@ -1,0 +1,3 @@
+# Planning
+
+You create plans and break down goals into actionable steps.

--- a/test/fixtures/subflow-pipeline/subflow/skillfold.yaml
+++ b/test/fixtures/subflow-pipeline/subflow/skillfold.yaml
@@ -1,0 +1,37 @@
+name: dev-cycle
+
+skills:
+  atomic:
+    coder: ./skills/coder
+    tester: ./skills/tester
+
+  composed:
+    engineer:
+      compose: [coder]
+      description: "Implements code changes."
+
+    qa:
+      compose: [tester]
+      description: "Validates implementation."
+
+state:
+  code:
+    type: string
+
+  tests-pass:
+    type: bool
+
+team:
+  flow:
+    - engineer:
+        writes: [state.code]
+      then: qa
+
+    - qa:
+        reads: [state.code]
+        writes: [state.tests-pass]
+      then:
+        - when: state.tests-pass == false
+          to: engineer
+        - when: state.tests-pass == true
+          to: end

--- a/test/fixtures/subflow-pipeline/subflow/skills/coder/SKILL.md
+++ b/test/fixtures/subflow-pipeline/subflow/skills/coder/SKILL.md
@@ -1,0 +1,3 @@
+# Coding
+
+You write production-quality code.

--- a/test/fixtures/subflow-pipeline/subflow/skills/tester/SKILL.md
+++ b/test/fixtures/subflow-pipeline/subflow/skills/tester/SKILL.md
@@ -1,0 +1,3 @@
+# Testing
+
+You write and run tests to verify correctness.


### PR DESCRIPTION
## Summary

- Flow nodes can now reference external pipeline configs as sub-flows via the `flow:` field on step nodes
- The compiler loads the referenced config, recursively resolves its imports and sub-flows, merges skills/state into the parent, and inlines the sub-flow's execution graph
- Circular sub-flow references are detected and rejected with a clear error message
- Orchestrator renders sub-flows with hierarchical step numbering (e.g., 2.1, 2.2)
- Mermaid visualization renders sub-flows as labeled subgraphs, consistent with map node rendering
- 19 new tests across parsing, validation, config resolution, orchestrator rendering, visualization, and end-to-end compilation (508 total, up from 489)

## Example

```yaml
team:
  flow:
    - planner:
        writes: [state.plan]
      then: dev-cycle

    - dev-cycle:
        flow: ./subflow/skillfold.yaml
        reads: [state.plan]
        writes: [state.result]
      then: end
```

## Changes

| File | What |
|------|------|
| `src/graph.ts` | `SubFlowNode` interface, `isSubFlowNode()` guard, parsing of `flow:` field, validation rules |
| `src/config.ts` | `resolveSubFlows()` function, wired into `loadConfig()`, skill/state merging, circular detection |
| `src/orchestrator.ts` | Sub-flow rendering with hierarchical steps and `(sub-flow)` label |
| `src/visualize.ts` | Sub-flow rendered as Mermaid subgraphs |
| `src/agent.ts` | `collectStepNodes` recurses into sub-flow inner graphs |
| `src/list.ts` | Sub-flow nodes labeled with `(sub-flow)` suffix |
| `skillfold.schema.json` | `flow` field added to `stepBody` definition |
| `CLAUDE.md` | Updated "What's Implemented", test counts, removed from "What's Next" |
| `BRIEF.md` | Marked importing/extending question as done |
| `src/subflow.test.ts` | 19 new tests |
| `test/fixtures/subflow-pipeline/` | Test fixture with parent + sub-flow configs |

## Test plan

- [x] All 508 tests pass (489 existing + 19 new)
- [x] TypeScript strict mode compiles cleanly
- [x] Parsing: sub-flow node from YAML, empty/missing flow path errors, sub-flow inside map rejected
- [x] Validation: reads/writes checked against state, inner graph validated, skill refs skipped for sub-flow nodes
- [x] Config resolution: loads sub-flow config, merges skills/state, populates inner graph, detects circular refs, errors on missing file and missing team.flow
- [x] Orchestrator: hierarchical step numbers, sub-flow label, inner steps rendered
- [x] Visualization: sub-flow rendered as Mermaid subgraph with inner nodes
- [x] E2e: full load -> resolve -> compile -> orchestrator -> mermaid pipeline with sub-flow fixture

Closes #283, #284, #285, #286, #287