### PR TITLE
feat: support npm: prefix in skill references and imports

### DIFF
--- a/skillfold.schema.json
+++ b/skillfold.schema.json
@@ -13,7 +13,7 @@
     },
     "imports": {
       "type": "array",
-      "description": "Paths or URLs to other skillfold configs. Imports pull in skills and state, not team.",
+      "description": "Paths, URLs, or npm: references to other skillfold configs. Imports pull in skills and state, not team. Use npm:package-name for npm packages (resolves to node_modules/package-name/skillfold.yaml) or npm:package-name/custom.yaml for a specific file.",
       "items": {
         "type": "string"
       }
@@ -29,12 +29,12 @@
       "properties": {
         "atomic": {
           "type": "object",
-          "description": "Atomic skills referenced by local path or GitHub URL.",
+          "description": "Atomic skills referenced by local path, GitHub URL, or npm: reference.",
           "additionalProperties": {
             "oneOf": [
               {
                 "type": "string",
-                "description": "Path to the skill directory (local path or GitHub tree URL)."
+                "description": "Path to the skill directory (local path, GitHub tree URL, or npm:package/path)."
               },
               {
                 "type": "object",

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ const SELF_IMPORT_PREFIX = "node_modules/skillfold/";
 
 import { ConfigError, didYouMean } from "./errors.js";
 import { type Graph, type GraphNode, type SubFlowNode, isMapNode, isSubFlowNode, parseGraph, validateGraph } from "./graph.js";
+import { isNpmRef, resolveNpmImportPath } from "./npm.js";
 import { fetchRemoteConfig } from "./remote.js";
 import { parseState, StateSchema } from "./state.js";
 
@@ -512,7 +513,7 @@ export function validateAndBuild(raw: RawConfig): Config {
 }
 
 // Rebase imported atomic skill paths from importDir-relative to targetDir-relative.
-// Remote (https://) paths are left unchanged.
+// Remote (https://) and npm: paths are left unchanged.
 function rebaseSkillPaths(
   skills: Record<string, SkillEntry>,
   importDir: string,
@@ -520,7 +521,7 @@ function rebaseSkillPaths(
 ): Record<string, SkillEntry> {
   const result: Record<string, SkillEntry> = {};
   for (const [name, skill] of Object.entries(skills)) {
-    if (isAtomic(skill) && !skill.path.startsWith("https://")) {
+    if (isAtomic(skill) && !skill.path.startsWith("https://") && !isNpmRef(skill.path)) {
       const abs = resolve(importDir, skill.path);
       const rebased = relative(targetDir, abs);
       const rebasedSkill: AtomicSkill = { path: rebased };
@@ -571,6 +572,14 @@ async function resolveImports(
     if (importPath.startsWith("https://")) {
       content = await fetchRemoteConfig(importPath);
       // Remote imports keep their paths as-is (already URLs or relative to remote)
+    } else if (isNpmRef(importPath)) {
+      const resolved = resolveNpmImportPath(importPath, baseDir);
+      importDir = dirname(resolved);
+      try {
+        content = readFileSync(resolved, "utf-8");
+      } catch {
+        throw new ConfigError(`Cannot read npm imported config: ${importPath} (resolved to ${resolved})`);
+      }
     } else {
       let resolved = resolve(baseDir, importPath);
       // When running via npx, node_modules/skillfold/ won't exist in the

--- a/src/npm.test.ts
+++ b/src/npm.test.ts
@@ -1,0 +1,553 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { loadConfig } from "./config.js";
+import { ConfigError, ResolveError } from "./errors.js";
+import { isNpmRef, parseNpmRef, resolveNpmImportPath, resolveNpmPackageDir, resolveNpmSkillPath } from "./npm.js";
+import { resolveSkills } from "./resolver.js";
+
+import type { Config } from "./config.js";
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `skillfold-npm-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("isNpmRef", () => {
+  it("returns true for npm: prefixed string", () => {
+    assert.equal(isNpmRef("npm:some-package"), true);
+  });
+
+  it("returns true for scoped npm: prefixed string", () => {
+    assert.equal(isNpmRef("npm:@scope/package"), true);
+  });
+
+  it("returns false for local path", () => {
+    assert.equal(isNpmRef("./skills/review"), false);
+  });
+
+  it("returns false for https URL", () => {
+    assert.equal(isNpmRef("https://github.com/org/repo"), false);
+  });
+
+  it("returns false for node_modules path", () => {
+    assert.equal(isNpmRef("node_modules/skillfold/library/skillfold.yaml"), false);
+  });
+});
+
+describe("parseNpmRef", () => {
+  it("parses unscoped package with no subpath", () => {
+    const result = parseNpmRef("npm:my-package");
+    assert.deepEqual(result, { packageName: "my-package", subpath: "" });
+  });
+
+  it("parses unscoped package with subpath", () => {
+    const result = parseNpmRef("npm:my-package/skills/planning");
+    assert.deepEqual(result, { packageName: "my-package", subpath: "skills/planning" });
+  });
+
+  it("parses unscoped package with file subpath", () => {
+    const result = parseNpmRef("npm:my-package/custom.yaml");
+    assert.deepEqual(result, { packageName: "my-package", subpath: "custom.yaml" });
+  });
+
+  it("parses scoped package with no subpath", () => {
+    const result = parseNpmRef("npm:@team/shared-skills");
+    assert.deepEqual(result, { packageName: "@team/shared-skills", subpath: "" });
+  });
+
+  it("parses scoped package with subpath", () => {
+    const result = parseNpmRef("npm:@team/shared-skills/skills/planning");
+    assert.deepEqual(result, { packageName: "@team/shared-skills", subpath: "skills/planning" });
+  });
+
+  it("parses scoped package with file subpath", () => {
+    const result = parseNpmRef("npm:@team/shared-skills/custom.yaml");
+    assert.deepEqual(result, { packageName: "@team/shared-skills", subpath: "custom.yaml" });
+  });
+
+  it("parses scoped package with deep subpath", () => {
+    const result = parseNpmRef("npm:@org/lib/a/b/c");
+    assert.deepEqual(result, { packageName: "@org/lib", subpath: "a/b/c" });
+  });
+
+  it("handles bare scope (edge case)", () => {
+    const result = parseNpmRef("npm:@scope");
+    assert.deepEqual(result, { packageName: "@scope", subpath: "" });
+  });
+});
+
+describe("resolveNpmPackageDir", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("falls back to direct node_modules path for missing package", () => {
+    tmpDir = makeTmpDir();
+    const result = resolveNpmPackageDir("nonexistent-pkg", tmpDir);
+    assert.equal(result, join(tmpDir, "node_modules", "nonexistent-pkg"));
+  });
+
+  it("falls back to direct node_modules path for scoped package", () => {
+    tmpDir = makeTmpDir();
+    const result = resolveNpmPackageDir("@scope/pkg", tmpDir);
+    assert.equal(result, join(tmpDir, "node_modules", "@scope/pkg"));
+  });
+
+  it("resolves package with package.json via require.resolve", () => {
+    tmpDir = makeTmpDir();
+    // Create a real package structure so require.resolve works
+    const pkgDir = join(tmpDir, "node_modules", "test-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), '{"name":"test-pkg","version":"1.0.0"}', "utf-8");
+
+    const result = resolveNpmPackageDir("test-pkg", tmpDir);
+    // Use realpathSync to normalize symlinks (e.g., /tmp -> /private/tmp on macOS)
+    assert.equal(realpathSync(result), realpathSync(pkgDir));
+  });
+});
+
+describe("resolveNpmImportPath", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("resolves bare package to skillfold.yaml", () => {
+    tmpDir = makeTmpDir();
+    const result = resolveNpmImportPath("npm:my-package", tmpDir);
+    assert.equal(result, join(tmpDir, "node_modules", "my-package", "skillfold.yaml"));
+  });
+
+  it("resolves package with explicit file subpath", () => {
+    tmpDir = makeTmpDir();
+    const result = resolveNpmImportPath("npm:my-package/custom.yaml", tmpDir);
+    assert.equal(result, join(tmpDir, "node_modules", "my-package", "custom.yaml"));
+  });
+
+  it("resolves scoped package to skillfold.yaml", () => {
+    tmpDir = makeTmpDir();
+    const result = resolveNpmImportPath("npm:@team/shared", tmpDir);
+    assert.equal(result, join(tmpDir, "node_modules", "@team/shared", "skillfold.yaml"));
+  });
+
+  it("resolves scoped package with subpath", () => {
+    tmpDir = makeTmpDir();
+    const result = resolveNpmImportPath("npm:@team/shared/library/skillfold.yaml", tmpDir);
+    assert.equal(result, join(tmpDir, "node_modules", "@team/shared", "library", "skillfold.yaml"));
+  });
+});
+
+describe("resolveNpmSkillPath", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("resolves bare package to package root", () => {
+    tmpDir = makeTmpDir();
+    const result = resolveNpmSkillPath("npm:my-package", tmpDir);
+    assert.equal(result, join(tmpDir, "node_modules", "my-package"));
+  });
+
+  it("resolves package with skill subpath", () => {
+    tmpDir = makeTmpDir();
+    const result = resolveNpmSkillPath("npm:my-package/skills/planning", tmpDir);
+    assert.equal(result, join(tmpDir, "node_modules", "my-package", "skills", "planning"));
+  });
+
+  it("resolves scoped package with skill subpath", () => {
+    tmpDir = makeTmpDir();
+    const result = resolveNpmSkillPath("npm:@team/shared/skills/planning", tmpDir);
+    assert.equal(result, join(tmpDir, "node_modules", "@team/shared", "skills", "planning"));
+  });
+});
+
+describe("npm: import integration", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("loads config with npm: import", async () => {
+    tmpDir = makeTmpDir();
+
+    // Create a mock npm package with a skillfold config
+    const pkgDir = join(tmpDir, "node_modules", "@team", "shared-skills");
+    const skillDir = join(pkgDir, "skills", "imported-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), '{"name":"@team/shared-skills","version":"1.0.0"}', "utf-8");
+    writeFileSync(
+      join(pkgDir, "skillfold.yaml"),
+      `name: shared
+skills:
+  atomic:
+    imported-skill: ./skills/imported-skill
+`,
+      "utf-8"
+    );
+    writeFileSync(join(skillDir, "SKILL.md"), "# Imported\n\nImported from npm.", "utf-8");
+
+    // Create the main config that imports from npm
+    const localSkillDir = join(tmpDir, "skills", "local-skill");
+    mkdirSync(localSkillDir, { recursive: true });
+    writeFileSync(join(localSkillDir, "SKILL.md"), "# Local\n\nLocal skill.", "utf-8");
+
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(
+      configPath,
+      `name: main
+imports:
+  - npm:@team/shared-skills
+
+skills:
+  atomic:
+    local-skill: ./skills/local-skill
+  composed:
+    combined:
+      compose:
+        - imported-skill
+        - local-skill
+      description: "Combines imported and local."
+`,
+      "utf-8"
+    );
+
+    const config = await loadConfig(configPath);
+    assert.ok("imported-skill" in config.skills, "imported skill should be present");
+    assert.ok("local-skill" in config.skills, "local skill should be present");
+    assert.ok("combined" in config.skills, "composed skill should be present");
+  });
+
+  it("loads config with npm: import using explicit subpath", async () => {
+    tmpDir = makeTmpDir();
+
+    // Create a mock npm package with a non-default config file
+    const pkgDir = join(tmpDir, "node_modules", "my-skills");
+    const skillDir = join(pkgDir, "skills", "special");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), '{"name":"my-skills","version":"1.0.0"}', "utf-8");
+    writeFileSync(
+      join(pkgDir, "custom.yaml"),
+      `name: custom
+skills:
+  atomic:
+    special: ./skills/special
+`,
+      "utf-8"
+    );
+    writeFileSync(join(skillDir, "SKILL.md"), "# Special\n\nSpecial skill.", "utf-8");
+
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(
+      configPath,
+      `name: main
+imports:
+  - npm:my-skills/custom.yaml
+
+skills:
+  atomic:
+    dummy: ./dummy
+`,
+      "utf-8"
+    );
+
+    const config = await loadConfig(configPath);
+    assert.ok("special" in config.skills, "skill from npm subpath import should be present");
+  });
+
+  it("throws ConfigError for missing npm package import", async () => {
+    tmpDir = makeTmpDir();
+
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(
+      configPath,
+      `name: broken
+imports:
+  - npm:@nonexistent/package
+
+skills:
+  atomic:
+    dummy: ./dummy
+`,
+      "utf-8"
+    );
+
+    await assert.rejects(
+      () => loadConfig(configPath),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /Cannot read npm imported config/);
+        assert.match(err.message, /npm:@nonexistent\/package/);
+        return true;
+      }
+    );
+  });
+
+  it("local override wins over npm import", async () => {
+    tmpDir = makeTmpDir();
+
+    // Create npm package with a skill
+    const pkgDir = join(tmpDir, "node_modules", "shared-pkg");
+    const pkgSkillDir = join(pkgDir, "skills", "my-skill");
+    mkdirSync(pkgSkillDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), '{"name":"shared-pkg","version":"1.0.0"}', "utf-8");
+    writeFileSync(
+      join(pkgDir, "skillfold.yaml"),
+      `name: shared
+skills:
+  atomic:
+    my-skill: ./skills/my-skill
+`,
+      "utf-8"
+    );
+    writeFileSync(join(pkgSkillDir, "SKILL.md"), "# From NPM", "utf-8");
+
+    // Create local override
+    const localDir = join(tmpDir, "skills", "my-skill");
+    mkdirSync(localDir, { recursive: true });
+    writeFileSync(join(localDir, "SKILL.md"), "# Local Override", "utf-8");
+
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(
+      configPath,
+      `name: main
+imports:
+  - npm:shared-pkg
+
+skills:
+  atomic:
+    my-skill: ./skills/my-skill
+`,
+      "utf-8"
+    );
+
+    const config = await loadConfig(configPath);
+    // Local skill should resolve to local path, not the npm-imported one
+    const skill = config.skills["my-skill"];
+    assert.ok("path" in skill);
+    assert.equal(skill.path, "./skills/my-skill");
+  });
+
+  it("merges state from npm import", async () => {
+    tmpDir = makeTmpDir();
+
+    const pkgDir = join(tmpDir, "node_modules", "shared-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), '{"name":"shared-pkg","version":"1.0.0"}', "utf-8");
+    writeFileSync(
+      join(pkgDir, "skillfold.yaml"),
+      `name: shared
+skills:
+  atomic:
+    dummy: ./dummy
+state:
+  SharedType:
+    score: number
+  shared-field:
+    type: string
+`,
+      "utf-8"
+    );
+
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(
+      configPath,
+      `name: main
+imports:
+  - npm:shared-pkg
+
+skills:
+  atomic:
+    local: ./local
+state:
+  local-field:
+    type: string
+`,
+      "utf-8"
+    );
+
+    const config = await loadConfig(configPath);
+    assert.ok(config.state, "merged config should have state");
+    assert.ok("SharedType" in config.state.types, "imported custom type should be present");
+    assert.ok("shared-field" in config.state.fields, "imported state field should be present");
+    assert.ok("local-field" in config.state.fields, "local state field should be present");
+  });
+});
+
+describe("npm: skill resolution", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("resolves atomic skill with npm: path", async () => {
+    tmpDir = makeTmpDir();
+
+    // Create npm package with a skill directory
+    const pkgDir = join(tmpDir, "node_modules", "@team", "shared-skills");
+    const skillDir = join(pkgDir, "skills", "planning");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), '{"name":"@team/shared-skills","version":"1.0.0"}', "utf-8");
+    writeFileSync(join(skillDir, "SKILL.md"), "# Planning\n\nPlan carefully.", "utf-8");
+
+    const config: Config = {
+      name: "test",
+      skills: {
+        planning: { path: "npm:@team/shared-skills/skills/planning" },
+      },
+    };
+
+    const bodies = await resolveSkills(config, tmpDir);
+    assert.equal(bodies.size, 1);
+    assert.equal(bodies.get("planning"), "# Planning\n\nPlan carefully.");
+  });
+
+  it("throws ResolveError for missing npm skill directory", async () => {
+    tmpDir = makeTmpDir();
+
+    const config: Config = {
+      name: "test",
+      skills: {
+        ghost: { path: "npm:@nonexistent/package/skills/ghost" },
+      },
+    };
+
+    await assert.rejects(
+      () => resolveSkills(config, tmpDir!),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /Directory not found/);
+        assert.match(err.message, /ghost/);
+        return true;
+      }
+    );
+  });
+
+  it("throws ResolveError for npm skill directory without SKILL.md", async () => {
+    tmpDir = makeTmpDir();
+
+    // Create the directory but without SKILL.md
+    const skillDir = join(tmpDir, "node_modules", "my-pkg", "skills", "empty");
+    mkdirSync(skillDir, { recursive: true });
+
+    const config: Config = {
+      name: "test",
+      skills: {
+        empty: { path: "npm:my-pkg/skills/empty" },
+      },
+    };
+
+    await assert.rejects(
+      () => resolveSkills(config, tmpDir!),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /SKILL\.md not found/);
+        assert.match(err.message, /empty/);
+        return true;
+      }
+    );
+  });
+
+  it("strips frontmatter from npm skill body", async () => {
+    tmpDir = makeTmpDir();
+
+    const pkgDir = join(tmpDir, "node_modules", "skills-pkg");
+    const skillDir = join(pkgDir, "skills", "review");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), '{"name":"skills-pkg","version":"1.0.0"}', "utf-8");
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---
+name: review
+description: Reviews code.
+---
+
+# Code Review
+
+Review the code carefully.
+`,
+      "utf-8"
+    );
+
+    const config: Config = {
+      name: "test",
+      skills: {
+        review: { path: "npm:skills-pkg/skills/review" },
+      },
+    };
+
+    const bodies = await resolveSkills(config, tmpDir);
+    const body = bodies.get("review")!;
+    assert.ok(!body.includes("---"), "Body should not contain frontmatter delimiters");
+    assert.ok(body.includes("# Code Review"), "Body should contain the markdown content");
+  });
+
+  it("npm: paths are not rebased during import", async () => {
+    tmpDir = makeTmpDir();
+
+    // Create npm package with a skill that has an npm: path in its imported config
+    const pkgDir = join(tmpDir, "node_modules", "base-pkg");
+    const pkgSkillDir = join(pkgDir, "skills", "core");
+    mkdirSync(pkgSkillDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), '{"name":"base-pkg","version":"1.0.0"}', "utf-8");
+    writeFileSync(
+      join(pkgDir, "skillfold.yaml"),
+      `name: base
+skills:
+  atomic:
+    core: npm:base-pkg/skills/core
+`,
+      "utf-8"
+    );
+    writeFileSync(join(pkgSkillDir, "SKILL.md"), "# Core\n\nCore skill.", "utf-8");
+
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(
+      configPath,
+      `name: main
+imports:
+  - npm:base-pkg
+
+skills:
+  atomic:
+    local: ./local
+`,
+      "utf-8"
+    );
+
+    const config = await loadConfig(configPath);
+    const coreSkill = config.skills["core"];
+    assert.ok("path" in coreSkill);
+    // npm: paths should be preserved as-is, not rebased
+    assert.equal(coreSkill.path, "npm:base-pkg/skills/core");
+  });
+});

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,0 +1,69 @@
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+const NPM_PREFIX = "npm:";
+
+export function isNpmRef(ref: string): boolean {
+  return ref.startsWith(NPM_PREFIX);
+}
+
+export function parseNpmRef(ref: string): { packageName: string; subpath: string } {
+  const raw = ref.slice(NPM_PREFIX.length);
+  // Handle scoped packages: @scope/pkg/sub/path
+  if (raw.startsWith("@")) {
+    const parts = raw.split("/");
+    if (parts.length < 2) {
+      return { packageName: raw, subpath: "" };
+    }
+    const packageName = parts.slice(0, 2).join("/");
+    const subpath = parts.slice(2).join("/");
+    return { packageName, subpath };
+  }
+  // Unscoped: pkg/sub/path
+  const slashIndex = raw.indexOf("/");
+  if (slashIndex === -1) return { packageName: raw, subpath: "" };
+  return { packageName: raw.slice(0, slashIndex), subpath: raw.slice(slashIndex + 1) };
+}
+
+/**
+ * Resolve the root directory of an npm package using Node's module resolution.
+ * Falls back to a direct node_modules lookup if require.resolve fails.
+ */
+export function resolveNpmPackageDir(packageName: string, baseDir: string): string {
+  const directPath = join(baseDir, "node_modules", packageName);
+  try {
+    const require = createRequire(join(baseDir, "package.json"));
+    const pkgJsonPath = require.resolve(`${packageName}/package.json`);
+    return dirname(pkgJsonPath);
+  } catch {
+    // Fall back to direct path (let the caller handle file-not-found)
+    return directPath;
+  }
+}
+
+/**
+ * Resolve an npm: import reference to a local file path.
+ * - `npm:pkg` -> node_modules/pkg/skillfold.yaml
+ * - `npm:pkg/custom.yaml` -> node_modules/pkg/custom.yaml
+ * - `npm:@scope/pkg` -> node_modules/@scope/pkg/skillfold.yaml
+ * - `npm:@scope/pkg/custom.yaml` -> node_modules/@scope/pkg/custom.yaml
+ */
+export function resolveNpmImportPath(ref: string, baseDir: string): string {
+  const { packageName, subpath } = parseNpmRef(ref);
+  const pkgDir = resolveNpmPackageDir(packageName, baseDir);
+  if (subpath) return join(pkgDir, subpath);
+  return join(pkgDir, "skillfold.yaml");
+}
+
+/**
+ * Resolve an npm: skill reference to a local directory path.
+ * - `npm:pkg/skills/planning` -> node_modules/pkg/skills/planning
+ * - `npm:@scope/pkg/skills/planning` -> node_modules/@scope/pkg/skills/planning
+ * - `npm:pkg` -> node_modules/pkg (package root)
+ */
+export function resolveNpmSkillPath(ref: string, baseDir: string): string {
+  const { packageName, subpath } = parseNpmRef(ref);
+  const pkgDir = resolveNpmPackageDir(packageName, baseDir);
+  if (subpath) return join(pkgDir, subpath);
+  return pkgDir;
+}

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -3,6 +3,7 @@ import { join, resolve } from "node:path";
 
 import { type Config, isAtomic } from "./config.js";
 import { ResolveError } from "./errors.js";
+import { isNpmRef, resolveNpmSkillPath } from "./npm.js";
 import { fetchRemoteSkill } from "./remote.js";
 
 export function stripFrontmatter(content: string): string {
@@ -34,7 +35,9 @@ export async function resolveSkills(
       continue;
     }
 
-    const skillDir = resolve(baseDir, skill.path);
+    const skillDir = isNpmRef(skill.path)
+      ? resolveNpmSkillPath(skill.path, baseDir)
+      : resolve(baseDir, skill.path);
     const skillFile = join(skillDir, "SKILL.md");
 
     if (!existsSync(skillDir)) {


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `npm:` prefix support for skill references and imports, resolving packages via Node's `createRequire` with a direct `node_modules` fallback
- Support scoped (`npm:@team/shared-skills`) and unscoped (`npm:my-package`) packages, with optional subpaths for specific files or skill directories
- Update JSON schema descriptions to document the new `npm:` prefix option

## Details

New `src/npm.ts` module provides four utilities:
- `isNpmRef()` - detect `npm:` prefixed strings
- `parseNpmRef()` - split into package name and subpath (handles scoped packages)
- `resolveNpmImportPath()` - resolve import refs (bare package defaults to `skillfold.yaml`)
- `resolveNpmSkillPath()` - resolve skill refs to local directories

Integration points:
- `config.ts` - `resolveImports()` gains an `npm:` branch before the local path fallback; `rebaseSkillPaths()` preserves `npm:` paths (like `https://`)
- `resolver.ts` - `resolveSkills()` resolves `npm:` skill paths before the local directory lookup

### Usage

```yaml
imports:
  - npm:@team/shared-skills               # -> node_modules/@team/shared-skills/skillfold.yaml
  - npm:@team/shared-skills/custom.yaml   # -> specific file in package

skills:
  atomic:
    planning: npm:@team/shared-skills/skills/planning  # -> node_modules/.../skills/planning/SKILL.md
```

## Test plan

- [x] Unit tests for `parseNpmRef` with scoped/unscoped packages and various subpaths
- [x] Unit tests for `resolveNpmPackageDir`, `resolveNpmImportPath`, `resolveNpmSkillPath`
- [x] Integration tests: mock `node_modules` structure in temp dirs, verify `loadConfig` merges skills and state from npm imports
- [x] Error tests: missing npm package throws `ConfigError` with descriptive message
- [x] Override test: local skills win over npm-imported skills
- [x] Rebase test: `npm:` paths are preserved as-is during import rebasing
- [x] Resolver tests: `resolveSkills` reads SKILL.md from npm paths, strips frontmatter, errors on missing dirs
- [x] All 541 tests pass (33 new), type check clean

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)