### PR TITLE
feat: add `skillfold search` command for npm skill discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Configuration language and compiler for multi-agent AI pipelines. Compiles YAML 
 - **Validate config**: `npx tsx src/cli.ts validate`
 - **Check output is current**: `npx tsx src/cli.ts --check`
 - **List pipeline**: `npx tsx src/cli.ts list`
+- **Search npm skills**: `npx tsx src/cli.ts search [query]`
 - **Run with custom config**: `npx tsx src/cli.ts --config path.yaml --out-dir out/`
 - **Build**: `npm run build`
 - **Build plugin**: `npm run build:plugin`
@@ -36,6 +37,7 @@ src/
   orchestrator.ts - Orchestrator SKILL.md generation from graph definition
   plugin.ts       - Claude Code plugin packaging (skillfold plugin)
   list.ts         - Pipeline introspection (skillfold list)
+  search.ts       - npm registry search for skillfold-skill packages (skillfold search)
   watch.ts        - File watching and auto-recompile (skillfold watch)
   init.ts         - skillfold init scaffolding
   errors.ts       - ConfigError, ResolveError, CompileError, GraphError
@@ -160,7 +162,8 @@ Located in `library/examples/`:
 - Resolved location URLs in orchestrator state table output (base URL templates from skill resources)
 - Compiler warnings for implicit state locations (skills without resource declarations)
 - Sub-flow imports: flow nodes can reference external pipeline configs via `flow:` field, with recursive resolution, skill/state merging, circular reference detection, orchestrator rendering with hierarchical steps, and Mermaid visualization as subgraphs
-- Test suite with 508 tests across 95 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, watch, errors, subflow, and e2e modules
+- `skillfold search [query]` command for discovering skill packages on npm (searches for `skillfold-skill` keyword)
+- Test suite with 517 tests across 96 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, search, watch, errors, subflow, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -291,4 +291,5 @@ Skillfold also ships a built-in plugin with 11 generic skills. Install it by ref
 - Try parallel `map` to process lists of items concurrently
 - Add `skillfold --check` to CI to verify compiled output stays in sync
 - Use `skillfold plugin` to package your pipeline for distribution
+- Use `skillfold search` to discover community skill packages on npm
 - Set `GITHUB_TOKEN` to reference skills from private GitHub repositories

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ Commands:
   graph             Output Mermaid flowchart of the team flow
   watch             Compile and watch for changes
   plugin            Package compiled output as a Claude Code plugin
+  search [query]    Search npm for skillfold skill packages
   (default)         Compile the pipeline config
 
 Options:
@@ -44,7 +45,7 @@ Options:
 Templates: ${TEMPLATES.join(", ")}`);
 }
 
-type Command = "init" | "adopt" | "compile" | "graph" | "list" | "validate" | "watch" | "plugin";
+type Command = "init" | "adopt" | "compile" | "graph" | "list" | "validate" | "watch" | "plugin" | "search";
 
 interface Args {
   command: Command;
@@ -54,6 +55,7 @@ interface Args {
   dir: string;
   target: CompileTarget;
   template: string | undefined;
+  query: string | undefined;
   check: boolean;
   help: boolean;
   version: boolean;
@@ -67,6 +69,7 @@ function parseArgs(argv: string[]): Args {
   let dir = ".";
   let target: CompileTarget = "skill";
   let template: string | undefined;
+  let query: string | undefined;
   let checkMode = false;
   let help = false;
   let version = false;
@@ -100,6 +103,18 @@ function parseArgs(argv: string[]): Args {
   } else if (argv.length > 0 && argv[0] === "plugin") {
     command = "plugin";
     i = 1;
+  } else if (argv.length > 0 && argv[0] === "search") {
+    command = "search";
+    i = 1;
+    // Capture remaining non-flag args as search query
+    const queryParts: string[] = [];
+    while (i < argv.length && !argv[i].startsWith("-")) {
+      queryParts.push(argv[i]);
+      i++;
+    }
+    if (queryParts.length > 0) {
+      query = queryParts.join(" ");
+    }
   }
 
   for (; i < argv.length; i++) {
@@ -145,6 +160,7 @@ function parseArgs(argv: string[]): Args {
     dir: resolve(dir),
     target,
     template,
+    query,
     check: checkMode,
     help,
     version,
@@ -213,6 +229,12 @@ async function main(): Promise<void> {
       }
       throw err;
     }
+    return;
+  }
+
+  if (args.command === "search") {
+    const { searchSkills } = await import("./search.js");
+    await searchSkills(args.query);
     return;
   }
 

--- a/src/search.test.ts
+++ b/src/search.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { searchSkills } from "./search.js";
+
+// Capture console output
+function captureConsole(): { logs: string[]; errors: string[]; restore: () => void } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
+  console.error = (...args: unknown[]) => errors.push(args.join(" "));
+  return {
+    logs,
+    errors,
+    restore() {
+      console.log = origLog;
+      console.error = origError;
+    },
+  };
+}
+
+function makeFetchResponse(body: object, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+const sampleResults = {
+  objects: [
+    {
+      package: {
+        name: "skillfold-planning",
+        description: "Planning skills for AI agents",
+        version: "1.0.0",
+        keywords: ["skillfold-skill"],
+        links: { npm: "https://www.npmjs.com/package/skillfold-planning" },
+      },
+      score: { detail: { popularity: 0.5 } },
+    },
+    {
+      package: {
+        name: "skillfold-testing",
+        description: "Testing skills for AI agents",
+        version: "2.1.0",
+        keywords: ["skillfold-skill"],
+        links: { npm: "https://www.npmjs.com/package/skillfold-testing" },
+      },
+      score: { detail: { popularity: 0.3 } },
+    },
+  ],
+  total: 2,
+};
+
+describe("searchSkills", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalExit: typeof process.exit;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalExit = process.exit;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.exit = originalExit;
+  });
+
+  it("displays results from npm registry", async () => {
+    globalThis.fetch = async () => makeFetchResponse(sampleResults);
+    const out = captureConsole();
+
+    try {
+      await searchSkills();
+    } finally {
+      out.restore();
+    }
+
+    const text = out.logs.join("\n");
+    assert.ok(text.includes("Found 2 skills"));
+    assert.ok(text.includes("skillfold-planning"));
+    assert.ok(text.includes("v1.0.0"));
+    assert.ok(text.includes("Planning skills for AI agents"));
+    assert.ok(text.includes("skillfold-testing"));
+    assert.ok(text.includes("v2.1.0"));
+    assert.ok(text.includes("npm install <package>"));
+    assert.ok(text.includes("imports: [npm:<package>]"));
+  });
+
+  it("passes query parameter to npm search", async () => {
+    let calledUrl = "";
+    globalThis.fetch = async (input: string | URL | Request) => {
+      calledUrl = typeof input === "string" ? input : input.toString();
+      return makeFetchResponse(sampleResults);
+    };
+    const out = captureConsole();
+
+    try {
+      await searchSkills("planning");
+    } finally {
+      out.restore();
+    }
+
+    assert.ok(calledUrl.includes("keywords%3Askillfold-skill"));
+    assert.ok(calledUrl.includes("planning"));
+  });
+
+  it("displays singular 'skill' for one result", async () => {
+    const singleResult = {
+      objects: [sampleResults.objects[0]],
+      total: 1,
+    };
+    globalThis.fetch = async () => makeFetchResponse(singleResult);
+    const out = captureConsole();
+
+    try {
+      await searchSkills();
+    } finally {
+      out.restore();
+    }
+
+    const text = out.logs.join("\n");
+    assert.ok(text.includes("Found 1 skill:"));
+    assert.ok(!text.includes("Found 1 skills"));
+  });
+
+  it("shows message when no results found", async () => {
+    globalThis.fetch = async () =>
+      makeFetchResponse({ objects: [], total: 0 });
+    const out = captureConsole();
+
+    try {
+      await searchSkills();
+    } finally {
+      out.restore();
+    }
+
+    const text = out.logs.join("\n");
+    assert.ok(text.includes("No skillfold skills found"));
+  });
+
+  it("shows query in no-results message", async () => {
+    globalThis.fetch = async () =>
+      makeFetchResponse({ objects: [], total: 0 });
+    const out = captureConsole();
+
+    try {
+      await searchSkills("nonexistent");
+    } finally {
+      out.restore();
+    }
+
+    const text = out.logs.join("\n");
+    assert.ok(text.includes('No skillfold skills found matching "nonexistent"'));
+  });
+
+  it("handles network error", async () => {
+    let exitCode: number | undefined;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error("process.exit called");
+    }) as typeof process.exit;
+
+    globalThis.fetch = async () => {
+      throw new Error("network failure");
+    };
+    const out = captureConsole();
+
+    try {
+      await searchSkills();
+    } catch {
+      // Expected: process.exit mock throws
+    } finally {
+      out.restore();
+    }
+
+    assert.equal(exitCode, 1);
+    assert.ok(out.errors.join("\n").includes("could not reach npm registry"));
+  });
+
+  it("handles non-ok response", async () => {
+    let exitCode: number | undefined;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error("process.exit called");
+    }) as typeof process.exit;
+
+    globalThis.fetch = async () => makeFetchResponse({}, 503);
+    const out = captureConsole();
+
+    try {
+      await searchSkills();
+    } catch {
+      // Expected: process.exit mock throws
+    } finally {
+      out.restore();
+    }
+
+    assert.equal(exitCode, 1);
+    assert.ok(out.errors.join("\n").includes("npm registry returned 503"));
+  });
+
+  it("handles package with no description", async () => {
+    const noDesc = {
+      objects: [
+        {
+          package: {
+            name: "skillfold-bare",
+            description: "",
+            version: "0.1.0",
+            keywords: ["skillfold-skill"],
+            links: { npm: "https://www.npmjs.com/package/skillfold-bare" },
+          },
+          score: { detail: { popularity: 0.1 } },
+        },
+      ],
+      total: 1,
+    };
+    globalThis.fetch = async () => makeFetchResponse(noDesc);
+    const out = captureConsole();
+
+    try {
+      await searchSkills();
+    } finally {
+      out.restore();
+    }
+
+    const text = out.logs.join("\n");
+    assert.ok(text.includes("No description"));
+  });
+
+  it("uses correct npm search URL without query", async () => {
+    let calledUrl = "";
+    globalThis.fetch = async (input: string | URL | Request) => {
+      calledUrl = typeof input === "string" ? input : input.toString();
+      return makeFetchResponse({ objects: [], total: 0 });
+    };
+    const out = captureConsole();
+
+    try {
+      await searchSkills();
+    } finally {
+      out.restore();
+    }
+
+    assert.ok(calledUrl.startsWith("https://registry.npmjs.org/-/v1/search"));
+    assert.ok(calledUrl.includes("keywords%3Askillfold-skill"));
+    assert.ok(calledUrl.includes("size=25"));
+  });
+});

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,59 @@
+interface NpmPackage {
+  name: string;
+  description: string;
+  version: string;
+  keywords: string[];
+  links: { npm: string; homepage?: string };
+}
+
+interface NpmSearchResult {
+  objects: Array<{
+    package: NpmPackage;
+    score: { detail: { popularity: number } };
+  }>;
+  total: number;
+}
+
+export async function searchSkills(query?: string): Promise<void> {
+  const searchTerms = ["keywords:skillfold-skill", query]
+    .filter(Boolean)
+    .join("+");
+  const url = `https://registry.npmjs.org/-/v1/search?text=${encodeURIComponent(searchTerms)}&size=25`;
+
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch {
+    console.error("Error: could not reach npm registry");
+    process.exit(1);
+  }
+
+  if (!response.ok) {
+    console.error(`Error: npm registry returned ${response.status}`);
+    process.exit(1);
+  }
+
+  const data = (await response.json()) as NpmSearchResult;
+
+  if (data.total === 0 || data.objects.length === 0) {
+    console.log(
+      query
+        ? `No skillfold skills found matching "${query}"`
+        : "No skillfold skills found",
+    );
+    return;
+  }
+
+  console.log(
+    `\n  Found ${data.objects.length} skill${data.objects.length === 1 ? "" : "s"}:\n`,
+  );
+
+  for (const { package: pkg } of data.objects) {
+    const desc = pkg.description || "No description";
+    console.log(`  ${pkg.name}  v${pkg.version}`);
+    console.log(`    ${desc}\n`);
+  }
+
+  console.log("  Install: npm install <package>");
+  console.log("  Import:  imports: [npm:<package>]\n");
+}


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `skillfold search [query]` command that queries the npm registry for packages tagged with the `skillfold-skill` keyword
- Works from any directory without requiring a `skillfold.yaml` config file
- Displays package name, version, description, and install/import hints

Closes #293

## Changes

- **`src/search.ts`** - New module: fetches npm registry search API, formats and displays results, handles errors
- **`src/cli.ts`** - Add `search` to Command type, parse `search [query]` subcommand with positional args, wire up handler before config-dependent commands
- **`src/search.test.ts`** - 9 tests covering: results display, query passthrough, singular/plural, no results, network errors, non-ok responses, missing descriptions, URL construction
- **`CLAUDE.md`** - Add search to quick reference, project structure, and test counts (517 tests, 96 suites)
- **`docs/getting-started.md`** - Mention search in "Next steps"

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (517 tests, 96 suites, 0 failures)
- [x] Verified search command appears in `--help` output
- [ ] Manual test: `npx tsx src/cli.ts search` against live npm registry
- [ ] Manual test: `npx tsx src/cli.ts search planning` with query filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)