### PR TITLE
docs: add skill publishing guide for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Commands:
   graph             Output Mermaid flowchart of the team flow
   watch             Compile and watch for changes
   plugin            Package compiled output as a Claude Code plugin
+  search [query]    Discover skill packages on npm
   (default)         Compile the pipeline config
 
 Options:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -283,7 +283,24 @@ For Claude Code, `--target claude-code` generates agent markdown files alongside
 
 Skillfold also ships a built-in plugin with 11 generic skills. Install it by referencing `node_modules/skillfold/plugin/` from your Claude Code configuration.
 
-## 10. Next steps
+## 10. Sharing skills
+
+Once you have skills worth reusing across projects or teams, publish them to npm. Any skill directory or pipeline config can be packaged and shared.
+
+```bash
+npm publish
+```
+
+Consumers install your package and import it:
+
+```yaml
+imports:
+  - npm:@team/shared-skills
+```
+
+See the [Publishing Guide](publishing.md) for package structure, required fields, and discovery via `skillfold search`.
+
+## 11. Next steps
 
 - Read the full config specification in [BRIEF.md](../BRIEF.md)
 - Explore the [shared library examples](../library/examples/) for real pipeline patterns

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,93 @@
+# Publishing Skills to npm
+
+Skillfold uses npm as its package registry. Any skill or pipeline config can be published as a standard npm package - no separate registry or tooling required.
+
+## Package Structure
+
+A publishable skill package contains a `package.json`, an optional `skillfold.yaml` for importable pipeline configs, and one or more atomic skill directories:
+
+```
+my-skills/
+  package.json
+  skillfold.yaml         # pipeline config (optional, for importable configs)
+  skills/
+    planning/SKILL.md    # atomic skills
+    testing/SKILL.md
+```
+
+Each skill directory follows the standard layout: a directory containing a `SKILL.md` file with YAML frontmatter and instructions.
+
+## package.json
+
+Required fields for a publishable skill package:
+
+```json
+{
+  "name": "@team/shared-skills",
+  "version": "1.0.0",
+  "keywords": ["skillfold-skill"],
+  "description": "Shared planning and review skills",
+  "files": ["skillfold.yaml", "skills/"]
+}
+```
+
+- **name** - Standard npm package name. Scoped names (`@team/...`) are recommended for team-owned packages.
+- **keywords** - Must include `skillfold-skill`. This is what `skillfold search` uses to find packages on the registry.
+- **files** - Limits the published package to only the config and skill files. Keep the package small.
+
+## Publishing
+
+Publish like any npm package:
+
+```bash
+npm publish              # public package
+npm publish --access public   # first publish of a scoped package
+```
+
+If the package includes a `skillfold.yaml`, consumers can import the full config. If it only contains skill directories, consumers reference individual skills by path.
+
+## Using Published Skills
+
+Install the package, then reference it in your config:
+
+```bash
+npm install @team/shared-skills
+```
+
+Import the full config to get all skills and state:
+
+```yaml
+imports:
+  - npm:@team/shared-skills
+```
+
+Or reference individual skills directly:
+
+```yaml
+skills:
+  atomic:
+    planning: npm:@team/shared-skills/skills/planning
+```
+
+The `npm:` prefix resolves to the package's install path under `node_modules/`.
+
+## Discovery
+
+Search for published skill packages on npm:
+
+```bash
+skillfold search planning    # search by keyword
+skillfold search             # list all skillfold-skill packages
+```
+
+This queries the npm registry for packages with the `skillfold-skill` keyword and displays their name, description, and version.
+
+## Versioning
+
+Follow standard semver conventions:
+
+- **Patch** (1.0.1) - Fix typos, clarify instructions, no behavior change
+- **Minor** (1.1.0) - Add new skills, add optional state fields
+- **Major** (2.0.0) - Rename or remove skills, change state schema in breaking ways
+
+Consumers pin versions through their `package.json` as usual. Run `npm update` to pull in compatible updates.


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `docs/publishing.md` covering how to publish reusable skills as npm packages: package structure, required `package.json` fields, `npm:` prefix imports, discovery via `skillfold search`, and versioning conventions
- Add a "Sharing Skills" section to `docs/getting-started.md` linking to the publishing guide
- Add `search [query]` to the CLI command list in `README.md`

## Test plan

- [ ] Verify `docs/publishing.md` renders correctly on GitHub
- [ ] Verify the new section in `docs/getting-started.md` has a working relative link to `publishing.md`
- [ ] Verify the README CLI table aligns correctly with the new entry

Closes #294

Generated with [Claude Code](https://claude.com/claude-code)