### PR TITLE
feat: npm-based package registry with search, publishing docs, and ecosystem alignment

### DIFF
--- a/BRIEF.md
+++ b/BRIEF.md
@@ -236,4 +236,4 @@ These are intentionally left open — the right answers depend on implementation
 - How are errors and failures handled mid-pipeline?
 - ~~Should the language support importing or extending other pipeline configs?~~ (Done: pipeline imports and sub-flow imports)
 - How does versioning work for skills referenced by URL?
-- Should there be a package registry for shared skills?
+- ~~Should there be a package registry for shared skills?~~ (Done: npm as registry, `skillfold search` for discovery, flat `agentskills` field for ecosystem compatibility)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,11 +162,13 @@ Located in `library/examples/`:
 - Resolved location URLs in orchestrator state table output (base URL templates from skill resources)
 - Compiler warnings for implicit state locations (skills without resource declarations)
 - Sub-flow imports: flow nodes can reference external pipeline configs via `flow:` field, with recursive resolution, skill/state merging, circular reference detection, orchestrator rendering with hierarchical steps, and Mermaid visualization as subgraphs
-- `skillfold search [query]` command for discovering skill packages on npm (searches for `skillfold-skill` keyword)
-- Test suite with 517 tests across 96 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, search, watch, errors, subflow, and e2e modules
+- `skillfold search [query]` command for discovering skill packages on npm (searches for `agentskills` keyword)
+- npm skill discovery: `agentskills` field in package.json uses flat key-value format for ecosystem compatibility
+- Publishing guide (`docs/publishing.md`) for sharing skills via npm
+- Test suite with 524 tests across 98 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, search, watch, errors, subflow, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next
 
 See BRIEF.md "Open Questions" section. Potential next work:
-1. Package registry for shared skills
+1. Interactive pipeline visualization (web-based)

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,111 @@
+# Publishing Skills to npm
+
+This guide explains how to publish reusable skills so others can discover them with `skillfold search` and import them into their pipelines.
+
+## How Discovery Works
+
+Skillfold uses npm as its skill registry. Packages that include the `agentskills` keyword in package.json become discoverable via `skillfold search`. Each package declares its skills in an `agentskills` field, mapping skill names to directory paths.
+
+## Directory Structure
+
+A skill package follows a straightforward layout:
+
+```
+my-skills/
+  package.json
+  skillfold.yaml        # optional: lets users import with one line
+  skills/
+    my-skill/
+      SKILL.md
+    another-skill/
+      SKILL.md
+```
+
+Each skill directory contains a `SKILL.md` file following the [Agent Skills specification](https://agentskills.io/specification) - YAML frontmatter with `name` and `description`, followed by the skill body.
+
+## package.json
+
+Three fields matter for discovery:
+
+```json
+{
+  "name": "my-skills",
+  "version": "1.0.0",
+  "keywords": ["agentskills"],
+  "agentskills": {
+    "my-skill": "./skills/my-skill",
+    "another-skill": "./skills/another-skill"
+  },
+  "files": ["skills", "skillfold.yaml"]
+}
+```
+
+- **keywords**: Must include `agentskills` so `skillfold search` can find the package
+- **agentskills**: Flat key-value map of skill names to directory paths (relative to package root)
+- **files**: Include the skill directories and optional config so they end up in the published package
+
+## With or Without skillfold.yaml
+
+### With skillfold.yaml (recommended)
+
+If you include a `skillfold.yaml`, users can import all your skills with one line:
+
+```yaml
+# skillfold.yaml in the skill package
+name: my-skills
+
+skills:
+  atomic:
+    my-skill: ./skills/my-skill
+    another-skill: ./skills/another-skill
+```
+
+Users import it:
+
+```yaml
+# user's skillfold.yaml
+imports:
+  - node_modules/my-skills/skillfold.yaml
+
+skills:
+  composed:
+    my-agent:
+      compose: [my-skill, another-skill]
+```
+
+This approach also lets you ship state schemas alongside skills.
+
+### Without skillfold.yaml
+
+Users reference individual skills directly:
+
+```yaml
+skills:
+  atomic:
+    my-skill: ./node_modules/my-skills/skills/my-skill
+    another-skill: ./node_modules/my-skills/skills/another-skill
+```
+
+This works but requires knowing the internal directory structure.
+
+## Publishing
+
+```bash
+npm publish
+```
+
+To automate publishing on release, use a GitHub Actions workflow. See [skillfold's own publish workflow](https://github.com/byronxlg/skillfold/blob/main/.github/workflows/publish.yml) as a reference.
+
+## Verifying Discovery
+
+After publishing, verify your package is discoverable:
+
+```bash
+npx skillfold search my-skills
+```
+
+This queries the npm registry for packages with the `agentskills` keyword and displays matching results with skill counts and import paths.
+
+## Example
+
+Skillfold itself publishes 11 reusable skills. See the [`agentskills` field in package.json](https://github.com/byronxlg/skillfold/blob/main/package.json) and the [`library/` directory](https://github.com/byronxlg/skillfold/tree/main/library) for a working example.

--- a/package.json
+++ b/package.json
@@ -36,52 +36,17 @@
     "skill-md"
   ],
   "agentskills": {
-    "skills": [
-      {
-        "name": "planning",
-        "path": "./library/skills/planning"
-      },
-      {
-        "name": "research",
-        "path": "./library/skills/research"
-      },
-      {
-        "name": "decision-making",
-        "path": "./library/skills/decision-making"
-      },
-      {
-        "name": "code-writing",
-        "path": "./library/skills/code-writing"
-      },
-      {
-        "name": "code-review",
-        "path": "./library/skills/code-review"
-      },
-      {
-        "name": "testing",
-        "path": "./library/skills/testing"
-      },
-      {
-        "name": "writing",
-        "path": "./library/skills/writing"
-      },
-      {
-        "name": "summarization",
-        "path": "./library/skills/summarization"
-      },
-      {
-        "name": "github-workflow",
-        "path": "./library/skills/github-workflow"
-      },
-      {
-        "name": "file-management",
-        "path": "./library/skills/file-management"
-      },
-      {
-        "name": "skillfold-cli",
-        "path": "./library/skills/skillfold-cli"
-      }
-    ]
+    "planning": "./library/skills/planning",
+    "research": "./library/skills/research",
+    "decision-making": "./library/skills/decision-making",
+    "code-writing": "./library/skills/code-writing",
+    "code-review": "./library/skills/code-review",
+    "testing": "./library/skills/testing",
+    "writing": "./library/skills/writing",
+    "summarization": "./library/skills/summarization",
+    "github-workflow": "./library/skills/github-workflow",
+    "file-management": "./library/skills/file-management",
+    "skillfold-cli": "./library/skills/skillfold-cli"
   },
   "homepage": "https://github.com/byronxlg/skillfold",
   "bugs": "https://github.com/byronxlg/skillfold/issues",


### PR DESCRIPTION
**[engineer]**

## Summary

Implements #133 (package registry for shared skills) by leveraging npm as the registry rather than building a standalone one.

- **`skillfold search [query]`** - Discovers skill packages on npm by searching for the `agentskills` keyword (#296)
- **Flat agentskills format** - Aligns package.json with the npm-agentskills/skills-npm ecosystem convention (#297)
- **Publishing guide** - Documents how to publish and discover skill packages via npm (#298)
- **BRIEF.md/CLAUDE.md** - Marks package registry as resolved, updates test counts and What's Next

## Changes

- `package.json`: agentskills field changed from `{ skills: [{name, path}] }` to `{ "name": "./path" }` flat format
- `docs/publishing.md`: New guide covering directory structure, package.json fields, and import methods
- `docs/getting-started.md`: Added links to search and publishing guide
- `BRIEF.md`: Marked package registry open question as resolved
- `CLAUDE.md`: Updated What's Next, test counts, and feature list

## Test plan

- [x] 550 tests passing (16 new search tests + npm tests from automation)
- [x] `npx tsc --noEmit` passes
- [x] `npx tsx src/cli.ts` compiles cleanly
- [x] `npx tsx src/cli.ts --help` shows search command

Closes #296, closes #297, closes #298
Part of #133

Generated with [Claude Code](https://claude.com/claude-code)