### PR TITLE
chore: update stale references, document npm features, bump v1.10.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,4 +174,4 @@ Located in `library/examples/`:
 ## What's Next
 
 See BRIEF.md "Open Questions" section. Potential next work:
-1. Interactive pipeline visualization (web-based)
+1. Features driven by user demand

--- a/README.md
+++ b/README.md
@@ -373,14 +373,16 @@ composed:
 
 ### Remote Skills and Imports
 
-Reference skills by GitHub URL or import them from other configs. Team flows stay local.
+Reference skills by GitHub URL, npm package, or import them from other configs. Team flows stay local.
 
 ```yaml
 skills:
   atomic:
     shared: https://github.com/org/repo/tree/main/skills/shared
+    planning: npm:skillfold-skill-planning    # resolve from npm package
 imports:
-  - node_modules/skillfold/library/skillfold.yaml
+  - npm:skillfold/library/skillfold.yaml      # npm: prefix (preferred)
+  - node_modules/skillfold/library/skillfold.yaml  # direct path (also works)
 ```
 
 > [!TIP]

--- a/docs/awesome-claude-code-submission.md
+++ b/docs/awesome-claude-code-submission.md
@@ -72,7 +72,7 @@ CI integration: ships a reusable GitHub Action (`action.yml`) that verifies comp
 
 11 library skills (planning, research, code-writing, testing, etc.) are discoverable via `npx skills add byronxlg/skillfold`.
 
-Single dependency (`yaml`), 508 tests across 95 suites, Node 20+.
+Single dependency (`yaml`), 550 tests across 103 suites, Node 20+.
 
 ---
 
@@ -86,7 +86,7 @@ pre-runs that evaluation against skillfold and documents the results.
 
 | Dimension | What it checks | Assessment |
 |---|---|---|
-| Code quality | Structure, readability, correctness, consistency | Pass - TypeScript strict mode, ESM, consistent conventions, 508 tests |
+| Code quality | Structure, readability, correctness, consistency | Pass - TypeScript strict mode, ESM, consistent conventions, 550 tests |
 | Security / safety | Implicit execution, file/network access, credentials | Pass - Pure compiler, no hooks, no persistent state, no credential storage |
 | Documentation / transparency | Docs match implementation, side effects disclosed | Pass - README, getting-started guide, integration guide, JSON Schema |
 | Functionality / scope | Does what it claims, breadth of features | Pass - Compiles YAML to SKILL.md and Claude Code agents as advertised |
@@ -152,7 +152,7 @@ and the documentation accurately describes what the tool does.
   stored or logged.
 - **Single dependency** - The only runtime dependency is `yaml` (YAML parser).
   No transitive dependency tree to audit.
-- **508 tests** across 95 suites, run with `node:test` (zero test framework
+- **550 tests** across 95 suites, run with `node:test` (zero test framework
   dependencies).
 - **MIT license**, clearly stated in LICENSE and package.json.
 - **CI on Node 20 + 22** via GitHub Actions, with `--check` flag for verifying

--- a/docs/awesome-claude-code-submission.md
+++ b/docs/awesome-claude-code-submission.md
@@ -152,7 +152,7 @@ and the documentation accurately describes what the tool does.
   stored or logged.
 - **Single dependency** - The only runtime dependency is `yaml` (YAML parser).
   No transitive dependency tree to audit.
-- **550 tests** across 95 suites, run with `node:test` (zero test framework
+- **550 tests** across 103 suites, run with `node:test` (zero test framework
   dependencies).
 - **MIT license**, clearly stated in LICENSE and package.json.
 - **CI on Node 20 + 22** via GitHub Actions, with `--check` flag for verifying

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillfold",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Compiler for multi-agent AI pipelines. Compose skills, wire team flows, generate orchestrators.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/skillfold-context/SKILL.md
+++ b/skills/skillfold-context/SKILL.md
@@ -58,8 +58,8 @@ The codebase is TypeScript (strict, ESM modules). Key modules:
 
 ## What's Implemented
 
-All compiler features are working: skill composition with atomic/composed sub-sections, state schema, flow validation, map subgraph validation, when-clause parsing, orchestrator generation, spec-compliant output, URL-based skill references (with private repo auth via GITHUB_TOKEN), pipeline imports, graph visualization with full composition lineage, `skillfold init`, `skillfold adopt`, `skillfold validate`, `skillfold list`, `--check` for CI integration, async flow nodes for external agents, resource namespace declarations with compile-time location path validation, and sub-flow imports for nested pipeline composition. Published on npm as `skillfold`. 508 tests across 95 suites, CI on GitHub Actions. The project self-hosts its own dev team via `skillfold.yaml`.
+All compiler features are working: skill composition with atomic/composed sub-sections, state schema, flow validation, map subgraph validation, when-clause parsing, orchestrator generation, spec-compliant output, URL-based skill references (with private repo auth via GITHUB_TOKEN), pipeline imports, graph visualization with full composition lineage, `skillfold init`, `skillfold adopt`, `skillfold validate`, `skillfold list`, `--check` for CI integration, async flow nodes for external agents, resource namespace declarations with compile-time location path validation, sub-flow imports for nested pipeline composition, npm skill search (`skillfold search`), `npm:` prefix resolution for skill imports, and skill publishing guide. Published on npm as `skillfold`. 550 tests across 103 suites, CI on GitHub Actions. The project self-hosts its own dev team via `skillfold.yaml`.
 
 ## What's Next
 
-Package registry for shared skills and features driven by user demand.
+Features driven by user demand.


### PR DESCRIPTION
**[engineer]**

## Summary

- Update test counts from 508/95 to 550/103 in skillfold-context SKILL.md and awesome-claude-code submission
- Add `npm:` prefix syntax example to README's Remote Skills and Imports section
- Add npm search, `npm:` prefix resolution, and skill publishing guide to skillfold-context "What's Implemented"
- Update "What's Next" in CLAUDE.md and skillfold-context (package registry is shipped)
- Bump version from 1.9.0 to 1.10.0 in package.json

## Test plan

- [x] `npx tsx src/cli.ts` compiles without errors
- [x] `npm test` passes all 550 tests across 103 suites

Closes #304