### PR TITLE
docs: add skills CLI integration guide and README comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Think of it like TypeScript for agent pipelines. TypeScript doesn't replace Java
 
 That coordination layer is what skillfold provides.
 
+Skill management tools like the [skills CLI](https://skills.sh) handle installing and updating individual SKILL.md files. Skillfold handles what comes after: composing multiple skills into coherent agents, declaring what each agent reads and writes, and validating the entire pipeline at compile time. You can use both together - reference your existing skills by path or GitHub URL, and skillfold composes and validates them.
+
 ---
 
 ## Already Using Claude Code?

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -115,6 +115,65 @@ Add `skillfold --check` to your CI pipeline to verify compiled output stays in s
 
 This exits with code 1 if the compiled output is stale, catching cases where someone edits the config but forgets to recompile.
 
+## Working with the Skills CLI
+
+If you already manage individual skills with the [skills CLI](https://skills.sh) (`npx skills add`), skillfold sits one layer above it. The skills CLI installs and updates individual SKILL.md files. Skillfold composes multiple skills into agents, adds typed state schemas, and validates execution flows at compile time. They're complementary.
+
+### Before: individual skills, managed separately
+
+```
+~/.agents/skills/
+  code-review/SKILL.md
+  planning/SKILL.md
+  testing/SKILL.md
+  code-writing/SKILL.md
+```
+
+Each agent references skills independently. No shared schema, no flow validation.
+
+### After: composed agents with typed coordination
+
+```yaml
+# skillfold.yaml
+skills:
+  atomic:
+    code-review: https://github.com/your-org/agent-skills/tree/main/skills/code-review
+    planning: ./skills/planning
+    testing: ./skills/testing
+    code-writing: ./skills/code-writing
+  composed:
+    engineer:
+      compose: [planning, code-writing, testing]
+    reviewer:
+      compose: [code-review, testing]
+
+state:
+  review: { type: Review }
+  Review: { approved: bool, feedback: string }
+
+team:
+  flow:
+    - engineer:
+        writes: [state.code]
+      then: reviewer
+    - reviewer:
+        reads: [state.code]
+        writes: [state.review]
+      then:
+        - when: review.approved == true
+          to: end
+        - when: review.approved == false
+          to: engineer
+```
+
+Compile to your existing skills directory:
+
+```bash
+npx skillfold --out-dir ~/.agents/skills
+```
+
+The compiled output is standard SKILL.md files, so it slots directly into your `~/.agents/` structure. Existing skills you reference by GitHub URL are fetched and composed at build time.
+
 ## Multiple Platforms
 
 If your team uses different platforms, compile to each target:

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -148,6 +148,7 @@ skills:
       compose: [code-review, testing]
 
 state:
+  code: { type: string }
   review: { type: Review }
   Review: { approved: bool, feedback: string }
 


### PR DESCRIPTION
**[engineer]**

## Summary

- Adds "Working with the skills CLI" section to `docs/integrations.md` with a before/after showing how individual skills become composed agents with typed coordination
- Adds skills management comparison paragraph to README's "How Is This Different?" section explaining the complementary relationship

## Context

PaulRBerg (2k followers, Sablier Labs co-founder) opened [dot-agents#58](https://github.com/PaulRBerg/dot-agents/issues/58) to explore skillfold. He manages ~30 skills via the Vercel `skills` CLI. Current docs assume fresh start or existing Claude Code agents - neither addresses users from the skills CLI ecosystem.

Closes #315, closes #316