### PR TITLE
ci: harden smoke tests and clean stale artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm test
       - run: npx tsx src/cli.ts && npx tsx src/cli.ts --check
-      - run: npm run build && node dist/cli.js --version
+      - run: npm run build && node dist/cli.js --check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm test
       - run: npm run build
-      - run: node dist/cli.js --version
+      - run: node dist/cli.js --check
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**[engineer]**

## Summary

- Replace `node dist/cli.js --version` with `node dist/cli.js --check` in both `ci.yml` and `publish.yml` so the built binary exercises the full compile pipeline instead of just printing the version string
- In `publish.yml`, the `--check` step runs after `npm run build` and before `npm publish`, catching compile failures before a broken package reaches npm

## Stale artifact cleanup (#321)

The following gitignored filesystem artifacts should be deleted manually:

- `.claude/logs/cron-build.log` - contains error referencing a nonexistent script (`/Users/byron/repos/skillfold/.claude/skills/cron-build/cron-build.sh: No such file or directory`)
- `.claude/worktrees/agent-a1271109/` - orphaned worktree directory with a leftover `test-frontmatter.ts` file (not a registered git worktree)

These are gitignored by the `.claude/*` rule and cannot be committed. To clean up:

```sh
rm .claude/logs/cron-build.log
rm -rf .claude/worktrees/agent-a1271109/
```

## Test plan

- [x] `npm test` - 559 tests pass
- [x] `npx tsc --noEmit` - type checking passes
- [x] No source code changes (only workflow files modified)

Refs: #319
Closes #320, closes #321