### PR TITLE
feat: add dashed-border styling for async nodes in Mermaid output

### DIFF
--- a/src/visualize.test.ts
+++ b/src/visualize.test.ts
@@ -482,8 +482,9 @@ describe("generateMermaid", () => {
     );
     const output = generateMermaid(config);
     // Async nodes use stadium shape: ([name])
-    assert.ok(output.includes("owner([owner])"));
+    assert.ok(output.includes("owner([owner]):::async"));
     assert.ok(output.includes("owner -->"));
+    assert.ok(output.includes("classDef async stroke-dasharray: 5 5"));
   });
 
   it("renders async node with writes as edge label", () => {
@@ -497,8 +498,9 @@ describe("generateMermaid", () => {
     };
     const config = atomicConfig([asyncNode], []);
     const output = generateMermaid(config);
-    assert.ok(output.includes("ci([ci])"));
+    assert.ok(output.includes("ci([ci]):::async"));
     assert.ok(output.includes("|\"status\"|"));
+    assert.ok(output.includes("classDef async stroke-dasharray: 5 5"));
   });
 
   it("renders async node followed by step node with fall-through", () => {
@@ -514,9 +516,18 @@ describe("generateMermaid", () => {
       ["processor"],
     );
     const output = generateMermaid(config);
-    assert.ok(output.includes("external([external])"));
+    assert.ok(output.includes("external([external]):::async"));
     assert.ok(output.includes("external -->"));
     assert.ok(output.includes("processor"));
+    assert.ok(output.includes("classDef async stroke-dasharray: 5 5"));
+  });
+  it("does not emit async classDef when no async nodes exist", () => {
+    const config = atomicConfig(
+      [step("alpha", { then: "beta" }), step("beta")],
+      ["alpha", "beta"],
+    );
+    const output = generateMermaid(config);
+    assert.ok(!output.includes("classDef async"));
   });
 });
 

--- a/src/visualize.ts
+++ b/src/visualize.ts
@@ -147,7 +147,7 @@ function renderNodes(
     } else if (isAsyncNode(node)) {
       // Async nodes render with stadium shape ([name])
       const currentId = sanitizeId(node.name);
-      lines.push(`${indent}${currentId}([${node.name}])`);
+      lines.push(`${indent}${currentId}([${node.name}]):::async`);
 
       if (node.then !== undefined) {
         renderThen(
@@ -260,6 +260,15 @@ function renderNodes(
   }
 }
 
+function hasAsyncNodes(nodes: GraphNode[]): boolean {
+  for (const node of nodes) {
+    if (isAsyncNode(node)) return true;
+    if (isMapNode(node) && hasAsyncNodes(node.graph)) return true;
+    if (isSubFlowNode(node) && node.graph && hasAsyncNodes(node.graph)) return true;
+  }
+  return false;
+}
+
 export function generateMermaid(config: Config): string {
   const lines: string[] = ["graph TD"];
   renderNodes(
@@ -269,6 +278,9 @@ export function generateMermaid(config: Config): string {
     "end_node",
     config.skills,
   );
+  if (hasAsyncNodes(config.team!.flow.nodes)) {
+    lines.push("    classDef async stroke-dasharray: 5 5");
+  }
   return lines.join("\n") + "\n";
 }
 


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `:::async` class suffix to async nodes in Mermaid graph output
- Emit `classDef async stroke-dasharray: 5 5` footer when async nodes present
- Async nodes now render with dashed borders, visually distinguishing external agents

## Changes

- `src/visualize.ts`: Add `hasAsyncNodes()` helper, append `:::async` class to async node rendering, conditionally emit classDef
- `src/visualize.test.ts`: Update 3 existing tests, add 1 new test (560 total)

## Test plan

- [x] All 560 tests pass
- [x] Async nodes get `:::async` class in output
- [x] `classDef` line emitted only when async nodes present
- [x] No `classDef` emitted for graphs without async nodes

Closes #323