### PR TITLE
feat: add dashed-border styling for async nodes in Mermaid output

### DIFF
--- a/src/visualize.test.ts
+++ b/src/visualize.test.ts
@@ -467,7 +467,7 @@ describe("generateMermaid", () => {
     assert.ok(output.includes('top_unique["unique"]'));
   });
 
-  it("renders async nodes with stadium shape", () => {
+  it("renders async nodes with stadium shape and dashed-border class", () => {
     const asyncNode: AsyncNode = {
       name: "owner",
       async: true,
@@ -481,9 +481,11 @@ describe("generateMermaid", () => {
       ["worker"],
     );
     const output = generateMermaid(config);
-    // Async nodes use stadium shape: ([name])
-    assert.ok(output.includes("owner([owner])"));
+    // Async nodes use stadium shape with :::async class
+    assert.ok(output.includes("owner([owner]):::async"));
     assert.ok(output.includes("owner -->"));
+    // classDef footer emitted when async nodes exist
+    assert.ok(output.includes("classDef async stroke-dasharray: 5 5"));
   });
 
   it("renders async node with writes as edge label", () => {
@@ -497,8 +499,9 @@ describe("generateMermaid", () => {
     };
     const config = atomicConfig([asyncNode], []);
     const output = generateMermaid(config);
-    assert.ok(output.includes("ci([ci])"));
+    assert.ok(output.includes("ci([ci]):::async"));
     assert.ok(output.includes("|\"status\"|"));
+    assert.ok(output.includes("classDef async stroke-dasharray: 5 5"));
   });
 
   it("renders async node followed by step node with fall-through", () => {
@@ -514,9 +517,19 @@ describe("generateMermaid", () => {
       ["processor"],
     );
     const output = generateMermaid(config);
-    assert.ok(output.includes("external([external])"));
+    assert.ok(output.includes("external([external]):::async"));
     assert.ok(output.includes("external -->"));
     assert.ok(output.includes("processor"));
+    assert.ok(output.includes("classDef async stroke-dasharray: 5 5"));
+  });
+
+  it("does not emit classDef async when no async nodes exist", () => {
+    const config = atomicConfig([
+      step("alpha", { then: "bravo" }),
+      step("bravo"),
+    ]);
+    const output = generateMermaid(config);
+    assert.ok(!output.includes("classDef async"));
   });
 });
 

--- a/src/visualize.ts
+++ b/src/visualize.ts
@@ -145,9 +145,9 @@ function renderNodes(
         }
       }
     } else if (isAsyncNode(node)) {
-      // Async nodes render with stadium shape ([name])
+      // Async nodes render with stadium shape ([name]) and dashed-border class
       const currentId = sanitizeId(node.name);
-      lines.push(`${indent}${currentId}([${node.name}])`);
+      lines.push(`${indent}${currentId}([${node.name}]):::async`);
 
       if (node.then !== undefined) {
         renderThen(
@@ -260,6 +260,16 @@ function renderNodes(
   }
 }
 
+// Check whether any node in the graph (recursively) is async.
+function hasAsyncNodes(nodes: GraphNode[]): boolean {
+  for (const node of nodes) {
+    if (isAsyncNode(node)) return true;
+    if (isMapNode(node) && hasAsyncNodes(node.graph)) return true;
+    if (isSubFlowNode(node) && node.graph && hasAsyncNodes(node.graph)) return true;
+  }
+  return false;
+}
+
 export function generateMermaid(config: Config): string {
   const lines: string[] = ["graph TD"];
   renderNodes(
@@ -269,6 +279,9 @@ export function generateMermaid(config: Config): string {
     "end_node",
     config.skills,
   );
+  if (hasAsyncNodes(config.team!.flow.nodes)) {
+    lines.push("    classDef async stroke-dasharray: 5 5");
+  }
   return lines.join("\n") + "\n";
 }
 


### PR DESCRIPTION
## Summary

**[engineer]**

- Append `:::async` class suffix to async node declarations in `renderNodes()`
- Emit `classDef async stroke-dasharray: 5 5` footer in `generateMermaid()` when async nodes exist (checked recursively through map/subflow subgraphs)
- Update existing tests to assert the new class suffix and classDef line, add test verifying classDef is omitted when no async nodes exist

Closes #323

## Test plan

- [x] All 560 tests pass (559 existing updated + 1 new)
- [x] `skillfold graph` output now matches the hand-edited README Mermaid diagrams
- [x] `skillfold --check` confirms compiled output is current
- [x] No classDef emitted for graphs without async nodes

Generated with [Claude Code](https://claude.com/claude-code)