### PR TITLE
feat: reframe npm registry from skill packages to pipeline configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Configuration language and compiler for multi-agent AI pipelines. Compiles YAML 
 - **Check output is current**: `npx tsx src/cli.ts --check`
 - **List pipeline**: `npx tsx src/cli.ts list`
 - **Interactive graph**: `npx tsx src/cli.ts graph --html > pipeline.html`
-- **Search npm skills**: `npx tsx src/cli.ts search [query]`
+- **Search npm pipelines**: `npx tsx src/cli.ts search [query]`
 - **Run with custom config**: `npx tsx src/cli.ts --config path.yaml --out-dir out/`
 - **Build**: `npm run build`
 - **Build plugin**: `npm run build:plugin`
@@ -39,7 +39,7 @@ src/
   plugin.ts       - Claude Code plugin packaging (skillfold plugin)
   list.ts         - Pipeline introspection (skillfold list)
   npm.ts          - npm package resolution (npm: prefix in skill refs and imports)
-  search.ts       - npm registry search for skillfold-skill packages (skillfold search)
+  search.ts       - npm registry search for skillfold pipeline configs (skillfold search)
   watch.ts        - File watching and auto-recompile (skillfold watch)
   init.ts         - skillfold init scaffolding
   errors.ts       - ConfigError, ResolveError, CompileError, GraphError
@@ -165,7 +165,7 @@ Located in `library/examples/`:
 - Resolved location URLs in orchestrator state table output (base URL templates from skill resources)
 - Compiler warnings for implicit state locations (skills without resource declarations)
 - Sub-flow imports: flow nodes can reference external pipeline configs via `flow:` field, with recursive resolution, skill/state merging, circular reference detection, orchestrator rendering with hierarchical steps, and Mermaid visualization as subgraphs
-- `skillfold search [query]` command for discovering skill packages on npm (searches for `skillfold-skill` keyword)
+- `skillfold search [query]` command for discovering pipeline configs on npm (searches for `skillfold-pipeline` keyword)
 - npm skill discovery: `agentskills` field in package.json uses flat key-value format for ecosystem compatibility
 - `npm:` prefix support for skill references and imports (resolves to node_modules paths)
 - Publishing guide (`docs/publishing.md`) for sharing skills via npm

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Reference skills by GitHub URL, npm package, or import them from other configs. 
 skills:
   atomic:
     shared: https://github.com/org/repo/tree/main/skills/shared
-    planning: npm:skillfold-skill-planning    # resolve from npm package
+    planning: npm:skillfold-pipeline-planning  # resolve from npm package
 imports:
   - npm:skillfold/library/skillfold.yaml      # npm: prefix (preferred)
   - node_modules/skillfold/library/skillfold.yaml  # direct path (also works)
@@ -510,7 +510,7 @@ Commands:
   graph             Output Mermaid flowchart of the team flow
   watch             Compile and watch for changes
   plugin            Package compiled output as a Claude Code plugin
-  search [query]    Discover skill packages on npm
+  search [query]    Discover pipeline configs on npm
   (default)         Compile the pipeline config
 
 Options:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -309,5 +309,5 @@ See the [Publishing Guide](publishing.md) for package structure, required fields
 - Try parallel `map` to process lists of items concurrently
 - Add `skillfold --check` to CI to verify compiled output stays in sync
 - Use `skillfold plugin` to package your pipeline for distribution
-- Use `skillfold search` to discover community skill packages on npm
+- Use `skillfold search` to discover community pipeline configs on npm
 - Set `GITHUB_TOKEN` to reference skills from private GitHub repositories

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,17 +1,17 @@
-# Publishing Skills to npm
+# Publishing Pipeline Configs to npm
 
-Skillfold uses npm as its package registry. Any skill or pipeline config can be published as a standard npm package - no separate registry or tooling required.
+Skillfold uses npm as its package registry. Any pipeline config - with its skills, state schema, and team flow - can be published as a standard npm package. No separate registry or tooling required.
 
 ## Package Structure
 
-A publishable skill package contains a `package.json`, an optional `skillfold.yaml` for importable pipeline configs, and one or more atomic skill directories:
+A publishable pipeline config contains a `package.json`, a `skillfold.yaml` with the pipeline definition, and the atomic skill directories it references:
 
 ```
-my-skills/
+my-pipeline/
   package.json
-  skillfold.yaml         # pipeline config (optional, for importable configs)
+  skillfold.yaml         # pipeline config (skills, state, team flow)
   skills/
-    planning/SKILL.md    # atomic skills
+    planning/SKILL.md    # atomic skills used by the config
     testing/SKILL.md
 ```
 
@@ -19,20 +19,20 @@ Each skill directory follows the standard layout: a directory containing a `SKIL
 
 ## package.json
 
-Required fields for a publishable skill package:
+Required fields for a publishable pipeline config:
 
 ```json
 {
-  "name": "@team/shared-skills",
+  "name": "@team/dev-pipeline",
   "version": "1.0.0",
-  "keywords": ["skillfold-skill"],
-  "description": "Shared planning and review skills",
+  "keywords": ["skillfold-pipeline"],
+  "description": "Dev team pipeline with planning, coding, and review agents",
   "files": ["skillfold.yaml", "skills/"]
 }
 ```
 
 - **name** - Standard npm package name. Scoped names (`@team/...`) are recommended for team-owned packages.
-- **keywords** - Must include `skillfold-skill`. This is what `skillfold search` uses to find packages on the registry.
+- **keywords** - Must include `skillfold-pipeline`. This is what `skillfold search` uses to find packages on the registry.
 - **files** - Limits the published package to only the config and skill files. Keep the package small.
 
 ## Publishing
@@ -44,21 +44,21 @@ npm publish              # public package
 npm publish --access public   # first publish of a scoped package
 ```
 
-If the package includes a `skillfold.yaml`, consumers can import the full config. If it only contains skill directories, consumers reference individual skills by path.
+Consumers import the full config to get the complete pipeline - skills, state schema, and team flow definition.
 
-## Using Published Skills
+## Using Published Configs
 
-Install the package, then reference it in your config:
+Install the package, then import it in your config:
 
 ```bash
-npm install @team/shared-skills
+npm install @team/dev-pipeline
 ```
 
 Import the full config to get all skills and state:
 
 ```yaml
 imports:
-  - npm:@team/shared-skills
+  - npm:@team/dev-pipeline
 ```
 
 Or reference individual skills directly:
@@ -66,21 +66,21 @@ Or reference individual skills directly:
 ```yaml
 skills:
   atomic:
-    planning: npm:@team/shared-skills/skills/planning
+    planning: npm:@team/dev-pipeline/skills/planning
 ```
 
 The `npm:` prefix resolves to the package's install path under `node_modules/`.
 
 ## Discovery
 
-Search for published skill packages on npm:
+Search for published pipeline configs on npm:
 
 ```bash
 skillfold search planning    # search by keyword
-skillfold search             # list all skillfold-skill packages
+skillfold search             # list all skillfold pipeline configs
 ```
 
-This queries the npm registry for packages with the `skillfold-skill` keyword and displays their name, description, and version.
+This queries the npm registry for packages with the `skillfold-pipeline` keyword and displays their name, description, and version.
 
 ## Versioning
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "codex",
     "gemini-cli",
     "agentskills",
-    "skillfold-skill",
+    "skillfold-pipeline",
     "skill-md"
   ],
   "agentskills": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ Commands:
   graph             Output Mermaid flowchart of the team flow
   watch             Compile and watch for changes
   plugin            Package compiled output as a Claude Code plugin
-  search [query]    Search npm for skillfold skill packages
+  search [query]    Search npm for pipeline configs
   (default)         Compile the pipeline config
 
 Options:
@@ -239,8 +239,8 @@ async function main(): Promise<void> {
   }
 
   if (args.command === "search") {
-    const { searchSkills } = await import("./search.js");
-    await searchSkills(args.query);
+    const { searchPipelines } = await import("./search.js");
+    await searchPipelines(args.query);
     return;
   }
 

--- a/src/search.test.ts
+++ b/src/search.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { searchSkills } from "./search.js";
+import { searchPipelines } from "./search.js";
 
 // Capture console output
 function captureConsole(): { logs: string[]; errors: string[]; restore: () => void } {
@@ -34,9 +34,9 @@ const sampleResults = {
     {
       package: {
         name: "skillfold-planning",
-        description: "Planning skills for AI agents",
+        description: "Planning pipeline for AI agents",
         version: "1.0.0",
-        keywords: ["skillfold-skill"],
+        keywords: ["skillfold-pipeline"],
         links: { npm: "https://www.npmjs.com/package/skillfold-planning" },
       },
       score: { detail: { popularity: 0.5 } },
@@ -44,9 +44,9 @@ const sampleResults = {
     {
       package: {
         name: "skillfold-testing",
-        description: "Testing skills for AI agents",
+        description: "Testing pipeline for AI agents",
         version: "2.1.0",
-        keywords: ["skillfold-skill"],
+        keywords: ["skillfold-pipeline"],
         links: { npm: "https://www.npmjs.com/package/skillfold-testing" },
       },
       score: { detail: { popularity: 0.3 } },
@@ -55,7 +55,7 @@ const sampleResults = {
   total: 2,
 };
 
-describe("searchSkills", () => {
+describe("searchPipelines", () => {
   let originalFetch: typeof globalThis.fetch;
   let originalExit: typeof process.exit;
 
@@ -74,16 +74,16 @@ describe("searchSkills", () => {
     const out = captureConsole();
 
     try {
-      await searchSkills();
+      await searchPipelines();
     } finally {
       out.restore();
     }
 
     const text = out.logs.join("\n");
-    assert.ok(text.includes("Found 2 skills"));
+    assert.ok(text.includes("Found 2 pipeline configs"));
     assert.ok(text.includes("skillfold-planning"));
     assert.ok(text.includes("v1.0.0"));
-    assert.ok(text.includes("Planning skills for AI agents"));
+    assert.ok(text.includes("Planning pipeline for AI agents"));
     assert.ok(text.includes("skillfold-testing"));
     assert.ok(text.includes("v2.1.0"));
     assert.ok(text.includes("npm install <package>"));
@@ -99,16 +99,16 @@ describe("searchSkills", () => {
     const out = captureConsole();
 
     try {
-      await searchSkills("planning");
+      await searchPipelines("planning");
     } finally {
       out.restore();
     }
 
-    assert.ok(calledUrl.includes("keywords%3Askillfold-skill"));
+    assert.ok(calledUrl.includes("keywords%3Askillfold-pipeline"));
     assert.ok(calledUrl.includes("planning"));
   });
 
-  it("displays singular 'skill' for one result", async () => {
+  it("displays singular form for one result", async () => {
     const singleResult = {
       objects: [sampleResults.objects[0]],
       total: 1,
@@ -117,14 +117,14 @@ describe("searchSkills", () => {
     const out = captureConsole();
 
     try {
-      await searchSkills();
+      await searchPipelines();
     } finally {
       out.restore();
     }
 
     const text = out.logs.join("\n");
-    assert.ok(text.includes("Found 1 skill:"));
-    assert.ok(!text.includes("Found 1 skills"));
+    assert.ok(text.includes("Found 1 pipeline config:"));
+    assert.ok(!text.includes("Found 1 pipeline configs"));
   });
 
   it("shows message when no results found", async () => {
@@ -133,13 +133,13 @@ describe("searchSkills", () => {
     const out = captureConsole();
 
     try {
-      await searchSkills();
+      await searchPipelines();
     } finally {
       out.restore();
     }
 
     const text = out.logs.join("\n");
-    assert.ok(text.includes("No skillfold skills found"));
+    assert.ok(text.includes("No pipeline configs found"));
   });
 
   it("shows query in no-results message", async () => {
@@ -148,13 +148,13 @@ describe("searchSkills", () => {
     const out = captureConsole();
 
     try {
-      await searchSkills("nonexistent");
+      await searchPipelines("nonexistent");
     } finally {
       out.restore();
     }
 
     const text = out.logs.join("\n");
-    assert.ok(text.includes('No skillfold skills found matching "nonexistent"'));
+    assert.ok(text.includes('No pipeline configs found matching "nonexistent"'));
   });
 
   it("handles network error", async () => {
@@ -170,7 +170,7 @@ describe("searchSkills", () => {
     const out = captureConsole();
 
     try {
-      await searchSkills();
+      await searchPipelines();
     } catch {
       // Expected: process.exit mock throws
     } finally {
@@ -192,7 +192,7 @@ describe("searchSkills", () => {
     const out = captureConsole();
 
     try {
-      await searchSkills();
+      await searchPipelines();
     } catch {
       // Expected: process.exit mock throws
     } finally {
@@ -211,7 +211,7 @@ describe("searchSkills", () => {
             name: "skillfold-bare",
             description: "",
             version: "0.1.0",
-            keywords: ["skillfold-skill"],
+            keywords: ["skillfold-pipeline"],
             links: { npm: "https://www.npmjs.com/package/skillfold-bare" },
           },
           score: { detail: { popularity: 0.1 } },
@@ -223,7 +223,7 @@ describe("searchSkills", () => {
     const out = captureConsole();
 
     try {
-      await searchSkills();
+      await searchPipelines();
     } finally {
       out.restore();
     }
@@ -241,13 +241,13 @@ describe("searchSkills", () => {
     const out = captureConsole();
 
     try {
-      await searchSkills();
+      await searchPipelines();
     } finally {
       out.restore();
     }
 
     assert.ok(calledUrl.startsWith("https://registry.npmjs.org/-/v1/search"));
-    assert.ok(calledUrl.includes("keywords%3Askillfold-skill"));
+    assert.ok(calledUrl.includes("keywords%3Askillfold-pipeline"));
     assert.ok(calledUrl.includes("size=25"));
   });
 });

--- a/src/search.ts
+++ b/src/search.ts
@@ -14,8 +14,8 @@ interface NpmSearchResult {
   total: number;
 }
 
-export async function searchSkills(query?: string): Promise<void> {
-  const searchTerms = ["keywords:skillfold-skill", query]
+export async function searchPipelines(query?: string): Promise<void> {
+  const searchTerms = ["keywords:skillfold-pipeline", query]
     .filter(Boolean)
     .join("+");
   const url = `https://registry.npmjs.org/-/v1/search?text=${encodeURIComponent(searchTerms)}&size=25`;
@@ -38,14 +38,14 @@ export async function searchSkills(query?: string): Promise<void> {
   if (data.total === 0 || data.objects.length === 0) {
     console.log(
       query
-        ? `No skillfold skills found matching "${query}"`
-        : "No skillfold skills found",
+        ? `No pipeline configs found matching "${query}"`
+        : "No pipeline configs found",
     );
     return;
   }
 
   console.log(
-    `\n  Found ${data.objects.length} skill${data.objects.length === 1 ? "" : "s"}:\n`,
+    `\n  Found ${data.objects.length} pipeline config${data.objects.length === 1 ? "" : "s"}:\n`,
   );
 
   for (const { package: pkg } of data.objects) {


### PR DESCRIPTION
**[engineer]**

Closes #332

## Summary

- Changed the npm search keyword from `skillfold-skill` to `skillfold-pipeline` across the codebase
- Renamed `searchSkills` to `searchPipelines` in `src/search.ts` and updated the CLI import in `src/cli.ts`
- Updated all user-facing strings: "skill packages" -> "pipeline configs", "No skillfold skills found" -> "No pipeline configs found", "Found N skills" -> "Found N pipeline configs"
- Rewrote `docs/publishing.md` with pipeline-first framing: title, examples, and narrative all center on sharing pre-wired pipeline configs
- Updated CLI help text, README, getting-started guide, and CLAUDE.md references
- Updated all tests in `src/search.test.ts` to match the new keyword, function name, and output strings

## Backwards compatibility

- The `npm:package/skills/foo` syntax for individual skills still works (no changes to `src/npm.ts`)
- The `agentskills` field in `package.json` is unchanged (ecosystem standard)
- The `search` command name is unchanged

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (560 tests, 0 failures)
- [x] Verified no remaining references to `skillfold-skill` or `searchSkills` in the codebase