### PR TITLE
feat: allow async nodes inside map subgraphs, rename map key to flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,11 +165,13 @@ Located in `library/examples/`:
 - Resolved location URLs in orchestrator state table output (base URL templates from skill resources)
 - Compiler warnings for implicit state locations (skills without resource declarations)
 - Sub-flow imports: flow nodes can reference external pipeline configs via `flow:` field, with recursive resolution, skill/state merging, circular reference detection, orchestrator rendering with hierarchical steps, and Mermaid visualization as subgraphs
+- Async nodes inside map subgraphs for modeling human/external tasks alongside agent tasks in parallel maps
+- Map subgraph `flow` key (with `graph` backward compat) for consistency with top-level `team.flow`
 - `skillfold search [query]` command for discovering pipeline configs on npm (searches for `skillfold-pipeline` keyword)
 - npm skill discovery: `agentskills` field in package.json uses flat key-value format for ecosystem compatibility
 - `npm:` prefix support for skill references and imports (resolves to node_modules paths)
 - Publishing guide (`docs/publishing.md`) for sharing skills via npm
-- Test suite with 560 tests across 104 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, and e2e modules
+- Test suite with 565 tests across 105 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/library/examples/content-pipeline/skillfold.yaml
+++ b/library/examples/content-pipeline/skillfold.yaml
@@ -35,7 +35,7 @@ team:
     - map:
         over: state.topics
         as: topic
-        graph:
+        flow:
           - writer:
               reads: [topic.title]
               writes: [topic.draft]

--- a/skillfold.schema.json
+++ b/skillfold.schema.json
@@ -285,9 +285,13 @@
     },
     "mapBody": {
       "type": "object",
-      "description": "Map node that parallelizes over a list state field.",
-      "required": ["over", "as", "graph"],
+      "description": "Map node that parallelizes over a list state field. Use 'flow' for the sub-flow (preferred). 'graph' is accepted for backward compatibility.",
+      "required": ["over", "as"],
       "additionalProperties": false,
+      "oneOf": [
+        { "required": ["flow"] },
+        { "required": ["graph"] }
+      ],
       "properties": {
         "over": {
           "type": "string",
@@ -297,9 +301,17 @@
           "type": "string",
           "description": "Alias for the current item in the map iteration."
         },
-        "graph": {
+        "flow": {
           "type": "array",
           "description": "Sub-flow executed for each item.",
+          "items": {
+            "$ref": "#/$defs/flowElement"
+          },
+          "minItems": 1
+        },
+        "graph": {
+          "type": "array",
+          "description": "Sub-flow executed for each item (deprecated, use 'flow').",
           "items": {
             "$ref": "#/$defs/flowElement"
           },

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -37,7 +37,7 @@ function collectStepNodes(nodes: GraphNode[]): StepNode[] {
   const steps: StepNode[] = [];
   for (const node of nodes) {
     if (isMapNode(node)) {
-      steps.push(...collectStepNodes(node.graph));
+      steps.push(...collectStepNodes(node.flow));
     } else if (isSubFlowNode(node)) {
       if (node.graph) {
         steps.push(...collectStepNodes(node.graph));

--- a/src/config.ts
+++ b/src/config.ts
@@ -627,7 +627,7 @@ function collectSubFlowNodes(nodes: GraphNode[]): SubFlowNode[] {
     if (isSubFlowNode(node)) {
       result.push(node);
     } else if (isMapNode(node)) {
-      result.push(...collectSubFlowNodes(node.graph));
+      result.push(...collectSubFlowNodes(node.flow));
     }
   }
   return result;

--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -91,7 +91,33 @@ describe("parseGraph", () => {
     assert.equal(node.then[1].to, "end");
   });
 
-  it("parses a map node with nested subgraph", () => {
+  it("parses a map node with nested subgraph using flow key", () => {
+    const raw = [
+      {
+        map: {
+          over: "state.tasks",
+          as: "task",
+          flow: [
+            {
+              engineer: { reads: ["task.description"], writes: ["task.output"] },
+              then: "end",
+            },
+          ],
+        },
+        then: "end",
+      },
+    ];
+    const graph = parseGraph(raw);
+    assert.equal(graph.nodes.length, 1);
+    const node = graph.nodes[0];
+    assert.ok(isMapNode(node));
+    assert.equal(node.over, "state.tasks");
+    assert.equal(node.as, "task");
+    assert.equal(node.flow.length, 1);
+    assert.equal(node.then, "end");
+  });
+
+  it("parses a map node with nested subgraph using graph key (backward compat)", () => {
     const raw = [
       {
         map: {
@@ -113,7 +139,7 @@ describe("parseGraph", () => {
     assert.ok(isMapNode(node));
     assert.equal(node.over, "state.tasks");
     assert.equal(node.as, "task");
-    assert.equal(node.graph.length, 1);
+    assert.equal(node.flow.length, 1);
     assert.equal(node.then, "end");
   });
 
@@ -255,12 +281,30 @@ describe("parseGraph", () => {
       );
     });
 
-    it("rejects map node missing graph", () => {
+    it("rejects map node missing flow", () => {
       assert.throws(
         () => parseGraph([{ map: { over: "state.tasks", as: "task" } }]),
         (err: unknown) => {
           assert.ok(err instanceof GraphError);
-          assert.match(err.message, /must have "graph"/);
+          assert.match(err.message, /must have "flow"/);
+          return true;
+        },
+      );
+    });
+
+    it("rejects map node with both flow and graph", () => {
+      assert.throws(
+        () => parseGraph([{
+          map: {
+            over: "state.tasks",
+            as: "task",
+            flow: [{ worker: {} }],
+            graph: [{ worker: {} }],
+          },
+        }]),
+        (err: unknown) => {
+          assert.ok(err instanceof GraphError);
+          assert.match(err.message, /cannot have both "flow" and "graph"/);
           return true;
         },
       );
@@ -504,7 +548,7 @@ describe("validateGraph", () => {
           {
             over: "state.tasks",
             as: "task",
-            graph: [
+            flow: [
               { skill: "engineer", reads: [], writes: ["state.goal"] },
             ],
           },
@@ -528,7 +572,7 @@ describe("validateGraph", () => {
           {
             over: "state.goal",
             as: "item",
-            graph: [
+            flow: [
               { skill: "engineer", reads: [], writes: [] },
             ],
           },
@@ -554,7 +598,7 @@ describe("validateGraph", () => {
           {
             over: "state.missing",
             as: "item",
-            graph: [
+            flow: [
               { skill: "engineer", reads: [], writes: [] },
             ],
           },
@@ -580,7 +624,7 @@ describe("validateGraph", () => {
           {
             over: "state.tasks",
             as: "goal",
-            graph: [
+            flow: [
               { skill: "engineer", reads: [], writes: [] },
             ],
           },
@@ -607,7 +651,7 @@ describe("validateGraph", () => {
           {
             over: "state.tasks",
             as: "task",
-            graph: [
+            flow: [
               { skill: "engineer", reads: ["task.description"], writes: ["task.output"] },
             ],
           },
@@ -646,7 +690,7 @@ describe("validateGraph", () => {
           {
             over: "state.tasks",
             as: "task",
-            graph: [
+            flow: [
               { skill: "engineer", reads: ["task.description"], writes: ["task.output"] },
             ],
           },
@@ -662,7 +706,7 @@ describe("validateGraph", () => {
           {
             over: "state.tasks",
             as: "task",
-            graph: [
+            flow: [
               { skill: "engineer", reads: ["task.nonexistent"], writes: [] },
             ],
           },
@@ -688,7 +732,7 @@ describe("validateGraph", () => {
           {
             over: "state.tasks",
             as: "task",
-            graph: [
+            flow: [
               { skill: "engineer", reads: [], writes: ["task.missing"] },
             ],
           },
@@ -714,7 +758,7 @@ describe("validateGraph", () => {
           {
             over: "state.tasks",
             as: "task",
-            graph: [
+            flow: [
               {
                 skill: "engineer",
                 reads: ["task.description"],
@@ -741,7 +785,7 @@ describe("validateGraph", () => {
           {
             over: "items",
             as: "item",
-            graph: [
+            flow: [
               { skill: "worker", reads: ["item.name"], writes: ["item.result"] },
             ],
           },
@@ -981,7 +1025,7 @@ describe("validateGraph when-clause validation", () => {
         {
           over: "state.tasks",
           as: "task",
-          graph: [
+          flow: [
             {
               skill: "engineer",
               reads: ["task.description"],
@@ -1011,7 +1055,7 @@ describe("validateGraph when-clause validation", () => {
         {
           over: "state.tasks",
           as: "task",
-          graph: [
+          flow: [
             {
               skill: "engineer",
               reads: ["task.description"],
@@ -1235,7 +1279,7 @@ describe("validateGraph: map over state without state declared", () => {
         {
           over: "state.items",
           as: "item",
-          graph: [
+          flow: [
             { skill: "worker", reads: [], writes: [] },
           ],
         },
@@ -1424,7 +1468,7 @@ describe("validateGraph: when-clause with custom type sub-field", () => {
 
 describe("type guards", () => {
   it("isMapNode returns true for MapNode", () => {
-    assert.equal(isMapNode({ over: "state.tasks", as: "task", graph: [] }), true);
+    assert.equal(isMapNode({ over: "state.tasks", as: "task", flow: [] }), true);
   });
 
   it("isMapNode returns false for StepNode", () => {
@@ -1612,31 +1656,75 @@ describe("parseGraph: async nodes", () => {
     );
   });
 
-  it("rejects async nodes inside map subgraphs", () => {
+  it("allows async nodes inside map subgraphs", () => {
     const raw = [
       {
         map: {
           over: "state.items",
           as: "item",
-          graph: [
+          flow: [
             {
               "async-worker": {
                 async: true,
                 writes: ["item.result"],
+                policy: "block",
               },
             },
           ],
         },
       },
     ];
-    assert.throws(
-      () => parseGraph(raw),
-      (err: unknown) => {
-        assert.ok(err instanceof GraphError);
-        assert.match(err.message, /async nodes are not allowed inside map subgraphs/);
-        return true;
+    const graph = parseGraph(raw);
+    assert.equal(graph.nodes.length, 1);
+    assert.ok(isMapNode(graph.nodes[0]));
+    const mapNode = graph.nodes[0];
+    assert.equal(mapNode.flow.length, 1);
+    assert.ok(isAsyncNode(mapNode.flow[0]));
+  });
+
+  it("async node inside map with conditional routing", () => {
+    const raw = [
+      {
+        map: {
+          over: "state.tasks",
+          as: "task",
+          flow: [
+            {
+              "task-router": {
+                reads: ["task.agent"],
+              },
+              then: [
+                { when: "task.agent == \"human\"", to: "human-worker" },
+                { when: "task.agent == \"engineer\"", to: "engineer" },
+              ],
+            },
+            {
+              "human-worker": {
+                async: true,
+                reads: ["task"],
+                policy: "block",
+              },
+              then: "end",
+            },
+            {
+              engineer: {
+                reads: ["task"],
+                writes: ["task.output"],
+              },
+              then: "end",
+            },
+          ],
+        },
       },
-    );
+    ];
+    const graph = parseGraph(raw);
+    assert.equal(graph.nodes.length, 1);
+    assert.ok(isMapNode(graph.nodes[0]));
+    const mapNode = graph.nodes[0];
+    assert.equal(mapNode.flow.length, 3);
+    assert.ok(!isAsyncNode(mapNode.flow[0]));
+    assert.ok(isAsyncNode(mapNode.flow[1]));
+    assert.ok(!isAsyncNode(mapNode.flow[2]));
   });
 
   it("isAsyncNode returns true for AsyncNode", () => {
@@ -1655,7 +1743,7 @@ describe("parseGraph: async nodes", () => {
   });
 
   it("isAsyncNode returns false for MapNode", () => {
-    assert.equal(isAsyncNode({ over: "state.tasks", as: "task", graph: [] }), false);
+    assert.equal(isAsyncNode({ over: "state.tasks", as: "task", flow: [] }), false);
   });
 
   it("async node in a chain with step nodes", () => {
@@ -1864,6 +1952,89 @@ describe("validateGraph: async nodes", () => {
     };
     const skills = makeSkills("engineer");
     const state = makeState({ ok: { kind: "primitive", value: "bool" } });
+    assert.doesNotThrow(() => validateGraph(graph, skills, state));
+  });
+
+  it("async node inside map with conditional routing validates", () => {
+    const state: StateSchema = {
+      types: {
+        Task: {
+          fields: {
+            title: "string",
+            description: "string",
+            agent: "string",
+            output: "string",
+            approved: "bool",
+          },
+        },
+      },
+      fields: {
+        direction: { type: { kind: "primitive", value: "string" } },
+        plan: { type: { kind: "primitive", value: "string" } },
+        tasks: { type: { kind: "list", element: "Task" } },
+      },
+    };
+    const skills = makeSkills("strategist", "architect", "task-router", "engineer", "reviewer", "marketer");
+    const graph: Graph = {
+      nodes: [
+        {
+          skill: "strategist",
+          reads: ["state.tasks"],
+          writes: ["state.direction"],
+          then: "architect",
+        },
+        {
+          skill: "architect",
+          reads: ["state.direction"],
+          writes: ["state.plan", "state.tasks"],
+          then: "map",
+        },
+        {
+          over: "state.tasks",
+          as: "task",
+          flow: [
+            {
+              skill: "task-router",
+              reads: ["task.agent"],
+              writes: [],
+              then: [
+                { when: "task.agent == \"human\"", to: "human-worker" },
+                { when: "task.agent == \"engineer\"", to: "engineer" },
+              ],
+            },
+            {
+              name: "human-worker",
+              async: true,
+              reads: ["task.title"],
+              writes: [],
+              policy: "block",
+              then: "end",
+            },
+            {
+              skill: "engineer",
+              reads: ["task.description"],
+              writes: ["task.output"],
+              then: "reviewer",
+            },
+            {
+              skill: "reviewer",
+              reads: ["task.output"],
+              writes: ["task.approved"],
+              then: [
+                { when: "task.approved == false", to: "engineer" },
+                { when: "task.approved == true", to: "end" },
+              ],
+            },
+          ],
+          then: "marketer",
+        },
+        {
+          skill: "marketer",
+          reads: ["state.direction"],
+          writes: [],
+        },
+      ],
+    };
     assert.doesNotThrow(() => validateGraph(graph, skills, state));
   });
 });

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -34,7 +34,7 @@ export interface AsyncNode {
 export interface MapNode {
   over: string;
   as: string;
-  graph: GraphNode[];
+  flow: GraphNode[];
   then?: Then;
 }
 
@@ -63,7 +63,7 @@ export function isMapNode(node: GraphNode): node is MapNode {
 }
 
 export function isSubFlowNode(node: GraphNode): node is SubFlowNode {
-  return "flow" in node;
+  return "flow" in node && !("over" in node);
 }
 
 export function isConditionalThen(then: Then): then is ConditionalBranch[] {
@@ -188,16 +188,25 @@ function parseGraphNodes(raw: unknown[], insideMap = false): GraphNode[] {
         throw new GraphError(`Graph element "map": must have "as" (string)`);
       }
 
-      if (!Array.isArray(mapObj.graph)) {
-        throw new GraphError(`Graph element "map": must have "graph" (array)`);
+      // Accept both "flow" (preferred) and "graph" (backward compat) for the subgraph
+      const hasFlow = "flow" in mapObj;
+      const hasGraph = "graph" in mapObj;
+      if (hasFlow && hasGraph) {
+        throw new GraphError(
+          `Graph element "map": cannot have both "flow" and "graph" (use "flow")`
+        );
+      }
+      const subgraphRaw = hasFlow ? mapObj.flow : mapObj.graph;
+      if (!Array.isArray(subgraphRaw)) {
+        throw new GraphError(`Graph element "map": must have "flow" (array)`);
       }
 
-      const subNodes = parseGraphNodes(mapObj.graph, true);
+      const subNodes = parseGraphNodes(subgraphRaw, true);
 
       nodes.push({
         over: mapObj.over,
         as: mapObj.as,
-        graph: subNodes,
+        flow: subNodes,
         ...(then !== undefined ? { then } : {}),
       });
     } else {
@@ -244,11 +253,6 @@ function parseGraphNodes(raw: unknown[], insideMap = false): GraphNode[] {
 
         if (stepObj.async === true) {
           isAsync = true;
-          if (insideMap) {
-            throw new GraphError(
-              `Graph element "${primaryKey}": async nodes are not allowed inside map subgraphs`
-            );
-          }
         }
 
         if (stepObj.policy !== undefined) {
@@ -563,7 +567,7 @@ function validateNodes(
     }
 
     // Recursively validate the subgraph
-    validateNodes(node.graph, skills, state, subMapCtx);
+    validateNodes(node.flow, skills, state, subMapCtx);
   }
 
   // Rule 9: Sub-flow inner graph validation (after resolution populates graph)

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -160,7 +160,7 @@ describe("generateOrchestrator", () => {
             {
               over: "state.tasks",
               as: "task",
-              graph: [
+              flow: [
                 {
                   skill: "worker",
                   reads: ["task.description"],
@@ -459,7 +459,7 @@ describe("generateOrchestrator", () => {
             {
               over: "state.tasks",
               as: "task",
-              graph: [
+              flow: [
                 {
                   skill: "worker",
                   reads: ["task.description"],
@@ -736,6 +736,110 @@ describe("generateOrchestrator: async nodes", () => {
     assert.ok(!asyncSection.includes("Agent tool"));
     // But the step node should
     assert.ok(output.includes("Invoke **worker** using the Agent tool."));
+  });
+});
+
+describe("generateOrchestrator: async nodes inside map", () => {
+  it("renders async node inside map with correct step numbering", () => {
+    const config: Config = {
+      name: "async-map-pipeline",
+      skills: {
+        architect: { path: "./skills/architect" },
+        "task-router": { path: "./skills/task-router" },
+        engineer: { path: "./skills/engineer" },
+        reviewer: { path: "./skills/reviewer" },
+      },
+      state: {
+        types: {
+          Task: {
+            fields: {
+              agent: "string",
+              output: "string",
+              approved: "bool",
+            },
+          },
+        },
+        fields: {
+          tasks: { type: { kind: "list", element: "Task" } },
+        },
+      },
+      team: {
+        flow: {
+          nodes: [
+            {
+              skill: "architect",
+              reads: [],
+              writes: ["state.tasks"],
+              then: "map",
+            },
+            {
+              over: "state.tasks",
+              as: "task",
+              flow: [
+                {
+                  skill: "task-router",
+                  reads: ["task.agent"],
+                  writes: [],
+                  then: [
+                    { when: "task.agent == \"human\"", to: "human-worker" },
+                    { when: "task.agent == \"engineer\"", to: "engineer" },
+                  ],
+                },
+                {
+                  name: "human-worker",
+                  async: true,
+                  reads: [],
+                  writes: [],
+                  policy: "block",
+                  then: "end",
+                },
+                {
+                  skill: "engineer",
+                  reads: ["task.agent"],
+                  writes: ["task.output"],
+                  then: "reviewer",
+                },
+                {
+                  skill: "reviewer",
+                  reads: ["task.output"],
+                  writes: ["task.approved"],
+                  then: [
+                    { when: "task.approved == false", to: "engineer" },
+                    { when: "task.approved == true", to: "end" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+
+    // Step 1: architect
+    assert.ok(output.includes("### Step 1: architect"));
+    assert.ok(output.includes("Invoke **architect**."));
+    assert.ok(output.includes("Then: proceed to step 2."));
+
+    // Step 2: map
+    assert.ok(output.includes("### Step 2: map over state.tasks"));
+
+    // Step 2.1: task-router
+    assert.ok(output.includes("#### Step 2.1: task-router"));
+    assert.ok(output.includes("Invoke **task-router**."));
+
+    // Step 2.2: human-worker (async)
+    assert.ok(output.includes("#### Step 2.2: human-worker (async)"));
+    assert.ok(output.includes("wait for the external agent"));
+
+    // Step 2.3: engineer
+    assert.ok(output.includes("#### Step 2.3: engineer"));
+
+    // Step 2.4: reviewer
+    assert.ok(output.includes("#### Step 2.4: reviewer"));
+    assert.ok(output.includes("- If `task.approved == false`: go to step 2.3"));
+    assert.ok(output.includes("- If `task.approved == true`: end"));
   });
 });
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -150,10 +150,10 @@ export function renderNodes(
       );
 
       // Build sub-step map for inner nodes
-      const subMap = buildStepMap(node.graph, stepNum);
+      const subMap = buildStepMap(node.flow, stepNum);
       const subHeading = headingLevel + "#";
       const subSections = renderNodes(
-        node.graph,
+        node.flow,
         subMap,
         stepNum,
         subHeading,

--- a/src/visualize.test.ts
+++ b/src/visualize.test.ts
@@ -22,13 +22,13 @@ function step(
 function map(
   over: string,
   as: string,
-  graph: GraphNode[],
+  flow: GraphNode[],
   then?: MapNode["then"],
 ): MapNode {
   return {
     over,
     as,
-    graph,
+    flow,
     ...(then !== undefined ? { then } : {}),
   };
 }

--- a/src/visualize.ts
+++ b/src/visualize.ts
@@ -132,7 +132,7 @@ function renderNodes(
       lines.push(`${indent}subgraph ${subgraphId}["${subgraphLabel}"]`);
       const innerIndent = indent + "    ";
       const innerEndId = `end_${subgraphId}`;
-      renderNodes(node.graph, lines, innerIndent, innerEndId, skills);
+      renderNodes(node.flow, lines, innerIndent, innerEndId, skills);
       lines.push(`${indent}end`);
 
       if (node.then !== undefined) {
@@ -263,7 +263,7 @@ function renderNodes(
 function hasAsyncNodes(nodes: GraphNode[]): boolean {
   for (const node of nodes) {
     if (isAsyncNode(node)) return true;
-    if (isMapNode(node) && hasAsyncNodes(node.graph)) return true;
+    if (isMapNode(node) && hasAsyncNodes(node.flow)) return true;
     if (isSubFlowNode(node) && node.graph && hasAsyncNodes(node.graph)) return true;
   }
   return false;
@@ -311,7 +311,7 @@ function collectNodeMeta(
         reads: [],
         writes: [],
       });
-      metas.push(...collectNodeMeta(node.graph, skills));
+      metas.push(...collectNodeMeta(node.flow, skills));
     } else if (isSubFlowNode(node)) {
       const meta: NodeMeta = {
         id: `subflow_${sanitizeId(node.name)}`,


### PR DESCRIPTION
**[orchestrator]**

## Summary

- Remove the `insideMap` guard that blocked async nodes inside map subgraphs, enabling mixed human/agent task routing in parallel maps
- Rename the map subgraph key from `graph` to `flow` for consistency with `team.flow`, with backward compatibility for `graph`
- Update JSON schema to accept either `flow` (preferred) or `graph` (deprecated) via `oneOf`
- Add 5 new tests covering async-in-map parsing, conditional routing, backward compat, and orchestrator rendering

Closes #327

## Test plan

- [x] All 565 tests pass (`npm test`)
- [x] Type check passes (`npx tsc --noEmit`)
- [ ] Review async node rendering inside map step numbering (Step N.M as async)
- [ ] Review backward compat: existing configs using `graph` key still parse
- [ ] Verify Mermaid visualization renders async nodes inside maps correctly