### PR TITLE
feat: support skillfold.local.yaml for local config overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 *.tsbuildinfo
 *.tmp
 .tmp-*
+*.local.yaml
 .claude/*
 !.claude/skills/
 .claude/skills/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,8 @@ Located in `library/examples/`:
 - npm skill discovery: `agentskills` field in package.json uses flat key-value format for ecosystem compatibility
 - `npm:` prefix support for skill references and imports (resolves to node_modules paths)
 - Publishing guide (`docs/publishing.md`) for sharing skills via npm
-- Test suite with 565 tests across 105 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, and e2e modules
+- `skillfold.local.yaml` support for local config overrides (gitignored), with merge semantics for skills/state/team
+- Test suite with 580 tests across 107 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -248,7 +248,43 @@ The orchestrator state table also benefits: instead of abstract `github: discuss
 
 Skills without `resources` still work - the compiler emits a warning suggesting you add declarations for compile-time validation.
 
-## 8. Start from a template
+## 8. Local overrides
+
+On a multi-developer team, you may want personal overrides without modifying the shared config. Create a `skillfold.local.yaml` alongside your main config:
+
+```yaml
+# skillfold.local.yaml - personal overrides (gitignored)
+skills:
+  composed:
+    engineer:
+      compose: [planning, coding, testing]
+      description: "My local engineer with extra testing skill."
+      model: claude-sonnet-4-20250514
+```
+
+The local file merges on top of the main config:
+
+- **Skills** - adds or replaces atomic and composed skills
+- **State** - adds fields (does not remove existing ones)
+- **Team** - replaces the team flow entirely if present
+
+The local file does not need a `name` field (the name comes from the main config) and cannot have its own `imports`.
+
+When `skillfold init` scaffolds a project, it adds `*.local.yaml` to `.gitignore` automatically. Add it manually to existing projects:
+
+```bash
+echo "*.local.yaml" >> .gitignore
+```
+
+The compiler logs when a local override is applied:
+
+```
+skillfold: using local override from skillfold.local.yaml
+```
+
+The local filename is derived from the main config: if your config is `my-pipeline.yaml`, the local file is `my-pipeline.local.yaml`.
+
+## 9. Start from a template
 
 If you prefer starting from a real-world pattern instead of the minimal starter:
 
@@ -266,7 +302,7 @@ Available templates:
 
 Templates use library skills via imports, so they work out of the box with no local skill directories needed.
 
-## 9. Deploy to your platform
+## 10. Deploy to your platform
 
 Compile directly to where your platform reads skills. See the [Integration Guide](integrations.md) for all platforms.
 
@@ -283,7 +319,7 @@ For Claude Code, `--target claude-code` generates agent markdown files alongside
 
 Skillfold also ships a built-in plugin with 11 generic skills. Install it by referencing `node_modules/skillfold/plugin/` from your Claude Code configuration.
 
-## 10. Sharing skills
+## 11. Sharing skills
 
 Once you have skills worth reusing across projects or teams, publish them to npm. Any skill directory or pipeline config can be packaged and shared.
 
@@ -300,7 +336,7 @@ imports:
 
 See the [Publishing Guide](publishing.md) for package structure, required fields, and discovery via `skillfold search`.
 
-## 11. Next steps
+## 12. Next steps
 
 - Read the full config specification in [BRIEF.md](../BRIEF.md)
 - Explore the [shared library examples](../library/examples/) for real pipeline patterns

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
-import { isAtomic, isComposed, loadConfig, readConfig } from "./config.js";
+import { getLocalConfigName, isAtomic, isComposed, loadConfig, readConfig } from "./config.js";
 import { compile } from "./compiler.js";
 import { ConfigError } from "./errors.js";
 import { resolveSkills } from "./resolver.js";
@@ -1717,5 +1717,360 @@ skills:
         return true;
       }
     );
+  });
+});
+
+describe("getLocalConfigName", () => {
+  it("derives local name from skillfold.yaml", () => {
+    assert.equal(getLocalConfigName("skillfold.yaml"), "skillfold.local.yaml");
+  });
+
+  it("derives local name from custom config path", () => {
+    assert.equal(getLocalConfigName("my-pipeline.yaml"), "my-pipeline.local.yaml");
+  });
+
+  it("handles path with directory", () => {
+    assert.equal(getLocalConfigName("/some/dir/skillfold.yaml"), "skillfold.local.yaml");
+  });
+
+  it("handles .yml extension", () => {
+    assert.equal(getLocalConfigName("pipeline.yml"), "pipeline.local.yml");
+  });
+});
+
+describe("local config override", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  function writeMainConfig(dir: string, content: string): string {
+    const filePath = join(dir, "skillfold.yaml");
+    writeFileSync(filePath, content, "utf-8");
+    return filePath;
+  }
+
+  function writeLocalConfig(dir: string, content: string): void {
+    writeFileSync(join(dir, "skillfold.local.yaml"), content, "utf-8");
+  }
+
+  function writeSkill(dir: string, name: string, body: string): void {
+    const skillDir = join(dir, "skills", name);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), `---\nname: ${name}\ndescription: ${name} skill.\n---\n\n${body}\n`, "utf-8");
+  }
+
+  it("works without local config file", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    const configPath = writeMainConfig(tmpDir, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+  composed:
+    bot:
+      compose: [alpha]
+      description: "A bot."
+`);
+    const config = await loadConfig(configPath);
+    assert.equal(config.name, "test");
+    assert.ok(isComposed(config.skills["bot"]));
+  });
+
+  it("merges local atomic skills on top of main config", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    writeSkill(tmpDir, "beta", "Beta body.");
+    const configPath = writeMainConfig(tmpDir, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+  composed:
+    bot:
+      compose: [alpha]
+      description: "A bot."
+`);
+    writeLocalConfig(tmpDir, `
+skills:
+  atomic:
+    beta: ./skills/beta
+  composed:
+    bot:
+      compose: [alpha, beta]
+      description: "A better bot."
+`);
+    const config = await loadConfig(configPath);
+    assert.equal(config.name, "test");
+    assert.ok(isAtomic(config.skills["alpha"]));
+    assert.ok(isAtomic(config.skills["beta"]));
+    const bot = config.skills["bot"];
+    assert.ok(isComposed(bot));
+    assert.deepEqual(bot.compose, ["alpha", "beta"]);
+    assert.equal(bot.description, "A better bot.");
+  });
+
+  it("local composed skills override main composed skills", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    writeSkill(tmpDir, "beta", "Beta body.");
+    const configPath = writeMainConfig(tmpDir, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+    beta: ./skills/beta
+  composed:
+    bot:
+      compose: [alpha]
+      description: "Uses alpha."
+`);
+    writeLocalConfig(tmpDir, `
+skills:
+  composed:
+    bot:
+      compose: [beta]
+      description: "Uses beta instead."
+`);
+    const config = await loadConfig(configPath);
+    const bot = config.skills["bot"];
+    assert.ok(isComposed(bot));
+    assert.deepEqual(bot.compose, ["beta"]);
+    assert.equal(bot.description, "Uses beta instead.");
+  });
+
+  it("local state adds fields to main state", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    const configPath = writeMainConfig(tmpDir, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+  composed:
+    bot:
+      compose: [alpha]
+      description: "A bot."
+state:
+  plan:
+    type: string
+`);
+    writeLocalConfig(tmpDir, `
+state:
+  notes:
+    type: string
+`);
+    const config = await loadConfig(configPath);
+    assert.ok(config.state);
+    assert.ok("plan" in config.state.fields);
+    assert.ok("notes" in config.state.fields);
+  });
+
+  it("local team replaces main team entirely", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    writeSkill(tmpDir, "beta", "Beta body.");
+    const configPath = writeMainConfig(tmpDir, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+    beta: ./skills/beta
+  composed:
+    bot-a:
+      compose: [alpha]
+      description: "Bot A."
+    bot-b:
+      compose: [beta]
+      description: "Bot B."
+state:
+  result:
+    type: string
+team:
+  flow:
+    - bot-a:
+        writes: [state.result]
+      then: bot-b
+    - bot-b:
+        reads: [state.result]
+      then: end
+`);
+    writeLocalConfig(tmpDir, `
+team:
+  flow:
+    - bot-b:
+        writes: [state.result]
+      then: end
+`);
+    const config = await loadConfig(configPath);
+    assert.ok(config.team);
+    // The local team has only bot-b, so the flow should have one node
+    assert.equal(config.team.flow.nodes.length, 1);
+    assert.equal((config.team.flow.nodes[0] as { skill: string }).skill, "bot-b");
+  });
+
+  it("local config does not require name field", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    writeSkill(tmpDir, "beta", "Beta body.");
+    const configPath = writeMainConfig(tmpDir, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+  composed:
+    bot:
+      compose: [alpha]
+      description: "A bot."
+`);
+    writeLocalConfig(tmpDir, `
+skills:
+  atomic:
+    beta: ./skills/beta
+`);
+    const config = await loadConfig(configPath);
+    assert.equal(config.name, "test");
+    assert.ok(isAtomic(config.skills["beta"]));
+  });
+
+  it("local config does not require skills section", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    const configPath = writeMainConfig(tmpDir, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+  composed:
+    bot:
+      compose: [alpha]
+      description: "A bot."
+state:
+  plan:
+    type: string
+`);
+    writeLocalConfig(tmpDir, `
+state:
+  notes:
+    type: string
+`);
+    const config = await loadConfig(configPath);
+    assert.ok(config.state);
+    assert.ok("notes" in config.state.fields);
+    // Original skills preserved
+    assert.ok(isAtomic(config.skills["alpha"]));
+    assert.ok(isComposed(config.skills["bot"]));
+  });
+
+  it("local config with only team section", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    const configPath = writeMainConfig(tmpDir, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+  composed:
+    bot:
+      compose: [alpha]
+      description: "A bot."
+state:
+  result:
+    type: string
+team:
+  flow:
+    - bot:
+        writes: [state.result]
+      then: end
+`);
+    writeLocalConfig(tmpDir, `
+team:
+  flow:
+    - bot:
+        reads: [state.result]
+      then: end
+`);
+    const config = await loadConfig(configPath);
+    assert.ok(config.team);
+    assert.equal((config.team.flow.nodes[0] as { skill: string }).skill, "bot");
+  });
+
+  it("local config rejects imports", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    const configPath = writeMainConfig(tmpDir, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+  composed:
+    bot:
+      compose: [alpha]
+      description: "A bot."
+`);
+    writeLocalConfig(tmpDir, `
+imports:
+  - some/path.yaml
+skills:
+  atomic:
+    beta: ./skills/beta
+`);
+    await assert.rejects(
+      () => loadConfig(configPath),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /Local config cannot have imports/);
+        return true;
+      }
+    );
+  });
+
+  it("local config uses custom config name", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    writeSkill(tmpDir, "beta", "Beta body.");
+    const configPath = join(tmpDir, "my-pipeline.yaml");
+    writeFileSync(configPath, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+  composed:
+    bot:
+      compose: [alpha]
+      description: "A bot."
+`, "utf-8");
+    writeFileSync(join(tmpDir, "my-pipeline.local.yaml"), `
+skills:
+  atomic:
+    beta: ./skills/beta
+`, "utf-8");
+    const config = await loadConfig(configPath);
+    assert.ok(isAtomic(config.skills["beta"]));
+  });
+
+  it("empty local config is a no-op", async () => {
+    tmpDir = makeTmpDir();
+    writeSkill(tmpDir, "alpha", "Alpha body.");
+    const configPath = writeMainConfig(tmpDir, `
+name: test
+skills:
+  atomic:
+    alpha: ./skills/alpha
+  composed:
+    bot:
+      compose: [alpha]
+      description: "A bot."
+`);
+    // An empty YAML document parses as null, which should be caught
+    writeLocalConfig(tmpDir, `# empty local config\n{}`);
+    const config = await loadConfig(configPath);
+    assert.equal(config.name, "test");
+    assert.ok(isComposed(config.skills["bot"]));
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, relative, resolve } from "node:path";
+import { basename, dirname, extname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { parse } from "yaml";
@@ -553,6 +553,123 @@ function mergeRawState(
   return { ...base, ...overlay };
 }
 
+// Derive the local config filename from the main config path.
+// skillfold.yaml -> skillfold.local.yaml
+// my-pipeline.yaml -> my-pipeline.local.yaml
+export function getLocalConfigName(configPath: string): string {
+  const base = basename(configPath);
+  const ext = extname(base);
+  const name = base.slice(0, -ext.length);
+  return `${name}.local${ext}`;
+}
+
+// Parse a local override config. Unlike parseRawConfig, this does not require
+// a name field or a skills section - any section is optional.
+function parseLocalConfig(content: string): Partial<RawConfig> {
+  const raw = parse(content);
+  if (typeof raw !== "object" || raw === null) {
+    throw new ConfigError("Local config must be a YAML object");
+  }
+
+  const result: Partial<RawConfig> = {};
+
+  if (raw.imports !== undefined) {
+    throw new ConfigError(
+      "Local config cannot have imports. Imports come from the main config only."
+    );
+  }
+
+  if (raw.skills !== undefined) {
+    if (typeof raw.skills !== "object" || raw.skills === null) {
+      throw new ConfigError("Local config: skills must be an object");
+    }
+
+    let skills: Record<string, SkillEntry> = {};
+
+    if (raw.skills.atomic !== undefined) {
+      if (typeof raw.skills.atomic !== "object" || raw.skills.atomic === null) {
+        throw new ConfigError("Local config: skills.atomic must be an object");
+      }
+      skills = normalizeAtomicSkills(raw.skills.atomic as Record<string, unknown>);
+    }
+
+    if (raw.skills.composed !== undefined) {
+      if (typeof raw.skills.composed !== "object" || raw.skills.composed === null) {
+        throw new ConfigError("Local config: skills.composed must be an object");
+      }
+      const composed = normalizeComposedSkills(raw.skills.composed as Record<string, unknown>);
+      for (const name of Object.keys(composed)) {
+        if (name in skills) {
+          throw new ConfigError(
+            `Local config: skill "${name}" appears in both atomic and composed sections`
+          );
+        }
+      }
+      skills = { ...skills, ...composed };
+    }
+
+    if (!raw.skills.atomic && !raw.skills.composed) {
+      throw new ConfigError(
+        "Local config: skills must have 'atomic' and/or 'composed' sub-sections"
+      );
+    }
+
+    validateNames(skills);
+    result.skills = skills;
+  }
+
+  if (raw.state !== undefined) {
+    if (typeof raw.state !== "object" || raw.state === null) {
+      throw new ConfigError("Local config: state must be a YAML object");
+    }
+    result.rawState = raw.state as Record<string, unknown>;
+  }
+
+  if (raw.team !== undefined) {
+    if (typeof raw.team !== "object" || raw.team === null) {
+      throw new ConfigError("Local config: team must be a YAML object");
+    }
+    if (!raw.team.flow) {
+      throw new ConfigError("Local config: team must have a 'flow' field");
+    }
+    if (!Array.isArray(raw.team.flow)) {
+      throw new ConfigError("Local config: team.flow must be a YAML array");
+    }
+    const rawTeam: NonNullable<RawConfig["rawTeam"]> = { rawFlow: raw.team.flow };
+    if (raw.team.orchestrator !== undefined) {
+      if (typeof raw.team.orchestrator !== "string") {
+        throw new ConfigError("Local config: team.orchestrator must be a string (skill name)");
+      }
+      rawTeam.orchestrator = raw.team.orchestrator;
+    }
+    result.rawTeam = rawTeam;
+  }
+
+  return result;
+}
+
+// Merge a local override on top of a (possibly already import-merged) RawConfig.
+function mergeLocalOverride(raw: RawConfig, localPath: string): RawConfig {
+  let content: string;
+  try {
+    content = readFileSync(localPath, "utf-8");
+  } catch {
+    throw new ConfigError(`Cannot read local config file: ${localPath}`);
+  }
+
+  const local = parseLocalConfig(content);
+
+  return {
+    name: raw.name,
+    skills: local.skills ? mergeSkills(raw.skills, local.skills) : raw.skills,
+    rawState: local.rawState !== undefined
+      ? mergeRawState(raw.rawState, local.rawState)
+      : raw.rawState,
+    rawTeam: local.rawTeam !== undefined ? local.rawTeam : raw.rawTeam,
+    _resolvedGraph: local.rawTeam !== undefined ? undefined : raw._resolvedGraph,
+  };
+}
+
 // Resolve imports: load each import, merge skills and state, ignore team/imports
 async function resolveImports(
   raw: RawConfig,
@@ -752,7 +869,16 @@ export async function loadConfig(configPath: string): Promise<Config> {
   try {
     const raw = parseRawConfig(content);
     const merged = await resolveImports(raw, dirname(configPath));
-    const resolved = await resolveSubFlows(merged, dirname(configPath));
+    let resolved = await resolveSubFlows(merged, dirname(configPath));
+
+    // Check for local override file (e.g. skillfold.local.yaml)
+    const localName = getLocalConfigName(configPath);
+    const localPath = resolve(dirname(configPath), localName);
+    if (existsSync(localPath)) {
+      process.stderr.write(`skillfold: using local override from ${localName}\n`);
+      resolved = mergeLocalOverride(resolved, localPath);
+    }
+
     return validateAndBuild(resolved);
   } catch (err) {
     if (err instanceof ConfigError && !err.message.includes(configPath)) {

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -126,8 +126,9 @@ describe("initFromTemplate", () => {
     tmpDir = makeTmpDir();
     const files = initFromTemplate(tmpDir, "dev-team");
 
-    assert.deepEqual(files, ["skillfold.yaml"]);
+    assert.deepEqual(files, ["skillfold.yaml", ".gitignore"]);
     assert.ok(existsSync(join(tmpDir, "skillfold.yaml")));
+    assert.ok(existsSync(join(tmpDir, ".gitignore")));
 
     const config = readFileSync(join(tmpDir, "skillfold.yaml"), "utf-8");
     assert.ok(config.includes("name: dev-team"));
@@ -149,7 +150,7 @@ describe("initFromTemplate", () => {
     for (const template of TEMPLATES) {
       tmpDir = makeTmpDir();
       const files = initFromTemplate(tmpDir, template);
-      assert.deepEqual(files, ["skillfold.yaml"]);
+      assert.deepEqual(files, ["skillfold.yaml", ".gitignore"]);
 
       const config = readFileSync(join(tmpDir, "skillfold.yaml"), "utf-8");
       assert.ok(config.includes(`name: ${template}`));

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -114,6 +114,19 @@ You review code for correctness, clarity, and security.
 - Provide specific, actionable feedback
 `;
 
+const LOCAL_GITIGNORE_ENTRY = "*.local.yaml\n";
+
+function ensureGitignoreLocal(dir: string): void {
+  const gitignorePath = join(dir, ".gitignore");
+  if (existsSync(gitignorePath)) {
+    const content = readFileSync(gitignorePath, "utf-8");
+    if (content.includes("*.local.yaml")) return;
+    appendFileSync(gitignorePath, (content.endsWith("\n") ? "" : "\n") + LOCAL_GITIGNORE_ENTRY, "utf-8");
+  } else {
+    writeFileSync(gitignorePath, LOCAL_GITIGNORE_ENTRY, "utf-8");
+  }
+}
+
 export const TEMPLATES = ["dev-team", "content-pipeline", "code-review-bot"] as const;
 export type Template = (typeof TEMPLATES)[number];
 
@@ -154,8 +167,9 @@ export function initFromTemplate(dir: string, template: string): string[] {
 
   mkdirSync(dir, { recursive: true });
   writeFileSync(configPath, config, "utf-8");
+  ensureGitignoreLocal(dir);
 
-  return ["skillfold.yaml"];
+  return ["skillfold.yaml", ".gitignore"];
 }
 
 export function initProject(dir: string): string[] {
@@ -185,6 +199,9 @@ export function initProject(dir: string): string[] {
     writeFileSync(join(skillDir, "SKILL.md"), content, "utf-8");
     files.push(`skills/${name}/SKILL.md`);
   }
+
+  ensureGitignoreLocal(dir);
+  files.push(".gitignore");
 
   return files;
 }

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,7 +1,7 @@
-import { watch, type FSWatcher } from "node:fs";
+import { existsSync, watch, type FSWatcher } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
 
-import { isAtomic, loadConfig } from "./config.js";
+import { getLocalConfigName, isAtomic, loadConfig } from "./config.js";
 import { type CompileTarget, compile } from "./compiler.js";
 import { ConfigError, CompileError, GraphError, ResolveError } from "./errors.js";
 import { resolveSkills } from "./resolver.js";
@@ -85,6 +85,26 @@ export async function watchPipeline(
 
     const configWatcher = watch(configPath, onChange);
     watchers.push(configWatcher);
+
+    // Watch the local override file if it exists
+    const localName = getLocalConfigName(configPath);
+    const localPath = resolve(dirname(configPath), localName);
+    if (existsSync(localPath)) {
+      const localWatcher = watch(localPath, onChange);
+      watchers.push(localWatcher);
+    }
+
+    // Watch the config directory for local file creation
+    try {
+      const dirWatcher = watch(dirname(configPath), (_, filename) => {
+        if (filename === localName) {
+          onChange();
+        }
+      });
+      watchers.push(dirWatcher);
+    } catch {
+      // Directory watcher may not be supported
+    }
 
     for (const dir of skillDirs) {
       try {


### PR DESCRIPTION
## Summary

- Add `skillfold.local.yaml` support so developers on a shared team can override the main config locally without modifying the committed file
- The local file merges on top of the main config: skills are added/replaced, state fields are added, and team flow is replaced entirely if present
- The local file does not require a `name` field and cannot have its own `imports`
- `skillfold init` now adds `*.local.yaml` to `.gitignore` automatically
- `skillfold watch` monitors the local config file for changes

Closes #330

## Changes

- **src/config.ts** - Add `parseLocalConfig()` (relaxed validation), `mergeLocalOverride()`, `getLocalConfigName()` helper; update `loadConfig()` to detect and apply local overrides after imports/sub-flows
- **src/watch.ts** - Watch the local config file and the config directory for local file creation/changes
- **src/init.ts** - Add `*.local.yaml` to `.gitignore` on `init` and `init --template`
- **.gitignore** - Add `*.local.yaml` to project root gitignore
- **src/config.test.ts** - 15 new tests covering merge semantics, edge cases, custom config names, and error handling
- **src/init.test.ts** - Update expectations to include `.gitignore` in scaffold output
- **docs/getting-started.md** - New "Local overrides" section (section 8)
- **CLAUDE.md** - Update What's Implemented and test count (580 tests, 107 suites)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (580 tests, 107 suites, 0 failures)
- [ ] Manual: create `skillfold.local.yaml` alongside a main config and verify merge behavior
- [ ] Manual: run `skillfold init` and verify `.gitignore` contains `*.local.yaml`
- [ ] Manual: run `skillfold watch` and verify local config changes trigger recompile

Generated with [Claude Code](https://claude.com/claude-code)