### PR TITLE
feat: move resource declarations to top-level config section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,15 +70,16 @@ BRIEF.md               - Full design brief
 
 ## Config Structure
 
-Three top-level sections: `skills`, `state`, `team`.
+Four top-level sections: `resources`, `skills`, `state`, `team`.
 
-- **skills.atomic**: Path references to atomic skill directories (can declare `resources` for compile-time location validation)
+- **resources**: Resource declarations mapping group names to namespace URLs for state location validation and orchestrator URL resolution
+- **skills.atomic**: Path references to atomic skill directories
 - **skills.composed**: Composition declarations combining atomic skills into agents
 - **state**: Typed state schema (top-level, importable independently)
 - **team.orchestrator**: Optional skill name to append generated plan to
 - **team.flow**: Directed execution graph with conditional routing, loops, parallel map, and sub-flow imports
 
-Imports pull in `skills` and `state`, ignore `team`.
+Imports pull in `skills`, `state`, and `resources`, ignore `team`.
 
 ## Design Brief Summary
 
@@ -161,8 +162,8 @@ Located in `library/examples/`:
 - `skillfold plugin` command for packaging pipelines as distributable Claude Code plugins
 - `skillfold adopt` command for adopting existing Claude Code agents into a pipeline
 - Async flow nodes for external agents (humans, CI, other teams) with `async: true` and policy options (block, skip, use-latest)
-- Resource namespace declarations on atomic skills for compile-time state location path validation
-- Resolved location URLs in orchestrator state table output (base URL templates from skill resources)
+- Top-level `resources` section for resource namespace declarations with compile-time state location path validation (skill-level resources deprecated but backward compatible)
+- Resolved location URLs in orchestrator state table output (base URL templates from top-level resources)
 - Compiler warnings for implicit state locations (skills without resource declarations)
 - Sub-flow imports: flow nodes can reference external pipeline configs via `flow:` field, with recursive resolution, skill/state merging, circular reference detection, orchestrator rendering with hierarchical steps, and Mermaid visualization as subgraphs
 - Async nodes inside map subgraphs for modeling human/external tasks alongside agent tasks in parallel maps
@@ -172,7 +173,7 @@ Located in `library/examples/`:
 - `npm:` prefix support for skill references and imports (resolves to node_modules paths)
 - Publishing guide (`docs/publishing.md`) for sharing skills via npm
 - `skillfold.local.yaml` support for local config overrides (gitignored), with merge semantics for skills/state/team
-- Test suite with 580 tests across 107 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, and e2e modules
+- Test suite with 592 tests across 108 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Then:
 
 ### Typed State Schemas
 
-Custom types, primitives, and `list<Type>`. The compiler validates that every read has a matching write, detects write conflicts, and maps state to external locations. Atomic skills can declare `resources` for compile-time validation of location paths.
+Custom types, primitives, and `list<Type>`. The compiler validates that every read has a matching write, detects write conflicts, and maps state to external locations. A top-level `resources` section declares namespace URLs for compile-time validation of location paths.
 
 ```yaml
 state:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -229,24 +229,25 @@ Async nodes participate in the flow graph like regular nodes - they have reads, 
 
 ## 7. Declare resource namespaces
 
-When a state field has a `location` pointing to an atomic skill, the compiler can validate that the location path matches a declared namespace. Add `resources` to your atomic skill definitions:
+When a state field has a `location`, the compiler can validate that the location path matches a declared namespace. Add a top-level `resources` section to your config:
 
 ```yaml
+resources:
+  github:
+    discussions: "https://github.com/org/repo/discussions"
+    issues: "https://github.com/org/repo/issues"
+    pull-requests: "https://github.com/org/repo/pulls"
+
 skills:
   atomic:
-    github:
-      path: ./skills/github
-      resources:
-        discussions: "https://github.com/org/repo/discussions"
-        issues: "https://github.com/org/repo/issues"
-        pull-requests: "https://github.com/org/repo/pulls"
+    github: ./skills/github
 ```
 
 Now when a state field references `github` with a `location.path`, the compiler checks that the first path segment matches a declared resource namespace. A path like `discussions/general` matches `discussions`; a path like `wikis/page` would fail with a clear error.
 
 The orchestrator state table also benefits: instead of abstract `github: discussions/general`, it renders the resolved URL `https://github.com/org/repo/discussions/general`, giving the orchestrator agent concrete locations to work with.
 
-Skills without `resources` still work - the compiler emits a warning suggesting you add declarations for compile-time validation.
+Resource groups without matching state locations still work. The compiler emits a warning suggesting you add resource declarations when a state location references a skill with no resource group.
 
 ## 8. Local overrides
 

--- a/skillfold.schema.json
+++ b/skillfold.schema.json
@@ -18,6 +18,23 @@
         "type": "string"
       }
     },
+    "resources": {
+      "type": "object",
+      "description": "Top-level resource declarations mapping resource group names to namespace-URL maps. State locations reference these by the group name in the 'skill' field. Decouples deployment-specific URLs from skill definitions.",
+      "additionalProperties": {
+        "type": "object",
+        "description": "Resource namespaces with base URL templates.",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        }
+      },
+      "propertyNames": {
+        "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+      }
+    },
     "skills": {
       "type": "object",
       "description": "Skill definitions split into atomic and composed sub-sections.",

--- a/skillfold.yaml
+++ b/skillfold.yaml
@@ -1,5 +1,11 @@
 name: skillfold-team
 
+resources:
+  github:
+    discussions: "https://github.com/byronxlg/skillfold/discussions"
+    issues: "https://github.com/byronxlg/skillfold/issues"
+    pull-requests: "https://github.com/byronxlg/skillfold/pulls"
+
 skills:
   atomic:
     # Remote public skills
@@ -12,12 +18,7 @@ skills:
     security-best-practices: https://github.com/openai/skills/tree/main/skills/.curated/security-best-practices
 
     # Project-specific skills
-    github:
-      path: ./skills/github
-      resources:
-        discussions: "https://github.com/byronxlg/skillfold/discussions"
-        issues: "https://github.com/byronxlg/skillfold/issues"
-        pull-requests: "https://github.com/byronxlg/skillfold/pulls"
+    github: ./skills/github
     moltbook: ./skills/moltbook
     product-strategy: ./skills/product-strategy
     skillfold-context: ./skills/skillfold-context

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1720,6 +1720,190 @@ skills:
   });
 });
 
+describe("top-level resources", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("parses top-level resources section", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github: ./skills/github
+resources:
+  github:
+    discussions: "https://github.com/org/repo/discussions"
+    issues: "https://github.com/org/repo/issues"
+`);
+    const config = readConfig(configPath);
+    assert.deepEqual(config.resources, {
+      github: {
+        discussions: "https://github.com/org/repo/discussions",
+        issues: "https://github.com/org/repo/issues",
+      },
+    });
+  });
+
+  it("uses top-level resources for state location validation", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github: ./skills/github
+resources:
+  github:
+    discussions: "https://github.com/org/repo/discussions"
+    issues: "https://github.com/org/repo/issues"
+state:
+  direction:
+    type: string
+    location:
+      skill: github
+      path: discussions/strategy
+`);
+    const config = readConfig(configPath);
+    assert.equal(config.state?.fields.direction.location?.skill, "github");
+    assert.equal(config.state?.fields.direction.location?.path, "discussions/strategy");
+  });
+
+  it("rejects invalid namespace against top-level resources", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github: ./skills/github
+resources:
+  github:
+    discussions: "https://github.com/org/repo/discussions"
+state:
+  direction:
+    type: string
+    location:
+      skill: github
+      path: wikis/strategy
+`);
+    assert.throws(
+      () => readConfig(configPath),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /namespace "wikis"/);
+        return true;
+      }
+    );
+  });
+
+  it("top-level resources take precedence over inline skill resources", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github:
+      path: ./skills/github
+      resources:
+        discussions: "https://old.example.com/discussions"
+resources:
+  github:
+    discussions: "https://new.example.com/discussions"
+state:
+  direction:
+    type: string
+    location:
+      skill: github
+      path: discussions/strategy
+`);
+    const config = readConfig(configPath);
+    assert.equal(config.state?.fields.direction.location?.skill, "github");
+    assert.deepEqual(config.resources, {
+      github: {
+        discussions: "https://new.example.com/discussions",
+      },
+    });
+  });
+
+  it("rejects top-level resources with invalid group name", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github: ./skills/github
+resources:
+  GitHub:
+    discussions: "https://example.com"
+`);
+    assert.throws(
+      () => readConfig(configPath),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /Resource group "GitHub"/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects top-level resources with non-map value", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github: ./skills/github
+resources: "not a map"
+`);
+    assert.throws(
+      () => readConfig(configPath),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /resources.*must be a YAML map/i);
+        return true;
+      }
+    );
+  });
+
+  it("accepts config with no resources section", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github: ./skills/github
+`);
+    const config = readConfig(configPath);
+    assert.equal(config.resources, undefined);
+  });
+
+  it("supports multiple resource groups", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    github: ./skills/github
+    slack: ./skills/slack
+resources:
+  github:
+    issues: "https://github.com/org/repo/issues"
+  slack:
+    channels: "https://slack.com/api/channels"
+`);
+    const config = readConfig(configPath);
+    assert.deepEqual(config.resources, {
+      github: { issues: "https://github.com/org/repo/issues" },
+      slack: { channels: "https://slack.com/api/channels" },
+    });
+  });
+});
+
 describe("getLocalConfigName", () => {
   it("derives local name from skillfold.yaml", () => {
     assert.equal(getLocalConfigName("skillfold.yaml"), "skillfold.local.yaml");

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,7 @@ export interface TeamConfig {
 export interface Config {
   name: string;
   skills: Record<string, SkillEntry>;
+  resources?: Record<string, Record<string, string>>;
   state?: StateSchema;
   team?: TeamConfig;
 }
@@ -75,6 +76,7 @@ export interface Config {
 export interface RawConfig {
   name: string;
   skills: Record<string, SkillEntry>;
+  resources?: Record<string, Record<string, string>>;
   rawState?: Record<string, unknown>;
   rawTeam?: {
     orchestrator?: string;
@@ -119,6 +121,24 @@ function parseResources(
     resources[key] = val;
   }
   return resources;
+}
+
+function parseTopLevelResources(
+  rawResources: unknown,
+): Record<string, Record<string, string>> {
+  if (typeof rawResources !== "object" || rawResources === null || Array.isArray(rawResources)) {
+    throw new ConfigError("Top-level resources must be a YAML map");
+  }
+  const result: Record<string, Record<string, string>> = {};
+  for (const [groupName, groupValue] of Object.entries(rawResources as Record<string, unknown>)) {
+    if (!RESOURCE_NAME_RE.test(groupName)) {
+      throw new ConfigError(
+        `Resource group "${groupName}" must be lowercase alphanumeric with hyphens`
+      );
+    }
+    result[groupName] = parseResources(groupName, groupValue);
+  }
+  return result;
 }
 
 function normalizeAtomicSkills(
@@ -422,6 +442,34 @@ export function parseRawConfig(content: string): RawConfig {
 
   const result: RawConfig = { name: raw.name, skills };
 
+  // Parse top-level resources
+  if (raw.resources !== undefined) {
+    result.resources = parseTopLevelResources(raw.resources);
+  }
+
+  // Check for deprecated skill-level resources and merge into top-level
+  let mergedResources: Record<string, Record<string, string>> = result.resources ? { ...result.resources } : {};
+  let hasSkillLevelResources = false;
+  for (const [name, skill] of Object.entries(skills)) {
+    if (isAtomic(skill) && skill.resources && Object.keys(skill.resources).length > 0) {
+      hasSkillLevelResources = true;
+      process.stderr.write(
+        `Warning: resources on skills.atomic.${name} is deprecated, move to top-level "resources" section\n`
+      );
+      // Skill-level provides defaults; top-level overrides
+      if (!(name in mergedResources)) {
+        mergedResources[name] = { ...skill.resources };
+      } else {
+        mergedResources[name] = { ...skill.resources, ...mergedResources[name] };
+      }
+    }
+  }
+  if (Object.keys(mergedResources).length > 0) {
+    result.resources = mergedResources;
+  } else if (hasSkillLevelResources) {
+    result.resources = mergedResources;
+  }
+
   if (raw.state !== undefined) {
     if (typeof raw.state !== "object" || raw.state === null) {
       throw new ConfigError("State must be a YAML object");
@@ -481,10 +529,20 @@ export function validateAndBuild(raw: RawConfig): Config {
 
   const config: Config = { name: raw.name, skills: raw.skills };
 
+  if (raw.resources && Object.keys(raw.resources).length > 0) {
+    config.resources = raw.resources;
+  }
+
   if (raw.rawState !== undefined) {
     const skillsForState: Record<string, { resources?: Record<string, string> }> = {};
     for (const [name, skill] of Object.entries(raw.skills)) {
-      skillsForState[name] = isAtomic(skill) ? { resources: skill.resources } : {};
+      if (config.resources && config.resources[name]) {
+        skillsForState[name] = { resources: config.resources[name] };
+      } else if (isAtomic(skill) && skill.resources) {
+        skillsForState[name] = { resources: skill.resources };
+      } else {
+        skillsForState[name] = {};
+      }
     }
     config.state = parseState(raw.rawState, skillsForState);
   }
@@ -524,11 +582,7 @@ function rebaseSkillPaths(
     if (isAtomic(skill) && !skill.path.startsWith("https://") && !isNpmRef(skill.path)) {
       const abs = resolve(importDir, skill.path);
       const rebased = relative(targetDir, abs);
-      const rebasedSkill: AtomicSkill = { path: rebased };
-      if (skill.resources) {
-        rebasedSkill.resources = skill.resources;
-      }
-      result[name] = rebasedSkill;
+      result[name] = { path: rebased };
     } else {
       result[name] = skill;
     }
@@ -551,6 +605,21 @@ function mergeRawState(
   if (!base) return overlay;
   if (!overlay) return base;
   return { ...base, ...overlay };
+}
+
+function mergeResources(
+  base: Record<string, Record<string, string>> | undefined,
+  overlay: Record<string, Record<string, string>> | undefined,
+): Record<string, Record<string, string>> | undefined {
+  if (!base) return overlay;
+  if (!overlay) return base;
+  const merged = { ...base };
+  for (const [group, resources] of Object.entries(overlay)) {
+    merged[group] = group in merged
+      ? { ...merged[group], ...resources }
+      : { ...resources };
+  }
+  return merged;
 }
 
 // Derive the local config filename from the main config path.
@@ -662,6 +731,7 @@ function mergeLocalOverride(raw: RawConfig, localPath: string): RawConfig {
   return {
     name: raw.name,
     skills: local.skills ? mergeSkills(raw.skills, local.skills) : raw.skills,
+    resources: raw.resources,
     rawState: local.rawState !== undefined
       ? mergeRawState(raw.rawState, local.rawState)
       : raw.rawState,
@@ -681,6 +751,7 @@ async function resolveImports(
 
   let mergedSkills: Record<string, SkillEntry> = {};
   let mergedState: Record<string, unknown> | undefined;
+  let mergedResources: Record<string, Record<string, string>> | undefined;
 
   for (const importPath of raw.imports) {
     let content: string;
@@ -722,15 +793,18 @@ async function resolveImports(
       : imported.skills;
     mergedSkills = mergeSkills(mergedSkills, skills);
     mergedState = mergeRawState(mergedState, imported.rawState);
+    mergedResources = mergeResources(mergedResources, imported.resources);
   }
 
   // Apply local on top (last-write-wins)
   mergedSkills = mergeSkills(mergedSkills, raw.skills);
   mergedState = mergeRawState(mergedState, raw.rawState);
+  mergedResources = mergeResources(mergedResources, raw.resources);
 
   return {
     name: raw.name,
     skills: mergedSkills,
+    resources: mergedResources,
     rawState: mergedState,
     rawTeam: raw.rawTeam,
     // imports consumed
@@ -769,6 +843,7 @@ async function resolveSubFlows(
   const resolvedPaths = visited ?? new Set<string>();
   let mergedSkills = { ...raw.skills };
   let mergedState = raw.rawState ? { ...raw.rawState } : undefined;
+  let mergedResources = raw.resources ? { ...raw.resources } : undefined;
 
   for (const sfNode of subFlowNodes) {
     const configPath = resolve(baseDir, sfNode.flow);
@@ -814,6 +889,9 @@ async function resolveSubFlows(
       mergedState = mergeRawState(mergedState, subResolved.rawState);
     }
 
+    // Merge resources from the sub-flow config
+    mergedResources = mergeResources(mergedResources, subResolved.resources);
+
     // Parse the sub-flow's flow graph and attach it to the node.
     // We mutate the sfNode.graph here; this is safe because parseGraph
     // created fresh objects from the raw YAML.
@@ -831,6 +909,7 @@ async function resolveSubFlows(
   return {
     name: raw.name,
     skills: mergedSkills,
+    resources: mergedResources,
     rawState: mergedState,
     rawTeam: raw.rawTeam,
     _resolvedGraph: graph,

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -365,14 +365,14 @@ team:
   it("inline config with resource declarations renders resolved URLs", () => {
     const raw = parseRawConfig(`
 name: resources-test
+resources:
+  github:
+    discussions: "https://github.com/org/repo/discussions"
+    issues: "https://github.com/org/repo/issues"
+    pull-requests: "https://github.com/org/repo/pulls"
 skills:
   atomic:
-    github:
-      path: ./skills/github
-      resources:
-        discussions: "https://github.com/org/repo/discussions"
-        issues: "https://github.com/org/repo/issues"
-        pull-requests: "https://github.com/org/repo/pulls"
+    github: ./skills/github
     coding: ./skills/coding
   composed:
     engineer:
@@ -414,6 +414,60 @@ team:
     assert.ok(output.includes("https://github.com/org/repo/issues"));
     assert.ok(output.includes("https://github.com/org/repo/pulls (review)"));
     // Should NOT contain abstract format
+    assert.ok(!output.includes("github: discussions"));
+  });
+
+  it("top-level resources render resolved URLs in orchestrator", () => {
+    const raw = parseRawConfig(`
+name: top-level-resources-test
+skills:
+  atomic:
+    github: ./skills/github
+    coding: ./skills/coding
+  composed:
+    engineer:
+      compose: [coding]
+      description: "Writes code."
+    orchestrator:
+      compose: [github]
+      description: "Coordinates."
+resources:
+  github:
+    discussions: "https://github.com/org/repo/discussions"
+    issues: "https://github.com/org/repo/issues"
+    pull-requests: "https://github.com/org/repo/pulls"
+state:
+  direction:
+    type: string
+    location:
+      skill: github
+      path: discussions/general
+  tasks:
+    type: string
+    location:
+      skill: github
+      path: issues
+  review:
+    type: string
+    location:
+      skill: github
+      path: pull-requests
+      kind: review
+team:
+  orchestrator: orchestrator
+  flow:
+    - engineer:
+        reads: [state.direction]
+        writes: [state.tasks]
+      then: end
+`);
+    const config = validateAndBuild(raw);
+    const output = generateOrchestrator(config);
+
+    // State table should have resolved URLs from top-level resources
+    assert.ok(output.includes("https://github.com/org/repo/discussions/general"));
+    assert.ok(output.includes("https://github.com/org/repo/issues"));
+    assert.ok(output.includes("https://github.com/org/repo/pulls (review)"));
     assert.ok(!output.includes("github: discussions"));
   });
 

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -845,9 +845,11 @@ describe("generateOrchestrator: async nodes inside map", () => {
 
 describe("formatLocation with resolved URLs", () => {
   const resources = {
-    discussions: "https://github.com/org/repo/discussions",
-    issues: "https://github.com/org/repo/issues",
-    "pull-requests": "https://github.com/org/repo/pulls",
+    github: {
+      discussions: "https://github.com/org/repo/discussions",
+      issues: "https://github.com/org/repo/issues",
+      "pull-requests": "https://github.com/org/repo/pulls",
+    },
   };
 
   it("resolves URL with sub-path", () => {
@@ -914,18 +916,18 @@ describe("formatLocation with resolved URLs", () => {
 });
 
 describe("generateOrchestrator with resolved URLs", () => {
-  it("renders resolved URLs in state table when skills have resources", () => {
+  it("renders resolved URLs in state table when config has resources", () => {
     const config: Config = {
       name: "resolved-urls",
       skills: {
-        github: {
-          path: "./skills/github",
-          resources: {
-            discussions: "https://github.com/org/repo/discussions",
-            issues: "https://github.com/org/repo/issues",
-          },
-        },
+        github: { path: "./skills/github" },
         worker: { compose: ["github"], description: "Does work." },
+      },
+      resources: {
+        github: {
+          discussions: "https://github.com/org/repo/discussions",
+          issues: "https://github.com/org/repo/issues",
+        },
       },
       state: {
         types: {},
@@ -957,5 +959,77 @@ describe("generateOrchestrator with resolved URLs", () => {
     const output = generateOrchestrator(config);
     assert.ok(output.includes("https://github.com/org/repo/discussions/general"));
     assert.ok(output.includes("https://github.com/org/repo/issues"));
+  });
+
+  it("renders resolved URLs from top-level resources", () => {
+    const config: Config = {
+      name: "top-level-resources",
+      skills: {
+        github: { path: "./skills/github" },
+        worker: { compose: ["github"], description: "Does work." },
+      },
+      resources: {
+        github: {
+          discussions: "https://github.com/org/repo/discussions",
+          issues: "https://github.com/org/repo/issues",
+        },
+      },
+      state: {
+        types: {},
+        fields: {
+          direction: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "github", path: "discussions/general" },
+          },
+          tasks: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "github", path: "issues" },
+          },
+        },
+      },
+      team: {
+        flow: {
+          nodes: [{ skill: "worker", reads: [], writes: [], then: "end" }],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+    assert.ok(output.includes("https://github.com/org/repo/discussions/general"));
+    assert.ok(output.includes("https://github.com/org/repo/issues"));
+  });
+
+  it("top-level resources take precedence over inline in orchestrator", () => {
+    const config: Config = {
+      name: "precedence-test",
+      skills: {
+        github: {
+          path: "./skills/github",
+          resources: { issues: "https://old.example.com/issues" },
+        },
+        worker: { compose: ["github"], description: "Does work." },
+      },
+      resources: {
+        github: { issues: "https://new.example.com/issues" },
+      },
+      state: {
+        types: {},
+        fields: {
+          tasks: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "github", path: "issues" },
+          },
+        },
+      },
+      team: {
+        flow: {
+          nodes: [{ skill: "worker", reads: [], writes: [], then: "end" }],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+    assert.ok(output.includes("https://new.example.com/issues"));
+    assert.ok(!output.includes("https://old.example.com/issues"));
   });
 });

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,5 +1,4 @@
 import type { Config } from "./config.js";
-import { isAtomic } from "./config.js";
 import { isAsyncNode, isConditionalThen, isMapNode, isSubFlowNode } from "./graph.js";
 import type { AsyncNode, GraphNode, Then } from "./graph.js";
 import type { StateField, StateType } from "./state.js";
@@ -22,11 +21,12 @@ export function formatType(type: StateType): string {
 
 export function formatLocation(
   field: StateField,
-  skillResources?: Record<string, string>,
+  resources?: Record<string, Record<string, string>>,
 ): string {
   if (!field.location) return "";
   const { skill, path, kind } = field.location;
 
+  const skillResources = resources?.[skill];
   if (skillResources) {
     const slashIdx = path.indexOf("/");
     const namespace = slashIdx === -1 ? path : path.slice(0, slashIdx);
@@ -338,14 +338,7 @@ export function generateOrchestrator(
 
     for (const [name, field] of Object.entries(config.state.fields)) {
       const typeStr = formatType(field.type);
-      let resources: Record<string, string> | undefined;
-      if (field.location) {
-        const skill = config.skills[field.location.skill];
-        if (skill && isAtomic(skill)) {
-          resources = skill.resources;
-        }
-      }
-      const locStr = formatLocation(field, resources);
+      const locStr = formatLocation(field, config.resources);
       lines.push(`| ${name} | ${typeStr} | ${locStr} |`);
     }
   }

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -536,15 +536,13 @@ describe("parseState", () => {
   });
 
   describe("resource namespace validation", () => {
-    const SKILLS_WITH_RESOURCES = {
+    const SKILL_NAMES = new Set(["github", "lint"]);
+    const RESOURCES = {
       github: {
-        resources: {
-          discussions: "https://github.com/org/repo/discussions",
-          issues: "https://github.com/org/repo/issues",
-          "pull-requests": "https://github.com/org/repo/pulls",
-        },
+        discussions: "https://github.com/org/repo/discussions",
+        issues: "https://github.com/org/repo/issues",
+        "pull-requests": "https://github.com/org/repo/pulls",
       },
-      lint: {},
     };
 
     it("accepts location path matching a declared namespace", () => {
@@ -554,7 +552,7 @@ describe("parseState", () => {
           location: { skill: "github", path: "discussions/general" },
         },
       };
-      const schema = parseState(raw, SKILLS_WITH_RESOURCES);
+      const schema = parseState(raw, SKILL_NAMES, RESOURCES);
       assert.equal(schema.fields["direction"].location?.path, "discussions/general");
     });
 
@@ -565,7 +563,7 @@ describe("parseState", () => {
           location: { skill: "github", path: "issues" },
         },
       };
-      const schema = parseState(raw, SKILLS_WITH_RESOURCES);
+      const schema = parseState(raw, SKILL_NAMES, RESOURCES);
       assert.equal(schema.fields["tasks"].location?.path, "issues");
     });
 
@@ -577,7 +575,7 @@ describe("parseState", () => {
         },
       };
       assert.throws(
-        () => parseState(raw, SKILLS_WITH_RESOURCES),
+        () => parseState(raw, SKILL_NAMES, RESOURCES),
         (err: unknown) => {
           assert.ok(err instanceof ConfigError);
           assert.match(err.message, /namespace "wikis" which is not declared/);
@@ -595,7 +593,7 @@ describe("parseState", () => {
         },
       };
       assert.throws(
-        () => parseState(raw, SKILLS_WITH_RESOURCES),
+        () => parseState(raw, SKILL_NAMES, RESOURCES),
         (err: unknown) => {
           assert.ok(err instanceof ConfigError);
           assert.match(err.message, /namespace "issue"/);
@@ -612,7 +610,7 @@ describe("parseState", () => {
           location: { skill: "lint", path: "anything/goes" },
         },
       };
-      const schema = parseState(raw, SKILLS_WITH_RESOURCES);
+      const schema = parseState(raw, SKILL_NAMES, RESOURCES);
       assert.equal(schema.fields["result"].location?.path, "anything/goes");
     });
 
@@ -625,6 +623,26 @@ describe("parseState", () => {
       };
       const schema = parseState(raw, SOME_SKILLS);
       assert.equal(schema.fields["result"].location?.skill, "review");
+    });
+
+    it("backward compat: Record<string, SkillResources> extracts resources", () => {
+      const SKILLS_WITH_RESOURCES = {
+        github: {
+          resources: {
+            discussions: "https://github.com/org/repo/discussions",
+            issues: "https://github.com/org/repo/issues",
+          },
+        },
+        lint: {},
+      };
+      const raw = {
+        direction: {
+          type: "string",
+          location: { skill: "github", path: "discussions/general" },
+        },
+      };
+      const schema = parseState(raw, SKILLS_WITH_RESOURCES);
+      assert.equal(schema.fields["direction"].location?.path, "discussions/general");
     });
   });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -107,7 +107,8 @@ function parseCustomType(
 function validateLocation(
   fieldName: string,
   location: unknown,
-  skills: Record<string, SkillResources>,
+  skillNames: Set<string>,
+  resources?: Record<string, Record<string, string>>,
 ): StateLocation {
   if (typeof location !== "object" || location === null) {
     throw new ConfigError(
@@ -129,29 +130,30 @@ function validateLocation(
     );
   }
 
-  if (!(loc.skill in skills)) {
+  // The "skill" field references a resource group name. It must either
+  // match a known skill name or a top-level resource group name.
+  if (!skillNames.has(loc.skill) && !(resources && loc.skill in resources)) {
     throw new ConfigError(
       `State field "${fieldName}": location references unknown skill "${loc.skill}"`
     );
   }
 
-  const skill = skills[loc.skill];
-
   // Validate namespace against resource declarations
-  if (skill.resources && Object.keys(skill.resources).length > 0) {
+  const resourceGroup = resources?.[loc.skill];
+  if (resourceGroup && Object.keys(resourceGroup).length > 0) {
     const slashIdx = loc.path.indexOf("/");
     const namespace = slashIdx === -1 ? loc.path : loc.path.slice(0, slashIdx);
-    if (!(namespace in skill.resources)) {
-      const declared = Object.keys(skill.resources);
+    if (!(namespace in resourceGroup)) {
+      const declared = Object.keys(resourceGroup);
       const hint = didYouMean(namespace, declared);
       throw new ConfigError(
         `State field "${fieldName}": location path "${loc.path}" references namespace "${namespace}" which is not declared by skill "${loc.skill}". Declared namespaces: ${declared.join(", ")}${hint}`
       );
     }
-  } else {
-    // Emit warning for implicit locations
+  } else if (!resourceGroup) {
+    // Emit warning for implicit locations (no resource group for this skill)
     process.stderr.write(
-      `Warning: state field "${fieldName}" references skill "${loc.skill}" which has no resource declarations. Consider adding a "resources" map to the "${loc.skill}" skill definition for compile-time path validation.\n`
+      `Warning: state field "${fieldName}" references skill "${loc.skill}" which has no resource declarations. Consider adding a "resources" map to the top-level "resources" section for compile-time path validation.\n`
     );
   }
 
@@ -166,12 +168,31 @@ function validateLocation(
 export function parseState(
   raw: Record<string, unknown>,
   skills: Set<string> | Record<string, SkillResources>,
+  resources?: Record<string, Record<string, string>>,
 ): StateSchema {
-  // Normalize: accept both Set<string> (legacy) and Record (new)
-  const skillsRecord: Record<string, SkillResources> =
-    skills instanceof Set
-      ? Object.fromEntries([...skills].map((n) => [n, {}]))
-      : skills;
+  // Normalize: accept both Set<string> (legacy) and Record<string, SkillResources> (legacy)
+  let skillNames: Set<string>;
+  let effectiveResources: Record<string, Record<string, string>> | undefined = resources;
+
+  if (skills instanceof Set) {
+    skillNames = skills;
+  } else {
+    skillNames = new Set(Object.keys(skills));
+    // Legacy path: extract resources from SkillResources if no top-level resources provided
+    if (!effectiveResources) {
+      const extracted: Record<string, Record<string, string>> = {};
+      let hasResources = false;
+      for (const [name, skill] of Object.entries(skills)) {
+        if (skill.resources && Object.keys(skill.resources).length > 0) {
+          extracted[name] = skill.resources;
+          hasResources = true;
+        }
+      }
+      if (hasResources) {
+        effectiveResources = extracted;
+      }
+    }
+  }
 
   const types: Record<string, CustomType> = {};
   const fields: Record<string, StateField> = {};
@@ -210,7 +231,7 @@ export function parseState(
     const field: StateField = { type: stateType };
 
     if ("location" in obj) {
-      field.location = validateLocation(name, obj.location, skillsRecord);
+      field.location = validateLocation(name, obj.location, skillNames, effectiveResources);
     }
 
     fields[name] = field;


### PR DESCRIPTION
**[engineer]**

## Summary

- Adds a top-level `resources` section to the config, decoupling resource URL declarations from atomic skill definitions
- Resources on atomic skills still work (backward compatible) with a deprecation warning
- Top-level resources take precedence when both exist
- Updates state validation, orchestrator URL resolution, and import/sub-flow merging
- Updates `skillfold.yaml` to use the new format
- Adds JSON Schema support for the new section

Closes #328

## Changes

**Config** (`src/config.ts`): New `resources` field on Config/RawConfig, `parseTopLevelResources()`, deprecated inline resources merged with warning, import/sub-flow resource merging, `mergeResources()` helper.

**State** (`src/state.ts`): `parseState()` accepts optional third `resources` arg, `validateLocation()` uses top-level resources for namespace validation.

**Orchestrator** (`src/orchestrator.ts`): `formatLocation()` accepts full resources map, resolves URLs from top-level resources directly.

**Config update** (`skillfold.yaml`): Moved github resources from `skills.atomic.github.resources` to top-level `resources.github`.

## Test plan

- [x] All 592 tests pass (27 new)
- [x] `npx tsc --noEmit` passes
- [x] `npx tsx src/cli.ts` compiles correctly
- [x] Orchestrator state table resolves URLs from top-level resources
- [x] Backward compat: inline skill resources still work