### PR TITLE
feat: add built-in state integrations for GitHub services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ src/
   search.ts       - npm registry search for skillfold-skill packages (skillfold search)
   watch.ts        - File watching and auto-recompile (skillfold watch)
   init.ts         - skillfold init scaffolding
+  integrations.ts - Built-in state integrations (GitHub issues, discussions, pull requests)
   errors.ts       - ConfigError, ResolveError, CompileError, GraphError
 skills/           - Atomic skill definitions (each has a SKILL.md)
 library/          - Shared skills library (11 generic skills + 3 example configs)
@@ -173,7 +174,8 @@ Located in `library/examples/`:
 - `npm:` prefix support for skill references and imports (resolves to node_modules paths)
 - Publishing guide (`docs/publishing.md`) for sharing skills via npm
 - `skillfold.local.yaml` support for local config overrides (gitignored), with merge semantics for skills/state/team
-- Test suite with 592 tests across 108 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, and e2e modules
+- Built-in state integrations for GitHub services (github-issues, github-discussions, github-pull-requests) with auto-generated URLs, filter options, and orchestrator instructions
+- Test suite with 649 tests across 121 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, integrations, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/skillfold.schema.json
+++ b/skillfold.schema.json
@@ -221,21 +221,116 @@
     },
     "stateLocation": {
       "type": "object",
-      "description": "External storage location for a state field.",
-      "required": ["skill", "path"],
+      "description": "External storage location for a state field. Use either skill+path (traditional) or a built-in integration type (github-issues, github-discussions, github-pull-requests).",
+      "oneOf": [
+        {
+          "required": ["skill", "path"],
+          "additionalProperties": false,
+          "properties": {
+            "skill": {
+              "type": "string",
+              "description": "Name of the skill or resource group that provides access to this storage."
+            },
+            "path": {
+              "type": "string",
+              "description": "Path within the external system."
+            },
+            "kind": {
+              "type": "string",
+              "description": "Optional qualifier (e.g., 'reply', 'review')."
+            }
+          }
+        },
+        {
+          "required": ["github-issues"],
+          "additionalProperties": false,
+          "properties": {
+            "github-issues": {
+              "$ref": "#/$defs/githubIssuesConfig"
+            },
+            "kind": {
+              "type": "string",
+              "description": "Optional qualifier."
+            }
+          }
+        },
+        {
+          "required": ["github-discussions"],
+          "additionalProperties": false,
+          "properties": {
+            "github-discussions": {
+              "$ref": "#/$defs/githubDiscussionsConfig"
+            },
+            "kind": {
+              "type": "string",
+              "description": "Optional qualifier."
+            }
+          }
+        },
+        {
+          "required": ["github-pull-requests"],
+          "additionalProperties": false,
+          "properties": {
+            "github-pull-requests": {
+              "$ref": "#/$defs/githubPullRequestsConfig"
+            },
+            "kind": {
+              "type": "string",
+              "description": "Optional qualifier."
+            }
+          }
+        }
+      ]
+    },
+    "githubIssuesConfig": {
+      "type": "object",
+      "description": "GitHub Issues integration config.",
+      "required": ["repo"],
       "additionalProperties": false,
       "properties": {
-        "skill": {
+        "repo": {
           "type": "string",
-          "description": "Name of the skill that provides access to this storage."
+          "description": "GitHub repository (owner/name)."
         },
-        "path": {
+        "label": {
           "type": "string",
-          "description": "Path within the external system."
+          "description": "Filter issues by label."
         },
-        "kind": {
+        "assignee": {
           "type": "string",
-          "description": "Optional qualifier (e.g., 'reply', 'review')."
+          "description": "Filter issues by assignee."
+        }
+      }
+    },
+    "githubDiscussionsConfig": {
+      "type": "object",
+      "description": "GitHub Discussions integration config.",
+      "required": ["repo"],
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string",
+          "description": "GitHub repository (owner/name)."
+        },
+        "category": {
+          "type": "string",
+          "description": "Filter discussions by category."
+        }
+      }
+    },
+    "githubPullRequestsConfig": {
+      "type": "object",
+      "description": "GitHub Pull Requests integration config.",
+      "required": ["repo"],
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string",
+          "description": "GitHub repository (owner/name)."
+        },
+        "state": {
+          "type": "string",
+          "description": "Filter pull requests by state (e.g., 'open', 'closed')."
         }
       }
     },

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -283,6 +283,121 @@ describe("e2e: dev-pipeline", () => {
   });
 });
 
+describe("e2e: integration locations", () => {
+  it("inline config with integration locations parses, validates, and renders", () => {
+    const raw = parseRawConfig(`
+name: integration-pipeline
+skills:
+  atomic:
+    coding: ./skills/coding
+  composed:
+    engineer:
+      compose: [coding]
+      description: "Writes code."
+state:
+  Task:
+    title: string
+    priority: number
+  direction:
+    type: string
+    location:
+      github-discussions:
+        repo: byronxlg/skillfold
+        category: strategy
+  tasks:
+    type: list<Task>
+    location:
+      github-issues:
+        repo: byronxlg/skillfold
+        label: task
+  review:
+    type: string
+    location:
+      github-pull-requests:
+        repo: byronxlg/skillfold
+team:
+  flow:
+    - engineer:
+        reads: [state.direction]
+        writes: [state.tasks]
+      then: end
+`);
+    const config = validateAndBuild(raw);
+
+    // Verify state fields have integration locations
+    assert.ok(config.state);
+    assert.ok(config.state.fields["direction"].location?.integration);
+    assert.equal(config.state.fields["direction"].location!.integration!.type, "github-discussions");
+    assert.equal(config.state.fields["direction"].location!.integration!.config.repo, "byronxlg/skillfold");
+    assert.equal(config.state.fields["direction"].location!.integration!.config.category, "strategy");
+
+    assert.ok(config.state.fields["tasks"].location?.integration);
+    assert.equal(config.state.fields["tasks"].location!.integration!.type, "github-issues");
+    assert.equal(config.state.fields["tasks"].location!.integration!.config.label, "task");
+
+    assert.ok(config.state.fields["review"].location?.integration);
+    assert.equal(config.state.fields["review"].location!.integration!.type, "github-pull-requests");
+
+    // Verify orchestrator output
+    const output = generateOrchestrator(config);
+    assert.ok(output.includes("https://github.com/byronxlg/skillfold/discussions"));
+    assert.ok(output.includes('category "strategy"'));
+    assert.ok(output.includes("https://github.com/byronxlg/skillfold/issues"));
+    assert.ok(output.includes('labeled "task"'));
+    assert.ok(output.includes("https://github.com/byronxlg/skillfold/pulls"));
+
+    // Verify list output
+    const listOutput = listPipeline(config);
+    assert.ok(listOutput.includes("https://github.com/byronxlg/skillfold/discussions"));
+    assert.ok(listOutput.includes("https://github.com/byronxlg/skillfold/issues"));
+    assert.ok(listOutput.includes("https://github.com/byronxlg/skillfold/pulls"));
+  });
+
+  it("integration locations coexist with traditional skill+path locations", () => {
+    const raw = parseRawConfig(`
+name: mixed-pipeline
+skills:
+  atomic:
+    coding: ./skills/coding
+    github: ./skills/github
+  composed:
+    engineer:
+      compose: [coding]
+      description: "Writes code."
+resources:
+  github:
+    discussions: "https://github.com/org/repo/discussions"
+state:
+  direction:
+    type: string
+    location:
+      github-discussions:
+        repo: org/repo
+        category: general
+  notes:
+    type: string
+    location:
+      skill: github
+      path: discussions/general
+team:
+  flow:
+    - engineer:
+        reads: [state.direction, state.notes]
+        writes: []
+      then: end
+`);
+    const config = validateAndBuild(raw);
+
+    const output = generateOrchestrator(config);
+
+    // Integration location renders its own URL and instructions
+    assert.ok(output.includes("https://github.com/org/repo/discussions - GitHub discussions in org/repo"));
+
+    // Traditional location renders resolved URL from resources
+    assert.ok(output.includes("https://github.com/org/repo/discussions/general"));
+  });
+});
+
 const asyncFixtureDir = join(__dirname, "..", "test", "fixtures", "async-pipeline");
 const asyncConfigPath = join(asyncFixtureDir, "skillfold.yaml");
 

--- a/src/integrations.test.ts
+++ b/src/integrations.test.ts
@@ -1,0 +1,369 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { ConfigError } from "./errors.js";
+import {
+  getIntegration,
+  INTEGRATION_NAMES,
+  isIntegrationLocation,
+  parseIntegrationLocation,
+  renderIntegrationInstructions,
+  resolveIntegrationUrl,
+} from "./integrations.js";
+
+describe("INTEGRATION_NAMES", () => {
+  it("contains the three GitHub integration types", () => {
+    assert.ok(INTEGRATION_NAMES.has("github-issues"));
+    assert.ok(INTEGRATION_NAMES.has("github-discussions"));
+    assert.ok(INTEGRATION_NAMES.has("github-pull-requests"));
+  });
+
+  it("has exactly 3 integrations", () => {
+    assert.equal(INTEGRATION_NAMES.size, 3);
+  });
+});
+
+describe("getIntegration", () => {
+  it("returns integration type for known names", () => {
+    assert.ok(getIntegration("github-issues"));
+    assert.ok(getIntegration("github-discussions"));
+    assert.ok(getIntegration("github-pull-requests"));
+  });
+
+  it("returns undefined for unknown names", () => {
+    assert.equal(getIntegration("github-wikis"), undefined);
+    assert.equal(getIntegration("slack"), undefined);
+  });
+});
+
+describe("isIntegrationLocation", () => {
+  it("detects github-issues location", () => {
+    assert.ok(isIntegrationLocation({
+      "github-issues": { repo: "org/repo" },
+    }));
+  });
+
+  it("detects github-discussions location", () => {
+    assert.ok(isIntegrationLocation({
+      "github-discussions": { repo: "org/repo", category: "general" },
+    }));
+  });
+
+  it("detects github-pull-requests location", () => {
+    assert.ok(isIntegrationLocation({
+      "github-pull-requests": { repo: "org/repo" },
+    }));
+  });
+
+  it("detects integration location with kind key", () => {
+    assert.ok(isIntegrationLocation({
+      "github-issues": { repo: "org/repo" },
+      kind: "artifact",
+    }));
+  });
+
+  it("rejects location with skill key (traditional format)", () => {
+    assert.ok(!isIntegrationLocation({
+      skill: "github",
+      path: "issues",
+    }));
+  });
+
+  it("rejects location with unknown integration name", () => {
+    assert.ok(!isIntegrationLocation({
+      "github-wikis": { repo: "org/repo" },
+    }));
+  });
+
+  it("rejects location with both skill and integration keys", () => {
+    assert.ok(!isIntegrationLocation({
+      skill: "github",
+      "github-issues": { repo: "org/repo" },
+    }));
+  });
+
+  it("rejects empty location", () => {
+    assert.ok(!isIntegrationLocation({}));
+  });
+});
+
+describe("parseIntegrationLocation", () => {
+  describe("github-issues", () => {
+    it("parses with required repo field", () => {
+      const result = parseIntegrationLocation("tasks", {
+        "github-issues": { repo: "org/repo" },
+      });
+      assert.deepEqual(result, {
+        type: "github-issues",
+        config: { repo: "org/repo" },
+      });
+    });
+
+    it("parses with optional label field", () => {
+      const result = parseIntegrationLocation("tasks", {
+        "github-issues": { repo: "org/repo", label: "task" },
+      });
+      assert.deepEqual(result, {
+        type: "github-issues",
+        config: { repo: "org/repo", label: "task" },
+      });
+    });
+
+    it("parses with optional assignee field", () => {
+      const result = parseIntegrationLocation("tasks", {
+        "github-issues": { repo: "org/repo", assignee: "alice" },
+      });
+      assert.deepEqual(result, {
+        type: "github-issues",
+        config: { repo: "org/repo", assignee: "alice" },
+      });
+    });
+
+    it("parses with all fields", () => {
+      const result = parseIntegrationLocation("tasks", {
+        "github-issues": { repo: "org/repo", label: "bug", assignee: "bob" },
+      });
+      assert.deepEqual(result, {
+        type: "github-issues",
+        config: { repo: "org/repo", label: "bug", assignee: "bob" },
+      });
+    });
+
+    it("rejects missing repo", () => {
+      assert.throws(
+        () => parseIntegrationLocation("tasks", {
+          "github-issues": { label: "task" },
+        }),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /github-issues requires a "repo" field/);
+          return true;
+        },
+      );
+    });
+
+    it("rejects non-string repo", () => {
+      assert.throws(
+        () => parseIntegrationLocation("tasks", {
+          "github-issues": { repo: 123 },
+        }),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /github-issues requires a "repo" field/);
+          return true;
+        },
+      );
+    });
+
+    it("rejects unknown fields", () => {
+      assert.throws(
+        () => parseIntegrationLocation("tasks", {
+          "github-issues": { repo: "org/repo", unknown: "value" },
+        }),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /github-issues has unknown field "unknown"/);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe("github-discussions", () => {
+    it("parses with required repo field", () => {
+      const result = parseIntegrationLocation("direction", {
+        "github-discussions": { repo: "org/repo" },
+      });
+      assert.deepEqual(result, {
+        type: "github-discussions",
+        config: { repo: "org/repo" },
+      });
+    });
+
+    it("parses with optional category field", () => {
+      const result = parseIntegrationLocation("direction", {
+        "github-discussions": { repo: "org/repo", category: "strategy" },
+      });
+      assert.deepEqual(result, {
+        type: "github-discussions",
+        config: { repo: "org/repo", category: "strategy" },
+      });
+    });
+
+    it("rejects unknown fields", () => {
+      assert.throws(
+        () => parseIntegrationLocation("direction", {
+          "github-discussions": { repo: "org/repo", filter: "recent" },
+        }),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /github-discussions has unknown field "filter"/);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe("github-pull-requests", () => {
+    it("parses with required repo field", () => {
+      const result = parseIntegrationLocation("review", {
+        "github-pull-requests": { repo: "org/repo" },
+      });
+      assert.deepEqual(result, {
+        type: "github-pull-requests",
+        config: { repo: "org/repo" },
+      });
+    });
+
+    it("parses with optional state field", () => {
+      const result = parseIntegrationLocation("review", {
+        "github-pull-requests": { repo: "org/repo", state: "open" },
+      });
+      assert.deepEqual(result, {
+        type: "github-pull-requests",
+        config: { repo: "org/repo", state: "open" },
+      });
+    });
+
+    it("rejects unknown fields", () => {
+      assert.throws(
+        () => parseIntegrationLocation("review", {
+          "github-pull-requests": { repo: "org/repo", branch: "main" },
+        }),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /github-pull-requests has unknown field "branch"/);
+          return true;
+        },
+      );
+    });
+  });
+
+  it("rejects non-object integration config", () => {
+    assert.throws(
+      () => parseIntegrationLocation("tasks", {
+        "github-issues": "org/repo",
+      }),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /github-issues config must be an object/);
+        return true;
+      },
+    );
+  });
+
+  it("rejects non-string optional field value", () => {
+    assert.throws(
+      () => parseIntegrationLocation("tasks", {
+        "github-issues": { repo: "org/repo", label: 42 },
+      }),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /github-issues field "label" must be a string/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("resolveIntegrationUrl", () => {
+  it("resolves github-issues URL", () => {
+    assert.equal(
+      resolveIntegrationUrl({ type: "github-issues", config: { repo: "org/repo" } }),
+      "https://github.com/org/repo/issues",
+    );
+  });
+
+  it("resolves github-discussions URL", () => {
+    assert.equal(
+      resolveIntegrationUrl({ type: "github-discussions", config: { repo: "org/repo" } }),
+      "https://github.com/org/repo/discussions",
+    );
+  });
+
+  it("resolves github-pull-requests URL", () => {
+    assert.equal(
+      resolveIntegrationUrl({ type: "github-pull-requests", config: { repo: "org/repo" } }),
+      "https://github.com/org/repo/pulls",
+    );
+  });
+});
+
+describe("renderIntegrationInstructions", () => {
+  it("renders github-issues with no filters", () => {
+    assert.equal(
+      renderIntegrationInstructions({ type: "github-issues", config: { repo: "org/repo" } }),
+      "GitHub issues in org/repo",
+    );
+  });
+
+  it("renders github-issues with label", () => {
+    assert.equal(
+      renderIntegrationInstructions({
+        type: "github-issues",
+        config: { repo: "org/repo", label: "task" },
+      }),
+      'GitHub issues in org/repo, labeled "task"',
+    );
+  });
+
+  it("renders github-issues with assignee", () => {
+    assert.equal(
+      renderIntegrationInstructions({
+        type: "github-issues",
+        config: { repo: "org/repo", assignee: "alice" },
+      }),
+      "GitHub issues in org/repo, assigned to alice",
+    );
+  });
+
+  it("renders github-issues with all filters", () => {
+    assert.equal(
+      renderIntegrationInstructions({
+        type: "github-issues",
+        config: { repo: "org/repo", label: "bug", assignee: "bob" },
+      }),
+      'GitHub issues in org/repo, labeled "bug", assigned to bob',
+    );
+  });
+
+  it("renders github-discussions with no category", () => {
+    assert.equal(
+      renderIntegrationInstructions({
+        type: "github-discussions",
+        config: { repo: "org/repo" },
+      }),
+      "GitHub discussions in org/repo",
+    );
+  });
+
+  it("renders github-discussions with category", () => {
+    assert.equal(
+      renderIntegrationInstructions({
+        type: "github-discussions",
+        config: { repo: "org/repo", category: "strategy" },
+      }),
+      'GitHub discussions in org/repo, category "strategy"',
+    );
+  });
+
+  it("renders github-pull-requests with no state filter", () => {
+    assert.equal(
+      renderIntegrationInstructions({
+        type: "github-pull-requests",
+        config: { repo: "org/repo" },
+      }),
+      "GitHub pull requests in org/repo",
+    );
+  });
+
+  it("renders github-pull-requests with state filter", () => {
+    assert.equal(
+      renderIntegrationInstructions({
+        type: "github-pull-requests",
+        config: { repo: "org/repo", state: "open" },
+      }),
+      "GitHub pull requests in org/repo, state: open",
+    );
+  });
+});

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -1,0 +1,173 @@
+import { ConfigError, didYouMean } from "./errors.js";
+
+export interface IntegrationLocation {
+  type: string;
+  config: Record<string, string>;
+}
+
+export interface IntegrationType {
+  name: string;
+  requiredFields: string[];
+  optionalFields: string[];
+  resolveUrl(config: Record<string, string>): string;
+  renderInstructions(config: Record<string, string>): string;
+}
+
+const githubIssues: IntegrationType = {
+  name: "github-issues",
+  requiredFields: ["repo"],
+  optionalFields: ["label", "assignee"],
+  resolveUrl(config) {
+    return `https://github.com/${config.repo}/issues`;
+  },
+  renderInstructions(config) {
+    const parts = [`GitHub issues in ${config.repo}`];
+    if (config.label) parts.push(`labeled "${config.label}"`);
+    if (config.assignee) parts.push(`assigned to ${config.assignee}`);
+    return parts.join(", ");
+  },
+};
+
+const githubDiscussions: IntegrationType = {
+  name: "github-discussions",
+  requiredFields: ["repo"],
+  optionalFields: ["category"],
+  resolveUrl(config) {
+    return `https://github.com/${config.repo}/discussions`;
+  },
+  renderInstructions(config) {
+    const parts = [`GitHub discussions in ${config.repo}`];
+    if (config.category) parts.push(`category "${config.category}"`);
+    return parts.join(", ");
+  },
+};
+
+const githubPullRequests: IntegrationType = {
+  name: "github-pull-requests",
+  requiredFields: ["repo"],
+  optionalFields: ["state"],
+  resolveUrl(config) {
+    return `https://github.com/${config.repo}/pulls`;
+  },
+  renderInstructions(config) {
+    const parts = [`GitHub pull requests in ${config.repo}`];
+    if (config.state) parts.push(`state: ${config.state}`);
+    return parts.join(", ");
+  },
+};
+
+const INTEGRATIONS: Record<string, IntegrationType> = {
+  "github-issues": githubIssues,
+  "github-discussions": githubDiscussions,
+  "github-pull-requests": githubPullRequests,
+};
+
+export const INTEGRATION_NAMES = new Set(Object.keys(INTEGRATIONS));
+
+export function getIntegration(name: string): IntegrationType | undefined {
+  return INTEGRATIONS[name];
+}
+
+/**
+ * Detect whether a location object uses an integration type rather than
+ * the traditional skill+path format. A location is an integration if it
+ * has exactly one key that matches a known integration name (the value
+ * is the integration config object).
+ */
+export function isIntegrationLocation(
+  loc: Record<string, unknown>,
+): boolean {
+  // An integration location has a single key that is a known integration name
+  // (plus an optional "kind" key). It must NOT have a "skill" key.
+  if ("skill" in loc) return false;
+  const keys = Object.keys(loc).filter((k) => k !== "kind");
+  return keys.length === 1 && INTEGRATION_NAMES.has(keys[0]);
+}
+
+/**
+ * Parse and validate an integration location from a raw YAML location object.
+ * Throws ConfigError on invalid config.
+ */
+export function parseIntegrationLocation(
+  fieldName: string,
+  loc: Record<string, unknown>,
+): IntegrationLocation {
+  const integrationKeys = Object.keys(loc).filter(
+    (k) => k !== "kind" && INTEGRATION_NAMES.has(k),
+  );
+
+  if (integrationKeys.length !== 1) {
+    throw new ConfigError(
+      `State field "${fieldName}": location must have exactly one integration type key`,
+    );
+  }
+
+  const typeName = integrationKeys[0];
+  const integration = INTEGRATIONS[typeName];
+  const rawConfig = loc[typeName];
+
+  if (typeof rawConfig !== "object" || rawConfig === null || Array.isArray(rawConfig)) {
+    throw new ConfigError(
+      `State field "${fieldName}": ${typeName} config must be an object`,
+    );
+  }
+
+  const configObj = rawConfig as Record<string, unknown>;
+  const config: Record<string, string> = {};
+
+  // Validate required fields
+  for (const field of integration.requiredFields) {
+    if (!(field in configObj) || typeof configObj[field] !== "string") {
+      throw new ConfigError(
+        `State field "${fieldName}": ${typeName} requires a "${field}" field (string)`,
+      );
+    }
+    config[field] = configObj[field] as string;
+  }
+
+  // Collect optional fields
+  for (const field of integration.optionalFields) {
+    if (field in configObj) {
+      if (typeof configObj[field] !== "string") {
+        throw new ConfigError(
+          `State field "${fieldName}": ${typeName} field "${field}" must be a string`,
+        );
+      }
+      config[field] = configObj[field] as string;
+    }
+  }
+
+  // Reject unknown fields
+  const allKnown = new Set([
+    ...integration.requiredFields,
+    ...integration.optionalFields,
+  ]);
+  for (const key of Object.keys(configObj)) {
+    if (!allKnown.has(key)) {
+      const hint = didYouMean(key, allKnown);
+      throw new ConfigError(
+        `State field "${fieldName}": ${typeName} has unknown field "${key}"${hint}`,
+      );
+    }
+  }
+
+  return { type: typeName, config };
+}
+
+/**
+ * Resolve the URL for an integration location.
+ */
+export function resolveIntegrationUrl(location: IntegrationLocation): string {
+  const integration = INTEGRATIONS[location.type];
+  return integration.resolveUrl(location.config);
+}
+
+/**
+ * Render human-readable instructions for an integration location.
+ */
+export function renderIntegrationInstructions(
+  location: IntegrationLocation,
+): string {
+  const integration = INTEGRATIONS[location.type];
+  return integration.renderInstructions(location.config);
+}

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,5 +1,6 @@
 import { type Config, type SkillEntry, isAtomic, isComposed } from "./config.js";
 import { type GraphNode, isAsyncNode, isConditionalThen, isMapNode, isSubFlowNode } from "./graph.js";
+import { resolveIntegrationUrl } from "./integrations.js";
 import { type StateField, type StateSchema } from "./state.js";
 
 function formatStateType(field: StateField): string {
@@ -15,6 +16,19 @@ function formatStateType(field: StateField): string {
 
 function formatLocation(field: StateField): string {
   if (!field.location) return "";
+
+  // Integration location
+  if (field.location.integration) {
+    const url = resolveIntegrationUrl(field.location.integration);
+    const parts = [url];
+    if (field.location.kind) {
+      parts.push(`(${field.location.kind})`);
+    }
+    return "-> " + parts.join(" ");
+  }
+
+  // Traditional skill+path location
+  if (!field.location.skill || !field.location.path) return "";
   const parts = [field.location.skill + ": " + field.location.path];
   if (field.location.kind) {
     parts.push(`(${field.location.kind})`);

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -1033,3 +1033,182 @@ describe("generateOrchestrator with resolved URLs", () => {
     assert.ok(!output.includes("https://old.example.com/issues"));
   });
 });
+
+describe("formatLocation with integration locations", () => {
+  it("renders github-issues integration location", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+      location: {
+        integration: {
+          type: "github-issues",
+          config: { repo: "org/repo" },
+        },
+      },
+    };
+    const result = formatLocation(field);
+    assert.equal(
+      result,
+      "https://github.com/org/repo/issues - GitHub issues in org/repo",
+    );
+  });
+
+  it("renders github-issues with label filter", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+      location: {
+        integration: {
+          type: "github-issues",
+          config: { repo: "org/repo", label: "task" },
+        },
+      },
+    };
+    const result = formatLocation(field);
+    assert.ok(result.includes("https://github.com/org/repo/issues"));
+    assert.ok(result.includes('labeled "task"'));
+  });
+
+  it("renders github-discussions integration location", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+      location: {
+        integration: {
+          type: "github-discussions",
+          config: { repo: "org/repo", category: "strategy" },
+        },
+      },
+    };
+    const result = formatLocation(field);
+    assert.ok(result.includes("https://github.com/org/repo/discussions"));
+    assert.ok(result.includes('category "strategy"'));
+  });
+
+  it("renders github-pull-requests integration location", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+      location: {
+        integration: {
+          type: "github-pull-requests",
+          config: { repo: "org/repo" },
+        },
+      },
+    };
+    const result = formatLocation(field);
+    assert.ok(result.includes("https://github.com/org/repo/pulls"));
+    assert.ok(result.includes("GitHub pull requests in org/repo"));
+  });
+
+  it("renders integration location with kind qualifier", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+      location: {
+        integration: {
+          type: "github-pull-requests",
+          config: { repo: "org/repo" },
+        },
+        kind: "review",
+      },
+    };
+    const result = formatLocation(field);
+    assert.ok(result.includes("https://github.com/org/repo/pulls (review)"));
+  });
+
+  it("renders empty string for field without location", () => {
+    const field: StateField = {
+      type: { kind: "primitive", value: "string" },
+    };
+    assert.equal(formatLocation(field), "");
+  });
+});
+
+describe("generateOrchestrator with integration locations", () => {
+  it("renders integration URLs in state table", () => {
+    const config: Config = {
+      name: "integration-test",
+      skills: {
+        worker: { path: "./skills/worker" },
+      },
+      state: {
+        types: {},
+        fields: {
+          direction: {
+            type: { kind: "primitive", value: "string" },
+            location: {
+              integration: {
+                type: "github-discussions",
+                config: { repo: "org/repo", category: "strategy" },
+              },
+            },
+          },
+          tasks: {
+            type: { kind: "primitive", value: "string" },
+            location: {
+              integration: {
+                type: "github-issues",
+                config: { repo: "org/repo", label: "task" },
+              },
+            },
+          },
+          review: {
+            type: { kind: "primitive", value: "string" },
+            location: {
+              integration: {
+                type: "github-pull-requests",
+                config: { repo: "org/repo" },
+              },
+            },
+          },
+        },
+      },
+      team: {
+        flow: {
+          nodes: [{ skill: "worker", reads: [], writes: [], then: "end" }],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+    assert.ok(output.includes("## State"));
+    assert.ok(output.includes("https://github.com/org/repo/discussions"));
+    assert.ok(output.includes("https://github.com/org/repo/issues"));
+    assert.ok(output.includes("https://github.com/org/repo/pulls"));
+    assert.ok(output.includes('category "strategy"'));
+    assert.ok(output.includes('labeled "task"'));
+    assert.ok(output.includes("external locations"));
+  });
+
+  it("mixes integration and traditional locations in state table", () => {
+    const config: Config = {
+      name: "mixed-locations",
+      skills: {
+        worker: { path: "./skills/worker" },
+      },
+      state: {
+        types: {},
+        fields: {
+          direction: {
+            type: { kind: "primitive", value: "string" },
+            location: {
+              integration: {
+                type: "github-discussions",
+                config: { repo: "org/repo" },
+              },
+            },
+          },
+          output: {
+            type: { kind: "primitive", value: "string" },
+            location: { skill: "worker", path: "result.md" },
+          },
+        },
+      },
+      team: {
+        flow: {
+          nodes: [{ skill: "worker", reads: [], writes: [], then: "end" }],
+        },
+      },
+    };
+
+    const output = generateOrchestrator(config);
+    assert.ok(output.includes("https://github.com/org/repo/discussions"));
+    assert.ok(output.includes("worker: result.md"));
+  });
+});

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,6 +1,7 @@
 import type { Config } from "./config.js";
 import { isAsyncNode, isConditionalThen, isMapNode, isSubFlowNode } from "./graph.js";
 import type { AsyncNode, GraphNode, Then } from "./graph.js";
+import { renderIntegrationInstructions, resolveIntegrationUrl } from "./integrations.js";
 import type { StateField, StateType } from "./state.js";
 
 export interface StepMapping {
@@ -24,7 +25,19 @@ export function formatLocation(
   resources?: Record<string, Record<string, string>>,
 ): string {
   if (!field.location) return "";
+
+  // Integration location (e.g., github-issues, github-discussions)
+  if (field.location.integration) {
+    const url = resolveIntegrationUrl(field.location.integration);
+    const instructions = renderIntegrationInstructions(field.location.integration);
+    const kind = field.location.kind;
+    const locationStr = kind ? `${url} (${kind})` : url;
+    return `${locationStr} - ${instructions}`;
+  }
+
+  // Traditional skill+path location
   const { skill, path, kind } = field.location;
+  if (!skill || !path) return "";
 
   const skillResources = resources?.[skill];
   if (skillResources) {

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -647,4 +647,160 @@ describe("parseState", () => {
       assert.equal(schema.fields["direction"].location?.path, "discussions/general");
     });
   });
+
+  describe("integration locations", () => {
+    it("parses github-issues integration location", () => {
+      const raw = {
+        tasks: {
+          type: "string",
+          location: {
+            "github-issues": { repo: "org/repo", label: "task" },
+          },
+        },
+      };
+      const schema = parseState(raw, NO_SKILLS);
+      assert.ok(schema.fields["tasks"].location);
+      assert.deepEqual(schema.fields["tasks"].location!.integration, {
+        type: "github-issues",
+        config: { repo: "org/repo", label: "task" },
+      });
+      assert.equal(schema.fields["tasks"].location!.skill, undefined);
+      assert.equal(schema.fields["tasks"].location!.path, undefined);
+    });
+
+    it("parses github-discussions integration location", () => {
+      const raw = {
+        direction: {
+          type: "string",
+          location: {
+            "github-discussions": { repo: "org/repo", category: "strategy" },
+          },
+        },
+      };
+      const schema = parseState(raw, NO_SKILLS);
+      assert.deepEqual(schema.fields["direction"].location!.integration, {
+        type: "github-discussions",
+        config: { repo: "org/repo", category: "strategy" },
+      });
+    });
+
+    it("parses github-pull-requests integration location", () => {
+      const raw = {
+        review: {
+          type: "string",
+          location: {
+            "github-pull-requests": { repo: "org/repo" },
+          },
+        },
+      };
+      const schema = parseState(raw, NO_SKILLS);
+      assert.deepEqual(schema.fields["review"].location!.integration, {
+        type: "github-pull-requests",
+        config: { repo: "org/repo" },
+      });
+    });
+
+    it("preserves kind field on integration location", () => {
+      const raw = {
+        tasks: {
+          type: "string",
+          location: {
+            "github-issues": { repo: "org/repo" },
+            kind: "artifact",
+          },
+        },
+      };
+      const schema = parseState(raw, NO_SKILLS);
+      assert.equal(schema.fields["tasks"].location!.kind, "artifact");
+      assert.ok(schema.fields["tasks"].location!.integration);
+    });
+
+    it("integration locations do not require skills to be defined", () => {
+      const raw = {
+        tasks: {
+          type: "string",
+          location: {
+            "github-issues": { repo: "org/repo" },
+          },
+        },
+      };
+      // No skills needed for integration locations
+      const schema = parseState(raw, NO_SKILLS);
+      assert.ok(schema.fields["tasks"].location!.integration);
+    });
+
+    it("rejects integration with missing required field", () => {
+      const raw = {
+        tasks: {
+          type: "string",
+          location: {
+            "github-issues": { label: "task" },
+          },
+        },
+      };
+      assert.throws(
+        () => parseState(raw, NO_SKILLS),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /github-issues requires a "repo" field/);
+          return true;
+        },
+      );
+    });
+
+    it("rejects integration with unknown fields", () => {
+      const raw = {
+        tasks: {
+          type: "string",
+          location: {
+            "github-issues": { repo: "org/repo", unknown: "value" },
+          },
+        },
+      };
+      assert.throws(
+        () => parseState(raw, NO_SKILLS),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /github-issues has unknown field "unknown"/);
+          return true;
+        },
+      );
+    });
+
+    it("traditional skill+path location still works alongside integrations", () => {
+      const raw = {
+        direction: {
+          type: "string",
+          location: {
+            "github-discussions": { repo: "org/repo", category: "strategy" },
+          },
+        },
+        output: {
+          type: "string",
+          location: { skill: "review", path: "output.md" },
+        },
+      };
+      const schema = parseState(raw, SOME_SKILLS);
+      assert.ok(schema.fields["direction"].location!.integration);
+      assert.equal(schema.fields["output"].location!.skill, "review");
+      assert.equal(schema.fields["output"].location!.path, "output.md");
+    });
+
+    it("gives helpful error when location has neither skill nor integration", () => {
+      const raw = {
+        tasks: {
+          type: "string",
+          location: { path: "output.md" },
+        },
+      };
+      assert.throws(
+        () => parseState(raw, SOME_SKILLS),
+        (err: unknown) => {
+          assert.ok(err instanceof ConfigError);
+          assert.match(err.message, /location must have a "skill" field or use a built-in integration/);
+          return true;
+        },
+      );
+    });
+  });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,9 @@
 import { ConfigError, didYouMean } from "./errors.js";
+import {
+  type IntegrationLocation,
+  isIntegrationLocation,
+  parseIntegrationLocation,
+} from "./integrations.js";
 
 export interface SkillResources {
   resources?: Record<string, string>;
@@ -12,9 +17,10 @@ export type StateType =
   | { kind: "custom"; name: string };
 
 export interface StateLocation {
-  skill: string;
-  path: string;
+  skill?: string;
+  path?: string;
   kind?: string;
+  integration?: IntegrationLocation;
 }
 
 export interface CustomType {
@@ -118,9 +124,20 @@ function validateLocation(
 
   const loc = location as Record<string, unknown>;
 
+  // Check for built-in integration location (e.g., github-issues, github-discussions)
+  if (isIntegrationLocation(loc)) {
+    const integration = parseIntegrationLocation(fieldName, loc);
+    const result: StateLocation = { integration };
+    if ("kind" in loc && typeof loc.kind === "string") {
+      result.kind = loc.kind;
+    }
+    return result;
+  }
+
+  // Traditional skill+path location format
   if (!("skill" in loc) || typeof loc.skill !== "string") {
     throw new ConfigError(
-      `State field "${fieldName}": location must have a "skill" field`
+      `State field "${fieldName}": location must have a "skill" field or use a built-in integration (github-issues, github-discussions, github-pull-requests)`
     );
   }
 


### PR DESCRIPTION
**[engineer]**

## Summary

- Add built-in integration types for state locations: `github-issues`, `github-discussions`, and `github-pull-requests`
- Each integration auto-generates URLs, validates required/optional fields, and renders human-readable instructions in orchestrator output
- The traditional `skill`+`path` location format remains fully supported and unchanged

## New location format

```yaml
state:
  direction:
    type: string
    location:
      github-discussions:
        repo: byronxlg/skillfold
        category: strategy
  tasks:
    type: list<Task>
    location:
      github-issues:
        repo: byronxlg/skillfold
        label: task
  review:
    type: string
    location:
      github-pull-requests:
        repo: byronxlg/skillfold
```

## Changes

- New `src/integrations.ts` with integration type system, URL generation, instruction rendering, and validation
- Updated `StateLocation` interface to support optional `integration` field alongside existing `skill`+`path`
- Updated `validateLocation()` in `src/state.ts` to detect and validate integration locations
- Updated `formatLocation()` in `src/orchestrator.ts` to render integration URLs and instructions
- Updated `formatLocation()` in `src/list.ts` for integration support
- Updated `skillfold.schema.json` with new location format schemas
- 57 new tests (649 total, all passing)

## Test plan

- [x] All 649 tests pass (`npm test`)
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Existing `skill`+`path` locations unchanged (backward compat verified by existing tests)
- [x] Integration parsing, validation, URL generation, and instruction rendering tested
- [x] Orchestrator and list output tested with integration locations
- [x] E2e test with inline config using all three integration types
- [x] Mixed integration + traditional locations tested in same config

Closes #329