### PR TITLE
feat(api): export integration types from public API

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -33,6 +33,15 @@ describe("public API surface", () => {
     assert.equal(typeof skillfold.parseState, "function");
   });
 
+  it("exports integration functions and constants", () => {
+    assert.equal(typeof skillfold.getIntegration, "function");
+    assert.ok(skillfold.INTEGRATION_NAMES instanceof Set);
+    assert.equal(typeof skillfold.isIntegrationLocation, "function");
+    assert.equal(typeof skillfold.parseIntegrationLocation, "function");
+    assert.equal(typeof skillfold.renderIntegrationInstructions, "function");
+    assert.equal(typeof skillfold.resolveIntegrationUrl, "function");
+  });
+
   it("exports orchestrator function", () => {
     assert.equal(typeof skillfold.generateOrchestrator, "function");
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,20 @@ export type {
   StateType,
 } from "./state.js";
 
+// State integrations
+export {
+  getIntegration,
+  INTEGRATION_NAMES,
+  isIntegrationLocation,
+  parseIntegrationLocation,
+  renderIntegrationInstructions,
+  resolveIntegrationUrl,
+} from "./integrations.js";
+export type {
+  IntegrationLocation,
+  IntegrationType,
+} from "./integrations.js";
+
 // Orchestrator generation
 export { generateOrchestrator } from "./orchestrator.js";
 


### PR DESCRIPTION
**[engineer]**

## Summary

- Re-export all public types and functions from `src/integrations.ts` via `src/index.ts`: `IntegrationLocation`, `IntegrationType`, `INTEGRATION_NAMES`, `getIntegration`, `isIntegrationLocation`, `parseIntegrationLocation`, `resolveIntegrationUrl`, `renderIntegrationInstructions`
- Add API surface test verifying all integration exports are accessible

## Test plan

- [x] `npx tsc --noEmit` passes with no type errors
- [x] `npm test` passes (650 tests, 0 failures)
- [x] New test in `src/api.test.ts` verifies all 6 functions/constants are exported with correct types

Closes #344