### PR TITLE
Migrate skillfold.yaml to built-in integration locations

### DIFF
--- a/skillfold.yaml
+++ b/skillfold.yaml
@@ -1,11 +1,5 @@
 name: skillfold-team
 
-resources:
-  github:
-    discussions: "https://github.com/byronxlg/skillfold/discussions"
-    issues: "https://github.com/byronxlg/skillfold/issues"
-    pull-requests: "https://github.com/byronxlg/skillfold/pulls"
-
 skills:
   atomic:
     # Remote public skills
@@ -65,46 +59,51 @@ state:
   human-discussion:
     type: string
     location:
-      skill: github
-      path: discussions/human
+      github-discussions:
+        repo: byronxlg/skillfold
+        category: human
 
   direction:
     type: string
     location:
-      skill: github
-      path: discussions/strategy
+      github-discussions:
+        repo: byronxlg/skillfold
+        category: strategy
 
   plan:
     type: string
     location:
-      skill: github
-      path: discussions/strategy
+      github-discussions:
+        repo: byronxlg/skillfold
+        category: strategy
       kind: reply
 
   tasks:
     type: list<Task>
     location:
-      skill: github
-      path: issues
+      github-issues:
+        repo: byronxlg/skillfold
+        label: task
 
   implementation:
     type: string
     location:
-      skill: github
-      path: pull-requests
+      github-pull-requests:
+        repo: byronxlg/skillfold
 
   review:
     type: Review
     location:
-      skill: github
-      path: pull-requests
+      github-pull-requests:
+        repo: byronxlg/skillfold
       kind: review
 
   announcement:
     type: string
     location:
-      skill: github
-      path: discussions/announcements
+      github-discussions:
+        repo: byronxlg/skillfold
+        category: announcements
 
 team:
   orchestrator: orchestrator


### PR DESCRIPTION
**[engineer]**

## Summary

- Migrated all 7 state locations in `skillfold.yaml` from legacy `skill: github` + `path` format to built-in integration types (`github-discussions`, `github-issues`, `github-pull-requests`)
- Removed `resources.github` section since integration locations are self-contained with their own URL resolution
- Preserved `kind` fields on `plan` (reply) and `review` (review)

## Details

| Field | Before | After |
|-------|--------|-------|
| human-discussion | `skill: github, path: discussions/human` | `github-discussions: { repo, category: human }` |
| direction | `skill: github, path: discussions/strategy` | `github-discussions: { repo, category: strategy }` |
| plan | `skill: github, path: discussions/strategy, kind: reply` | `github-discussions: { repo, category: strategy }, kind: reply` |
| tasks | `skill: github, path: issues` | `github-issues: { repo, label: task }` |
| implementation | `skill: github, path: pull-requests` | `github-pull-requests: { repo }` |
| review | `skill: github, path: pull-requests, kind: review` | `github-pull-requests: { repo }, kind: review` |
| announcement | `skill: github, path: discussions/announcements` | `github-discussions: { repo, category: announcements }` |

## Test plan

- [x] Compiler runs cleanly with no warnings (`npx tsx src/cli.ts`)
- [x] All 649 tests pass (`npm test`)
- [x] `skillfold --check` confirms output is current
- [x] Compiled orchestrator state table renders correct URLs and instructions

Closes #342