### PR TITLE
feat: export integration types from public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,20 @@ export type {
   StateType,
 } from "./state.js";
 
+// State integrations
+export {
+  getIntegration,
+  INTEGRATION_NAMES,
+  isIntegrationLocation,
+  parseIntegrationLocation,
+  renderIntegrationInstructions,
+  resolveIntegrationUrl,
+} from "./integrations.js";
+export type {
+  IntegrationLocation,
+  IntegrationType,
+} from "./integrations.js";
+
 // Orchestrator generation
 export { generateOrchestrator } from "./orchestrator.js";
 


### PR DESCRIPTION
## Summary
- Export all public types and functions from `src/integrations.ts` via `src/index.ts`
- Adds `getIntegration`, `INTEGRATION_NAMES`, `isIntegrationLocation`, `parseIntegrationLocation`, `renderIntegrationInstructions`, `resolveIntegrationUrl` functions and `IntegrationLocation`, `IntegrationType` types to the public API surface

Closes #344

## Test plan
- [x] `npx tsc --noEmit` passes with no type errors
- [x] All 649 tests pass with no regressions

Generated with [Claude Code](https://claude.com/claude-code)