### PR TITLE
feat: migrate skillfold.yaml to built-in integration locations

### DIFF
--- a/skillfold.yaml
+++ b/skillfold.yaml
@@ -1,11 +1,5 @@
 name: skillfold-team
 
-resources:
-  github:
-    discussions: "https://github.com/byronxlg/skillfold/discussions"
-    issues: "https://github.com/byronxlg/skillfold/issues"
-    pull-requests: "https://github.com/byronxlg/skillfold/pulls"
-
 skills:
   atomic:
     # Remote public skills
@@ -65,46 +59,39 @@ state:
   human-discussion:
     type: string
     location:
-      skill: github
-      path: discussions/human
+      github-discussions: { repo: byronxlg/skillfold, category: human }
 
   direction:
     type: string
     location:
-      skill: github
-      path: discussions/strategy
+      github-discussions: { repo: byronxlg/skillfold, category: strategy }
 
   plan:
     type: string
     location:
-      skill: github
-      path: discussions/strategy
+      github-discussions: { repo: byronxlg/skillfold, category: strategy }
       kind: reply
 
   tasks:
     type: list<Task>
     location:
-      skill: github
-      path: issues
+      github-issues: { repo: byronxlg/skillfold, label: task }
 
   implementation:
     type: string
     location:
-      skill: github
-      path: pull-requests
+      github-pull-requests: { repo: byronxlg/skillfold }
 
   review:
     type: Review
     location:
-      skill: github
-      path: pull-requests
+      github-pull-requests: { repo: byronxlg/skillfold }
       kind: review
 
   announcement:
     type: string
     location:
-      skill: github
-      path: discussions/announcements
+      github-discussions: { repo: byronxlg/skillfold, category: announcements }
 
 team:
   orchestrator: orchestrator


### PR DESCRIPTION
## Summary

- Migrate all 7 state locations in `skillfold.yaml` from legacy `skill: github` + `path:` format to built-in integration syntax (`github-discussions`, `github-issues`, `github-pull-requests`)
- Remove the top-level `resources.github` section since integration locations are self-contained (they carry their own repo URL)

Closes #342

## Migration

| Field | Before | After |
|-------|--------|-------|
| human-discussion | `skill: github, path: discussions/human` | `github-discussions: { repo: byronxlg/skillfold, category: human }` |
| direction | `skill: github, path: discussions/strategy` | `github-discussions: { repo: byronxlg/skillfold, category: strategy }` |
| plan | `skill: github, path: discussions/strategy, kind: reply` | `github-discussions: { repo: byronxlg/skillfold, category: strategy }` + `kind: reply` |
| tasks | `skill: github, path: issues` | `github-issues: { repo: byronxlg/skillfold, label: task }` |
| implementation | `skill: github, path: pull-requests` | `github-pull-requests: { repo: byronxlg/skillfold }` |
| review | `skill: github, path: pull-requests, kind: review` | `github-pull-requests: { repo: byronxlg/skillfold }` + `kind: review` |
| announcement | `skill: github, path: discussions/announcements` | `github-discussions: { repo: byronxlg/skillfold, category: announcements }` |

## Test plan

- [x] Compilation passes (`npx tsx src/cli.ts`)
- [x] All 649 tests pass (`npm test`)
- [x] Type check passes (`npx tsc --noEmit`)