### PR TITLE
feat: add live demo page with interactive pipeline visualizer

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     nav: [
       { text: "Guide", link: "/getting-started" },
       { text: "Reference", link: "/reference/config" },
+      { text: "Demo", link: "/demo" },
       { text: "GitHub", link: "https://github.com/byronxlg/skillfold" },
       { text: "npm", link: "https://www.npmjs.com/package/skillfold" },
     ],
@@ -20,6 +21,7 @@ export default defineConfig({
         text: "Guide",
         items: [
           { text: "Getting Started", link: "/getting-started" },
+          { text: "Live Demo", link: "/demo" },
           { text: "Platform Integration", link: "/integrations" },
           { text: "Publishing Skills", link: "/publishing" },
         ],

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,108 @@
+# Live Demo
+
+## Interactive Pipeline Visualizer
+
+The graph below shows a `dev-team` pipeline compiled from `skillfold.yaml`. Click any node to see its composition, state reads/writes, and description.
+
+<iframe src="/skillfold/demo-graph.html" width="100%" height="500" style="border: 1px solid var(--vp-c-divider); border-radius: 8px;" allow="clipboard-write"></iframe>
+
+Generate this for your own pipeline:
+
+```bash
+npx skillfold graph --html > pipeline.html
+```
+
+## Quick Start
+
+Scaffold a pipeline, compile it, and see the output in under 30 seconds:
+
+```bash
+# Scaffold from a template
+npx skillfold init my-team --template dev-team
+cd my-team
+
+# Compile to standard SKILL.md files
+npx skillfold
+
+# Or compile directly to Claude Code agents
+npx skillfold --target claude-code
+
+# Visualize the flow
+npx skillfold graph --html > pipeline.html
+```
+
+## Example Config
+
+This is the `dev-team` template config that generates the graph above:
+
+```yaml
+name: dev-team
+
+imports:
+  - npm:skillfold/library/skillfold.yaml
+
+skills:
+  composed:
+    planner:
+      compose: [planning, decision-making]
+      description: "Analyzes the goal and produces a structured plan."
+
+    engineer:
+      compose: [planning, code-writing, testing]
+      description: "Implements the plan by writing production code and tests."
+
+    reviewer:
+      compose: [code-review, testing]
+      description: "Reviews code for correctness, clarity, and test coverage."
+
+    orchestrator:
+      compose: [planning]
+      description: "Coordinates pipeline execution."
+
+state:
+  Review:
+    approved: bool
+    feedback: string
+
+  plan:
+    type: string
+  implementation:
+    type: string
+  review:
+    type: Review
+
+team:
+  orchestrator: orchestrator
+
+  flow:
+    - planner:
+        writes: [state.plan]
+      then: engineer
+
+    - engineer:
+        reads: [state.plan]
+        writes: [state.implementation]
+      then: reviewer
+
+    - reviewer:
+        reads: [state.implementation]
+        writes: [state.review]
+      then:
+        - when: review.approved == false
+          to: engineer
+        - when: review.approved == true
+          to: end
+```
+
+## What the Compiler Produces
+
+Running `npx skillfold` on this config generates four SKILL.md files:
+
+| Agent | Composed From | Description |
+|-------|--------------|-------------|
+| `planner` | planning + decision-making | Plans and makes key decisions |
+| `engineer` | planning + code-writing + testing | Writes code and tests |
+| `reviewer` | code-review + testing | Reviews code quality |
+| `orchestrator` | planning + generated execution plan | Coordinates the flow |
+
+The `engineer` agent's SKILL.md contains the bodies of `planning`, `code-writing`, and `testing` concatenated in order - no duplication, no drift.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,10 @@ hero:
       text: Get Started
       link: /getting-started
     - theme: alt
-      text: View on GitHub
+      text: Live Demo
+      link: /demo
+    - theme: alt
+      text: GitHub
       link: https://github.com/byronxlg/skillfold
 
 features:

--- a/docs/public/demo-graph.html
+++ b/docs/public/demo-graph.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>dev-team - Pipeline Graph</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #c9d1d9; display: flex; height: 100vh; overflow: hidden; }
+  #graph-container { flex: 1; overflow: auto; padding: 24px; display: flex; align-items: flex-start; justify-content: center; }
+  #graph-container svg { max-width: 100%; height: auto; }
+  #sidebar { width: 320px; background: #161b22; border-left: 1px solid #30363d; padding: 20px; overflow-y: auto; display: flex; flex-direction: column; gap: 16px; transition: transform 0.2s; }
+  #sidebar.collapsed { transform: translateX(320px); }
+  h1 { font-size: 16px; font-weight: 600; color: #f0f6fc; }
+  h2 { font-size: 13px; font-weight: 600; color: #8b949e; text-transform: uppercase; letter-spacing: 0.5px; }
+  .meta-section { display: flex; flex-direction: column; gap: 8px; }
+  .meta-label { font-size: 11px; color: #8b949e; text-transform: uppercase; letter-spacing: 0.5px; }
+  .meta-value { font-size: 13px; color: #c9d1d9; }
+  .tag { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 12px; margin: 2px; }
+  .tag-read { background: #0d419d; color: #79c0ff; }
+  .tag-write { background: #3d1e00; color: #f0883e; }
+  .tag-skill { background: #1b4721; color: #56d364; }
+  .tag-type { background: #3d1e3e; color: #d2a8ff; }
+  .placeholder { color: #484f58; font-size: 13px; text-align: center; margin-top: 40px; }
+  #toolbar { display: flex; gap: 8px; padding: 12px 20px; background: #161b22; border-bottom: 1px solid #30363d; position: absolute; top: 0; left: 0; z-index: 10; }
+  .btn { padding: 6px 12px; background: #21262d; border: 1px solid #30363d; border-radius: 6px; color: #c9d1d9; font-size: 12px; cursor: pointer; }
+  .btn:hover { background: #30363d; }
+  #graph-container { padding-top: 56px; }
+  .node-label, .nodeLabel, .label { cursor: pointer !important; }
+  .cluster-label span, .nodeLabel p { cursor: pointer !important; }
+</style>
+</head>
+<body>
+
+<div id="toolbar">
+  <button class="btn" onclick="exportSvg()">Export SVG</button>
+  <button class="btn" onclick="toggleSidebar()">Toggle Details</button>
+</div>
+
+<div id="graph-container">
+  <pre class="mermaid">graph TD
+    subgraph planner
+        planner_planning["planning"]
+        planner_decision_making["decision-making"]
+    end
+    planner --&gt;|"plan"| engineer
+    subgraph engineer
+        engineer_planning["planning"]
+        engineer_code_writing["code-writing"]
+        engineer_testing["testing"]
+    end
+    engineer --&gt;|"implementation"| reviewer
+    subgraph reviewer
+        reviewer_code_review["code-review"]
+        reviewer_testing["testing"]
+    end
+    reviewer --&gt;|"review.approved == true"| end_node([end])
+    reviewer --&gt;|"review.approved == false"| engineer
+</pre>
+</div>
+
+<div id="sidebar">
+  <h1>dev-team</h1>
+  <div id="detail-content">
+    <p class="placeholder">Click a node to see details</p>
+  </div>
+</div>
+
+<script type="module">
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+
+const nodeMeta = [{"id":"planner","label":"planner","type":"step","reads":[],"writes":["state.plan"],"composition":["planning","decision-making"],"description":"Analyzes the goal and produces a structured plan with key decisions."},{"id":"engineer","label":"engineer","type":"step","reads":["state.plan"],"writes":["state.implementation"],"composition":["planning","code-writing","testing"],"description":"Implements the plan by writing production code and tests."},{"id":"reviewer","label":"reviewer","type":"step","reads":["state.implementation"],"writes":["state.review"],"composition":["code-review","testing"],"description":"Reviews code for correctness, clarity, and test coverage."}];
+const metaMap = new Map(nodeMeta.map(n => [n.id, n]));
+
+mermaid.initialize({
+  startOnLoad: true,
+  theme: "dark",
+  securityLevel: "loose",
+  flowchart: { curve: "basis", padding: 16 },
+});
+
+setTimeout(() => {
+  const svg = document.querySelector("#graph-container svg");
+  if (!svg) return;
+
+  svg.querySelectorAll(".node, .cluster").forEach(el => {
+    el.style.cursor = "pointer";
+    el.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const id = el.id || el.getAttribute("data-id") || "";
+      const cleanId = id.replace(/^flowchart-/, "").replace(/-\d+$/, "");
+      showDetail(cleanId);
+    });
+  });
+}, 500);
+
+function showDetail(nodeId) {
+  const meta = metaMap.get(nodeId);
+  const detail = document.getElementById("detail-content");
+  if (!meta) {
+    for (const [key, val] of metaMap) {
+      if (nodeId.includes(key) || key.includes(nodeId)) {
+        renderDetail(val);
+        return;
+      }
+    }
+    detail.innerHTML = '<p class="placeholder">No metadata for this node</p>';
+    return;
+  }
+  renderDetail(meta);
+}
+
+function renderDetail(meta) {
+  const detail = document.getElementById("detail-content");
+  let html = '<div class="meta-section">';
+  html += '<div><span class="meta-label">Name</span><div class="meta-value">' + esc(meta.label) + '</div></div>';
+  html += '<div><span class="meta-label">Type</span><div class="meta-value"><span class="tag tag-type">' + meta.type + '</span></div></div>';
+
+  if (meta.description) {
+    html += '<div><span class="meta-label">Description</span><div class="meta-value">' + esc(meta.description) + '</div></div>';
+  }
+
+  if (meta.composition && meta.composition.length > 0) {
+    html += '<div><span class="meta-label">Composition</span><div class="meta-value">';
+    meta.composition.forEach(s => { html += '<span class="tag tag-skill">' + esc(s) + '</span>'; });
+    html += '</div></div>';
+  }
+
+  if (meta.reads.length > 0) {
+    html += '<div><span class="meta-label">Reads</span><div class="meta-value">';
+    meta.reads.forEach(r => { html += '<span class="tag tag-read">' + esc(r) + '</span>'; });
+    html += '</div></div>';
+  }
+
+  if (meta.writes.length > 0) {
+    html += '<div><span class="meta-label">Writes</span><div class="meta-value">';
+    meta.writes.forEach(w => { html += '<span class="tag tag-write">' + esc(w) + '</span>'; });
+    html += '</div></div>';
+  }
+
+  html += '</div>';
+  detail.innerHTML = html;
+}
+
+function esc(s) {
+  const el = document.createElement("span");
+  el.textContent = s;
+  return el.innerHTML;
+}
+
+window.exportSvg = function() {
+  const svg = document.querySelector("#graph-container svg");
+  if (!svg) return;
+  const serializer = new XMLSerializer();
+  const svgStr = serializer.serializeToString(svg);
+  const blob = new Blob([svgStr], { type: "image/svg+xml" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "dev-team-pipeline.svg";
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+window.toggleSidebar = function() {
+  document.getElementById("sidebar").classList.toggle("collapsed");
+};
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "file-management": "./library/skills/file-management",
     "skillfold-cli": "./library/skills/skillfold-cli"
   },
-  "homepage": "https://github.com/byronxlg/skillfold",
+  "homepage": "https://byronxlg.github.io/skillfold/",
   "bugs": "https://github.com/byronxlg/skillfold/issues",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**[engineer]**

## Summary

- Add a live demo page to the docs site with an embedded interactive pipeline graph (dev-team template)
- Clickable nodes show skill composition, state reads/writes, and descriptions
- Demo page includes quick start commands and example config walkthrough
- Updated landing page with "Live Demo" CTA button
- Updated nav and sidebar to include demo link
- Updated package.json homepage to point to docs site

Part of #331.

## Test plan

- [x] `npm run docs:build` succeeds
- [x] All 650 tests pass
- [x] Demo graph HTML renders correctly (standalone page in docs/public/)
- [x] VitePress includes demo.html and demo-graph.html in build output