### PR TITLE
docs: add comparison table to landing page (closes #355)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,3 +26,18 @@ features:
   - title: Multi-Platform
     details: Compile to Claude Code agents, Cursor rules, VS Code Copilot instructions, OpenAI Codex, or standard SKILL.md files.
 ---
+
+## How Skillfold Compares to Runtime Orchestration
+
+Skillfold is a compiler, not a runtime framework. It validates your pipeline at compile time and emits plain files that agents read directly. Runtime orchestration tools like CrewAI, AutoGen, and LangGraph take a different approach - they coordinate agents at execution time through a framework process. Both are valid; which one fits depends on your pipeline.
+
+| | Skillfold (compile-time) | Runtime orchestration (CrewAI, AutoGen, LangGraph) |
+| --- | --- | --- |
+| **When coordination happens** | At compile time, before agents run | At runtime, while agents execute |
+| **Output format** | Standard files (SKILL.md, .claude/agents/, Cursor rules) | Proprietary runtime objects and APIs |
+| **Platform lock-in** | None - output is plain files any tool can read | Tied to the framework's runtime and SDK |
+| **Validation** | Compile-time type checking for state, flows, and references | Runtime errors surface during execution |
+| **Runtime overhead** | Zero - agents read files directly, no middleware | Framework process runs alongside agents |
+| **Best for** | Known pipelines with static topology and typed state | Dynamic workflows where topology changes based on intermediate results |
+
+Runtime tools are the better choice when your pipeline needs to make structural decisions mid-execution - spawning new agents, rewiring flows, or adapting the graph based on intermediate output. Skillfold is the better choice when you know the shape of your pipeline ahead of time and want the compiler to catch errors before anything runs.


### PR DESCRIPTION
**[engineer]**

## Summary

- Add a "How Skillfold Compares to Runtime Orchestration" section below the features grid on the VitePress landing page
- Comparison table covers six dimensions: coordination timing, output format, platform lock-in, validation, runtime overhead, and best use cases
- Honest framing that acknowledges runtime tools (CrewAI, AutoGen, LangGraph) are the better fit for truly dynamic workflows

Closes #355