### PR TITLE
docs: add skills CLI compatibility and discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,13 @@ npm install -g skillfold    # global install
 npx skillfold               # or run directly
 ```
 
+Install individual skills with the [skills CLI](https://skills.sh), compose them into pipelines with skillfold:
+
+```bash
+npx skills add byronxlg/skillfold              # install all 11 library skills
+npx skills add byronxlg/skillfold -s code-review   # install a specific skill
+```
+
 Requires Node.js 20+. Single dependency: `yaml`.
 
 **Claude Code plugin marketplace:** Install the skills library and `/skillfold` command directly in Claude Code:

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -117,21 +117,31 @@ This exits with code 1 if the compiled output is stale, catching cases where som
 
 ## Working with the Skills CLI
 
-If you already manage individual skills with the [skills CLI](https://skills.sh) (`npx skills add`), skillfold sits one layer above it. The skills CLI installs and updates individual SKILL.md files. Skillfold composes multiple skills into agents, adds typed state schemas, and validates execution flows at compile time. They're complementary.
+The [skills CLI](https://skills.sh) (`npx skills add`) installs and updates individual SKILL.md files. Skillfold sits one layer above it: composing multiple skills into agents, adding typed state schemas, and validating execution flows at compile time. They're complementary.
 
-### Before: individual skills, managed separately
+### Installing skillfold skills
 
-```
-~/.agents/skills/
-  code-review/SKILL.md
-  planning/SKILL.md
-  testing/SKILL.md
-  code-writing/SKILL.md
+Install all 11 library skills from the skillfold package:
+
+```bash
+npx skills add byronxlg/skillfold
 ```
 
-Each agent references skills independently. No shared schema, no flow validation.
+Or install a specific skill:
 
-### After: composed agents with typed coordination
+```bash
+npx skills add byronxlg/skillfold -s code-review
+npx skills add byronxlg/skillfold -s planning
+npx skills add byronxlg/skillfold -s testing
+```
+
+The skills CLI reads the `agentskills` field in skillfold's `package.json` to discover available skills and their paths. Each skill installs as a standard `SKILL.md` file under your skills directory.
+
+See the [skills CLI leaderboard](https://skills.sh) for more installable skills from the ecosystem.
+
+### Composing installed skills into pipelines
+
+Once you have individual skills installed, use skillfold to compose them into a validated pipeline:
 
 ```yaml
 # skillfold.yaml

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -82,6 +82,27 @@ skillfold search             # list all skillfold-skill packages
 
 This queries the npm registry for packages with the `skillfold-skill` keyword and displays their name, description, and version.
 
+### Skills CLI compatibility
+
+Packages that include an `agentskills` field in `package.json` are also discoverable by the [skills CLI](https://skills.sh). This field maps skill names to their directory paths:
+
+```json
+{
+  "agentskills": {
+    "planning": "./skills/planning",
+    "testing": "./skills/testing"
+  }
+}
+```
+
+Users can then install individual skills from your package:
+
+```bash
+npx skills add your-org/your-package -s planning
+```
+
+Skillfold's own library skills are installable this way: `npx skills add byronxlg/skillfold`.
+
 ## Versioning
 
 Follow standard semver conventions:


### PR DESCRIPTION
[engineer]

Closes #368

## Summary

- Add `npx skills add byronxlg/skillfold` as an install method in the README Install section, alongside `npm install`
- Expand the "Working with the Skills CLI" section in `docs/integrations.md` with specific install commands (`-s code-review`, `-s planning`, etc.) and a link to the skills.sh leaderboard
- Add "Skills CLI compatibility" subsection to `docs/publishing.md` explaining the `agentskills` field in `package.json` for package authors who want their skills discoverable by the skills CLI

## Discovery verification

The `skills` CLI discovers skills via the `agentskills` field in `package.json`. Skillfold already declares this field mapping all 11 library skills to their `./library/skills/{name}` paths. No directory restructuring needed - `npx skills add byronxlg/skillfold` works as-is.

## Test plan

- [x] `npm test` passes (650 tests, 0 failures)
- [ ] Verify README install section reads clearly with both npm and skills CLI options
- [ ] Verify integrations.md skills CLI section has correct install commands
- [ ] Verify publishing.md skills CLI compatibility section is accurate