### PR TITLE
docs: add library skills page with skills CLI install commands

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
         text: "Guide",
         items: [
           { text: "Getting Started", link: "/getting-started" },
+          { text: "Library Skills", link: "/library" },
           { text: "Live Demo", link: "/demo" },
           { text: "Pipeline Builder", link: "/builder" },
           { text: "Examples", link: "/examples" },

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,10 @@
 # Examples
 
-Skillfold ships with three starter templates in the shared skills library. Each demonstrates a different pipeline pattern and can be scaffolded with a single command. All templates import the 11 built-in library skills, so you can start composing agents immediately.
+Skillfold ships with three starter templates in the shared skills library. Each demonstrates a different pipeline pattern and can be scaffolded with a single command. All templates import the [11 built-in library skills](/library), so you can start composing agents immediately.
+
+::: tip Standalone installation
+Don't need a full pipeline? Install any library skill individually with `npx skills add byronxlg/skillfold -s <skill-name>`. See the [Library Skills](/library) page for the full list.
+:::
 
 ## dev-team
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -162,7 +162,11 @@ npx skillfold graph      # output a Mermaid flowchart
 
 ## 5. Import library skills
 
-Skillfold ships with 11 generic skills you can use instead of writing your own. Uncomment the imports line in your config:
+Skillfold ships with 11 generic skills you can use instead of writing your own. These skills also work standalone with any coding agent - see the [Library Skills](/library) page for individual install commands.
+
+**Option A: Import into a skillfold pipeline**
+
+Uncomment the imports line in your config:
 
 ```yaml
 imports:
@@ -195,6 +199,18 @@ skills:
 ```
 
 The import makes all 11 library skills available: `planning`, `research`, `decision-making`, `code-writing`, `code-review`, `testing`, `writing`, `summarization`, `github-workflow`, `file-management`, and `skillfold-cli`.
+
+**Option B: Install standalone with the skills CLI**
+
+If you don't use skillfold pipelines, install individual skills directly:
+
+```bash
+npx skills add byronxlg/skillfold -s code-writing
+npx skills add byronxlg/skillfold -s testing
+npx skills add byronxlg/skillfold -s code-review
+```
+
+Or install all 11 at once: `npx skills add byronxlg/skillfold`. Each skill installs as a standard SKILL.md file that any coding agent can read.
 
 ## 6. Add async nodes for external agents
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ hero:
 
 features:
   - title: Skill Composition
-    details: Define atomic skills once, compose them into agents. No copy-paste, no drift. The compiler handles deduplication.
+    details: Define atomic skills once, compose them into agents. No copy-paste, no drift. 11 library skills included, installable standalone via npx skills add.
   - title: Typed State and Flows
     details: Declare state schemas, wire agents into execution flows with conditional routing and parallel map. Validated at compile time.
   - title: Built-in Integrations

--- a/docs/library.md
+++ b/docs/library.md
@@ -1,0 +1,145 @@
+# Library Skills
+
+Skillfold ships with 11 generic, reusable skills that work with any coding agent. Each skill is a standalone `SKILL.md` file - you can use them with skillfold pipelines, install them individually via the [skills CLI](https://skills.sh), or read them directly.
+
+## Install with the skills CLI
+
+Install all 11 skills at once:
+
+```bash
+npx skills add byronxlg/skillfold
+```
+
+Or install individual skills:
+
+```bash
+npx skills add byronxlg/skillfold -s <skill-name>
+```
+
+No skillfold config or compilation needed. Each skill installs as a standard `SKILL.md` file that any agent can read.
+
+---
+
+## Available Skills
+
+### planning
+
+Break problems into steps, identify dependencies, and estimate scope.
+
+```bash
+npx skills add byronxlg/skillfold -s planning
+```
+
+### research
+
+Gather information, evaluate sources, and synthesize findings.
+
+```bash
+npx skills add byronxlg/skillfold -s research
+```
+
+### decision-making
+
+Evaluate trade-offs, document options, and justify recommendations.
+
+```bash
+npx skills add byronxlg/skillfold -s decision-making
+```
+
+### code-writing
+
+Write clean, correct, production-quality code.
+
+```bash
+npx skills add byronxlg/skillfold -s code-writing
+```
+
+### code-review
+
+Review code for correctness, clarity, and security.
+
+```bash
+npx skills add byronxlg/skillfold -s code-review
+```
+
+### testing
+
+Write and reason about tests, covering behavior, edge cases, and errors.
+
+```bash
+npx skills add byronxlg/skillfold -s testing
+```
+
+### writing
+
+Produce clear, structured prose and documentation.
+
+```bash
+npx skills add byronxlg/skillfold -s writing
+```
+
+### summarization
+
+Condense information with audience-appropriate detail levels.
+
+```bash
+npx skills add byronxlg/skillfold -s summarization
+```
+
+### github-workflow
+
+Work with GitHub branches, PRs, issues, and reviews via the gh CLI.
+
+```bash
+npx skills add byronxlg/skillfold -s github-workflow
+```
+
+### file-management
+
+Read, create, edit, and organize files and directories.
+
+```bash
+npx skills add byronxlg/skillfold -s file-management
+```
+
+### skillfold-cli
+
+Use the skillfold compiler to manage multi-agent pipeline configs.
+
+```bash
+npx skills add byronxlg/skillfold -s skillfold-cli
+```
+
+---
+
+## Using with skillfold pipelines
+
+If you use the skillfold compiler, import all library skills at once instead of installing them individually:
+
+```yaml
+imports:
+  - npm:skillfold/library/skillfold.yaml
+```
+
+This makes all 11 skills available as atomic skills in your pipeline config. Compose them into agents:
+
+```yaml
+skills:
+  composed:
+    engineer:
+      compose: [planning, code-writing, testing]
+      description: "Implements the plan by writing production code and tests."
+    reviewer:
+      compose: [code-review, testing]
+      description: "Reviews code for correctness, clarity, and test coverage."
+```
+
+See the [Examples](/examples) page for complete pipeline configs using library skills.
+
+## Browsing on skills.sh
+
+All 11 skills are indexed on [skills.sh](https://skills.sh) and discoverable via the skills CLI leaderboard. Search for them with:
+
+```bash
+npx skills search skillfold
+```


### PR DESCRIPTION
**[marketer]**

Closes #373

## Summary

- Added a dedicated **Library Skills** page (`docs/library.md`) listing all 11 skills with descriptions and individual `npx skills add byronxlg/skillfold -s <name>` install commands
- Updated **Getting Started** guide (section 5) with a standalone install option alongside the pipeline import path
- Added cross-links from the **Examples** page and **homepage** to the new library skills page
- Registered the new page in the VitePress sidebar (between Getting Started and Live Demo)
- Posted to Moltbook `tooling` submolt announcing the 11 standalone skills for the agent-building community

## Moltbook post

Published to `tooling` (Tooling & Prompts) submolt: "11 standalone SKILL.md files for common agent tasks" - community-focused, leads with what's useful for other agents, mentions skills.sh for discoverability.

## Test plan

- [ ] Verify `docs/library.md` renders correctly in VitePress dev server
- [ ] Verify sidebar shows "Library Skills" link between "Getting Started" and "Live Demo"
- [ ] Verify cross-links from examples page tip box and getting-started section 5 work
- [ ] Verify all 11 skill install commands are correct

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>