### PR TITLE
feat(run): add linear flow runner

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ Commands:
   graph             Output Mermaid flowchart of the team flow
   watch             Compile and watch for changes
   plugin            Package compiled output as a Claude Code plugin
+  run               Execute a linear pipeline flow
   search [query]    Search npm for skillfold skill packages
   (default)         Compile the pipeline config
 
@@ -39,6 +40,7 @@ Options:
   --target <mode>      Output mode: skill, claude-code, cursor, windsurf, codex, copilot
   --template <name>    Start from a library template (init only)
   --check              Verify compiled output is up-to-date (exit 1 if stale)
+  --dry-run            Print execution plan without running (run only)
   --html               Output interactive HTML instead of Mermaid (graph only)
   --help               Show this help
   --version            Show version
@@ -46,7 +48,7 @@ Options:
 Templates: ${TEMPLATES.join(", ")}`);
 }
 
-type Command = "init" | "adopt" | "compile" | "graph" | "list" | "validate" | "watch" | "plugin" | "search";
+type Command = "init" | "adopt" | "compile" | "graph" | "list" | "validate" | "watch" | "plugin" | "run" | "search";
 
 interface Args {
   command: Command;
@@ -58,6 +60,7 @@ interface Args {
   template: string | undefined;
   query: string | undefined;
   check: boolean;
+  dryRun: boolean;
   html: boolean;
   help: boolean;
   version: boolean;
@@ -73,6 +76,7 @@ function parseArgs(argv: string[]): Args {
   let template: string | undefined;
   let query: string | undefined;
   let checkMode = false;
+  let dryRun = false;
   let html = false;
   let help = false;
   let version = false;
@@ -105,6 +109,9 @@ function parseArgs(argv: string[]): Args {
     i = 1;
   } else if (argv.length > 0 && argv[0] === "plugin") {
     command = "plugin";
+    i = 1;
+  } else if (argv.length > 0 && argv[0] === "run") {
+    command = "run";
     i = 1;
   } else if (argv.length > 0 && argv[0] === "search") {
     command = "search";
@@ -140,6 +147,8 @@ function parseArgs(argv: string[]): Args {
       template = argv[++i];
     } else if (argv[i] === "--check") {
       checkMode = true;
+    } else if (argv[i] === "--dry-run") {
+      dryRun = true;
     } else if (argv[i] === "--html") {
       html = true;
     } else if (argv[i] === "--help") {
@@ -175,6 +184,7 @@ function parseArgs(argv: string[]): Args {
     template,
     query,
     check: checkMode,
+    dryRun,
     html,
     help,
     version,
@@ -325,6 +335,80 @@ async function main(): Promise<void> {
   if (args.command === "watch") {
     const { watchPipeline } = await import("./watch.js");
     await watchPipeline(args.configPath, args.outDir, pkg.version, args.target);
+    return;
+  }
+
+  if (args.command === "run") {
+    if (args.target === "skill") {
+      console.error("skillfold error: run requires a runtime target (e.g. --target claude-code)");
+      process.exit(1);
+    }
+    try {
+      const config = await loadConfig(args.configPath);
+      if (!config.team) {
+        console.error("skillfold error: No team flow defined in config. Add a team.flow section to run a pipeline.");
+        process.exit(1);
+      }
+
+      const baseDir = dirname(args.configPath);
+      const bodies = await resolveSkills(config, baseDir);
+
+      const { run } = await import("./run.js");
+      const nodeCount = config.team.flow.nodes.length;
+
+      if (args.dryRun) {
+        console.error(`skillfold: dry run for ${config.name} (${nodeCount} steps)`);
+      } else {
+        console.error(`skillfold: running ${config.name} (${nodeCount} steps)`);
+      }
+
+      const result = await run({
+        config,
+        bodies,
+        outDir: args.outDir,
+        dryRun: args.dryRun,
+      });
+
+      if (args.dryRun) {
+        for (const step of result.steps) {
+          const node = config.team!.flow.nodes[step.step - 1];
+          const reads = "reads" in node ? (node.reads as string[]).join(", ") : "";
+          const writes = "writes" in node ? (node.writes as string[]).join(", ") : "";
+          const parts: string[] = [];
+          if (reads) parts.push(`reads: ${reads}`);
+          if (writes) parts.push(`writes: ${writes}`);
+          const detail = parts.length > 0 ? ` (${parts.join(", ")})` : "";
+          console.error(`  [${step.step}/${nodeCount}] ${step.agent}${detail}`);
+        }
+      }
+
+      const errors = result.steps.filter((s) => s.status === "error");
+      if (errors.length > 0) {
+        console.error(`skillfold: pipeline failed at step ${errors[0].step} (${errors[0].agent})`);
+        if (errors[0].error) {
+          console.error(`  ${errors[0].error}`);
+        }
+        process.exit(1);
+      }
+
+      if (!args.dryRun) {
+        console.error("skillfold: pipeline complete");
+      }
+    } catch (err) {
+      if (
+        err instanceof ConfigError ||
+        err instanceof ResolveError ||
+        err instanceof GraphError
+      ) {
+        console.error(`skillfold error: ${err.message}`);
+        process.exit(1);
+      }
+      if (err instanceof Error) {
+        console.error(`skillfold error: ${err.message}`);
+        process.exit(1);
+      }
+      throw err;
+    }
     return;
   }
 

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -633,19 +633,18 @@ describe("run", () => {
         },
       };
 
-      // No bodies provided for the skill
-      const result = await run({
-        config,
-        bodies: new Map(),
-        outDir: tmpDir,
-        dryRun: false,
-        workDir: tmpDir,
-        spawner: new MockSpawner({}),
-      });
-
-      assert.equal(result.steps.length, 1);
-      assert.equal(result.steps[0].status, "error");
-      assert.ok(result.steps[0].error?.includes("missing"));
+      // No bodies provided - expandComposedBodies throws CompileError
+      await assert.rejects(
+        () => run({
+          config,
+          bodies: new Map(),
+          outDir: tmpDir!,
+          dryRun: false,
+          workDir: tmpDir!,
+          spawner: new MockSpawner({}),
+        }),
+        { message: /missing-base/ },
+      );
     });
   });
 
@@ -751,6 +750,47 @@ describe("run", () => {
 
       assert.equal(result.steps.length, 1);
       assert.equal(result.steps[0].status, "ok");
+    });
+
+    it("then: end on a middle node stops execution early", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {
+          "a-base": { path: "./skills/a" },
+          a: { compose: ["a-base"], description: "A" },
+          "b-base": { path: "./skills/b" },
+          b: { compose: ["b-base"], description: "B" },
+        },
+        team: {
+          flow: {
+            nodes: [
+              { skill: "a", reads: [], writes: ["state.x"], then: "end" },
+              { skill: "b", reads: ["state.x"], writes: ["state.y"] },
+            ],
+          },
+        },
+      };
+
+      const spawner = new MockSpawner({
+        a: { x: "done" },
+        b: { y: "should not run" },
+      });
+
+      const result = await run({
+        config,
+        bodies: new Map([["a-base", "A."], ["b-base", "B."]]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[0].agent, "a");
+      assert.equal(spawner.calls.length, 1);
+      assert.deepEqual(result.state, { x: "done" });
     });
   });
 });

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -1,0 +1,785 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import type { Config } from "./config.js";
+import type { Graph } from "./graph.js";
+import { type RunResult, type Spawner, parseStateFromOutput, run } from "./run.js";
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `skillfold-run-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** A mock spawner that returns predetermined state updates per agent. */
+class MockSpawner implements Spawner {
+  calls: { agentName: string; skillContent: string; state: Record<string, unknown> }[] = [];
+  responses: Map<string, Record<string, unknown>>;
+
+  constructor(responses: Record<string, Record<string, unknown>>) {
+    this.responses = new Map(Object.entries(responses));
+  }
+
+  async spawn(
+    agentName: string,
+    skillContent: string,
+    state: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    this.calls.push({ agentName, skillContent, state });
+    return this.responses.get(agentName) ?? {};
+  }
+}
+
+/** A mock spawner that throws on the specified agent. */
+class ErrorSpawner implements Spawner {
+  errorAgent: string;
+  calls: string[] = [];
+
+  constructor(errorAgent: string) {
+    this.errorAgent = errorAgent;
+  }
+
+  async spawn(
+    agentName: string,
+    _skillContent: string,
+    _state: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    this.calls.push(agentName);
+    if (agentName === this.errorAgent) {
+      throw new Error(`Agent "${agentName}" failed`);
+    }
+    return {};
+  }
+}
+
+function makeLinearConfig(nodes: { skill: string; reads: string[]; writes: string[] }[]): Config {
+  const skills: Config["skills"] = {};
+
+  // Create composed skills for each node
+  for (const node of nodes) {
+    // Create an atomic skill and a composed skill wrapping it
+    skills[`${node.skill}-base`] = { path: `./skills/${node.skill}` };
+    skills[node.skill] = {
+      compose: [`${node.skill}-base`],
+      description: `${node.skill} agent`,
+    };
+  }
+
+  const flow: Graph = {
+    nodes: nodes.map((n) => ({
+      skill: n.skill,
+      reads: n.reads,
+      writes: n.writes,
+    })),
+  };
+
+  return {
+    name: "test-pipeline",
+    skills,
+    team: { flow },
+  };
+}
+
+function makeBodies(skills: string[]): Map<string, string> {
+  const bodies = new Map<string, string>();
+  for (const skill of skills) {
+    bodies.set(`${skill}-base`, `You are the ${skill} agent.`);
+  }
+  return bodies;
+}
+
+describe("run", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  describe("linear flow execution", () => {
+    it("executes a 3-step linear flow in order", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "planner", reads: [], writes: ["state.plan"] },
+        { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        { skill: "reviewer", reads: ["state.code"], writes: ["state.review"] },
+      ]);
+
+      const spawner = new MockSpawner({
+        planner: { plan: "the plan" },
+        engineer: { code: "the code" },
+        reviewer: { review: "approved" },
+      });
+
+      const result = await run({
+        config,
+        bodies: makeBodies(["planner", "engineer", "reviewer"]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      assert.equal(result.steps.length, 3);
+      assert.equal(result.steps[0].agent, "planner");
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[1].agent, "engineer");
+      assert.equal(result.steps[1].status, "ok");
+      assert.equal(result.steps[2].agent, "reviewer");
+      assert.equal(result.steps[2].status, "ok");
+
+      // Verify order
+      assert.equal(spawner.calls.length, 3);
+      assert.equal(spawner.calls[0].agentName, "planner");
+      assert.equal(spawner.calls[1].agentName, "engineer");
+      assert.equal(spawner.calls[2].agentName, "reviewer");
+    });
+
+    it("accumulates state writes across steps", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "planner", reads: [], writes: ["state.plan"] },
+        { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+      ]);
+
+      const spawner = new MockSpawner({
+        planner: { plan: "the plan" },
+        engineer: { code: "the code" },
+      });
+
+      const result = await run({
+        config,
+        bodies: makeBodies(["planner", "engineer"]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      assert.deepEqual(result.state, { plan: "the plan", code: "the code" });
+    });
+
+    it("passes only read fields to spawner", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "planner", reads: [], writes: ["state.plan"] },
+        { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+      ]);
+
+      const spawner = new MockSpawner({
+        planner: { plan: "the plan" },
+        engineer: { code: "the code" },
+      });
+
+      await run({
+        config,
+        bodies: makeBodies(["planner", "engineer"]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      // Planner reads nothing
+      assert.deepEqual(spawner.calls[0].state, {});
+      // Engineer reads state.plan
+      assert.deepEqual(spawner.calls[1].state, { plan: "the plan" });
+    });
+  });
+
+  describe("state management", () => {
+    it("creates state.json if it does not exist", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "planner", reads: [], writes: ["state.plan"] },
+      ]);
+
+      const spawner = new MockSpawner({ planner: { plan: "the plan" } });
+
+      await run({
+        config,
+        bodies: makeBodies(["planner"]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      const statePath = join(tmpDir, "state.json");
+      assert.ok(existsSync(statePath));
+      const state = JSON.parse(readFileSync(statePath, "utf-8"));
+      assert.deepEqual(state, { plan: "the plan" });
+    });
+
+    it("reads existing state.json at startup", async () => {
+      tmpDir = makeTmpDir();
+      writeFileSync(
+        join(tmpDir, "state.json"),
+        JSON.stringify({ existing: "value" }),
+        "utf-8",
+      );
+
+      const config = makeLinearConfig([
+        { skill: "planner", reads: ["state.existing"], writes: ["state.plan"] },
+      ]);
+
+      const spawner = new MockSpawner({ planner: { plan: "the plan" } });
+
+      await run({
+        config,
+        bodies: makeBodies(["planner"]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      // The spawner should have received the existing state field
+      assert.deepEqual(spawner.calls[0].state, { existing: "value" });
+
+      // Final state.json should have both
+      const state = JSON.parse(readFileSync(join(tmpDir, "state.json"), "utf-8"));
+      assert.equal(state.existing, "value");
+      assert.equal(state.plan, "the plan");
+    });
+
+    it("strips state. prefix from field names", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "planner", reads: [], writes: ["state.plan"] },
+      ]);
+
+      const spawner = new MockSpawner({ planner: { plan: "result" } });
+
+      const result = await run({
+        config,
+        bodies: makeBodies(["planner"]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      // State uses stripped names (no "state." prefix)
+      assert.equal(result.state.plan, "result");
+      assert.equal(result.state["state.plan"], undefined);
+    });
+  });
+
+  describe("dry-run mode", () => {
+    it("does not call spawner", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "planner", reads: [], writes: ["state.plan"] },
+      ]);
+
+      const spawner = new MockSpawner({ planner: { plan: "x" } });
+
+      await run({
+        config,
+        bodies: makeBodies(["planner"]),
+        outDir: tmpDir,
+        dryRun: true,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      assert.equal(spawner.calls.length, 0);
+    });
+
+    it("does not create or modify state.json", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "planner", reads: [], writes: ["state.plan"] },
+      ]);
+
+      await run({
+        config,
+        bodies: makeBodies(["planner"]),
+        outDir: tmpDir,
+        dryRun: true,
+        workDir: tmpDir,
+        spawner: new MockSpawner({}),
+      });
+
+      assert.ok(!existsSync(join(tmpDir, "state.json")));
+    });
+
+    it("returns steps with skipped status", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "planner", reads: [], writes: ["state.plan"] },
+        { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+      ]);
+
+      const result = await run({
+        config,
+        bodies: makeBodies(["planner", "engineer"]),
+        outDir: tmpDir,
+        dryRun: true,
+        workDir: tmpDir,
+        spawner: new MockSpawner({}),
+      });
+
+      assert.equal(result.steps.length, 2);
+      assert.equal(result.steps[0].status, "skipped");
+      assert.equal(result.steps[1].status, "skipped");
+    });
+  });
+
+  describe("unsupported features", () => {
+    it("rejects map nodes with clear error", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {
+          "writer-base": { path: "./skills/writer" },
+          writer: { compose: ["writer-base"], description: "Writer agent" },
+        },
+        team: {
+          flow: {
+            nodes: [{
+              over: "state.topics",
+              as: "topic",
+              flow: [{ skill: "writer", reads: [], writes: [] }],
+            }],
+          },
+        },
+      };
+
+      await assert.rejects(
+        () => run({
+          config,
+          bodies: new Map([["writer-base", "Write."]]),
+          outDir: tmpDir!,
+          dryRun: false,
+          workDir: tmpDir!,
+          spawner: new MockSpawner({}),
+        }),
+        { message: "map nodes not supported in skillfold run MVP - use the orchestrator" },
+      );
+    });
+
+    it("rejects conditional then with clear error", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {
+          "planner-base": { path: "./skills/planner" },
+          planner: { compose: ["planner-base"], description: "Planner" },
+          "alt-base": { path: "./skills/alt" },
+          alt: { compose: ["alt-base"], description: "Alt" },
+        },
+        team: {
+          flow: {
+            nodes: [
+              {
+                skill: "planner",
+                reads: [],
+                writes: ["state.plan"],
+                then: [{ when: "state.plan == done", to: "end" }],
+              },
+              { skill: "alt", reads: [], writes: [] },
+            ],
+          },
+        },
+      };
+
+      await assert.rejects(
+        () => run({
+          config,
+          bodies: new Map([["planner-base", "Plan."], ["alt-base", "Alt."]]),
+          outDir: tmpDir!,
+          dryRun: false,
+          workDir: tmpDir!,
+          spawner: new MockSpawner({}),
+        }),
+        { message: "conditional routing not supported in skillfold run MVP - use the orchestrator" },
+      );
+    });
+
+    it("rejects non-linear jump with clear error", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {
+          "a-base": { path: "./skills/a" },
+          a: { compose: ["a-base"], description: "A" },
+          "b-base": { path: "./skills/b" },
+          b: { compose: ["b-base"], description: "B" },
+          "c-base": { path: "./skills/c" },
+          c: { compose: ["c-base"], description: "C" },
+        },
+        team: {
+          flow: {
+            nodes: [
+              { skill: "a", reads: [], writes: [], then: "c" },
+              { skill: "b", reads: [], writes: [] },
+              { skill: "c", reads: [], writes: [] },
+            ],
+          },
+        },
+      };
+
+      await assert.rejects(
+        () => run({
+          config,
+          bodies: new Map([["a-base", "A."], ["b-base", "B."], ["c-base", "C."]]),
+          outDir: tmpDir!,
+          dryRun: false,
+          workDir: tmpDir!,
+          spawner: new MockSpawner({}),
+        }),
+        { message: /non-linear jump/ },
+      );
+    });
+
+    it("rejects sub-flow nodes with clear error", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {},
+        team: {
+          flow: {
+            nodes: [{
+              name: "sub",
+              flow: "other.yaml",
+              reads: [],
+              writes: [],
+            }],
+          },
+        },
+      };
+
+      await assert.rejects(
+        () => run({
+          config,
+          bodies: new Map(),
+          outDir: tmpDir!,
+          dryRun: false,
+          workDir: tmpDir!,
+          spawner: new MockSpawner({}),
+        }),
+        { message: "sub-flow nodes not supported in skillfold run MVP - use the orchestrator" },
+      );
+    });
+  });
+
+  describe("async node handling", () => {
+    it("skips async nodes with skipped status", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {
+          "planner-base": { path: "./skills/planner" },
+          planner: { compose: ["planner-base"], description: "Planner" },
+        },
+        team: {
+          flow: {
+            nodes: [
+              { skill: "planner", reads: [], writes: ["state.plan"] },
+              { name: "human-review", async: true as const, reads: ["state.plan"], writes: ["state.feedback"], policy: "skip" as const },
+            ],
+          },
+        },
+      };
+
+      const spawner = new MockSpawner({ planner: { plan: "the plan" } });
+
+      const result = await run({
+        config,
+        bodies: new Map([["planner-base", "Plan."]]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      assert.equal(result.steps.length, 2);
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[1].status, "skipped");
+      assert.equal(result.steps[1].agent, "human-review");
+    });
+
+    it("continues execution past async nodes", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {
+          "a-base": { path: "./skills/a" },
+          a: { compose: ["a-base"], description: "A" },
+          "b-base": { path: "./skills/b" },
+          b: { compose: ["b-base"], description: "B" },
+        },
+        team: {
+          flow: {
+            nodes: [
+              { skill: "a", reads: [], writes: ["state.x"] },
+              { name: "external", async: true as const, reads: [], writes: [], policy: "skip" as const },
+              { skill: "b", reads: ["state.x"], writes: ["state.y"] },
+            ],
+          },
+        },
+      };
+
+      const spawner = new MockSpawner({
+        a: { x: "hello" },
+        b: { y: "world" },
+      });
+
+      const result = await run({
+        config,
+        bodies: new Map([["a-base", "A."], ["b-base", "B."]]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      assert.equal(result.steps.length, 3);
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[1].status, "skipped");
+      assert.equal(result.steps[2].status, "ok");
+      assert.equal(spawner.calls.length, 2);
+    });
+  });
+
+  describe("error handling", () => {
+    it("captures spawner error in step result", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "planner", reads: [], writes: ["state.plan"] },
+        { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+      ]);
+
+      const spawner = new ErrorSpawner("engineer");
+
+      const result = await run({
+        config,
+        bodies: makeBodies(["planner", "engineer"]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      assert.equal(result.steps.length, 2);
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[1].status, "error");
+      assert.ok(result.steps[1].error?.includes("engineer"));
+    });
+
+    it("halts execution on spawner error", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "planner", reads: [], writes: ["state.plan"] },
+        { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        { skill: "reviewer", reads: ["state.code"], writes: ["state.review"] },
+      ]);
+
+      const spawner = new ErrorSpawner("engineer");
+
+      const result = await run({
+        config,
+        bodies: makeBodies(["planner", "engineer", "reviewer"]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      // Should stop after engineer fails - reviewer never runs
+      assert.equal(result.steps.length, 2);
+      assert.equal(spawner.calls.length, 2);
+    });
+
+    it("errors when no team flow is defined", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {},
+      };
+
+      await assert.rejects(
+        () => run({
+          config,
+          bodies: new Map(),
+          outDir: tmpDir!,
+          dryRun: false,
+          workDir: tmpDir!,
+          spawner: new MockSpawner({}),
+        }),
+        { message: "No team flow defined in config" },
+      );
+    });
+
+    it("errors when skill content is not found for a step", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {
+          "missing-base": { path: "./skills/missing" },
+          missing: { compose: ["missing-base"], description: "Missing" },
+        },
+        team: {
+          flow: {
+            nodes: [{ skill: "missing", reads: [], writes: [] }],
+          },
+        },
+      };
+
+      // No bodies provided for the skill
+      const result = await run({
+        config,
+        bodies: new Map(),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner: new MockSpawner({}),
+      });
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "error");
+      assert.ok(result.steps[0].error?.includes("missing"));
+    });
+  });
+
+  describe("edge cases", () => {
+    it("empty flow completes with no steps", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {},
+        team: { flow: { nodes: [] } },
+      };
+
+      const result = await run({
+        config,
+        bodies: new Map(),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner: new MockSpawner({}),
+      });
+
+      assert.equal(result.steps.length, 0);
+    });
+
+    it("flow with only async nodes completes with all skipped", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {},
+        team: {
+          flow: {
+            nodes: [
+              { name: "human-a", async: true as const, reads: [], writes: [], policy: "skip" as const },
+              { name: "human-b", async: true as const, reads: [], writes: [], policy: "skip" as const },
+            ],
+          },
+        },
+      };
+
+      const result = await run({
+        config,
+        bodies: new Map(),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner: new MockSpawner({}),
+      });
+
+      assert.equal(result.steps.length, 2);
+      assert.equal(result.steps[0].status, "skipped");
+      assert.equal(result.steps[1].status, "skipped");
+    });
+
+    it("single-node flow works correctly", async () => {
+      tmpDir = makeTmpDir();
+      const config = makeLinearConfig([
+        { skill: "solo", reads: [], writes: ["state.output"] },
+      ]);
+
+      const spawner = new MockSpawner({ solo: { output: "done" } });
+
+      const result = await run({
+        config,
+        bodies: makeBodies(["solo"]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "ok");
+      assert.deepEqual(result.state, { output: "done" });
+    });
+
+    it("then: end stops execution cleanly", async () => {
+      tmpDir = makeTmpDir();
+      const config: Config = {
+        name: "test",
+        skills: {
+          "a-base": { path: "./skills/a" },
+          a: { compose: ["a-base"], description: "A" },
+        },
+        team: {
+          flow: {
+            nodes: [
+              { skill: "a", reads: [], writes: ["state.x"], then: "end" },
+            ],
+          },
+        },
+      };
+
+      const spawner = new MockSpawner({ a: { x: "val" } });
+
+      const result = await run({
+        config,
+        bodies: new Map([["a-base", "A."]]),
+        outDir: tmpDir,
+        dryRun: false,
+        workDir: tmpDir,
+        spawner,
+      });
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "ok");
+    });
+  });
+});
+
+describe("parseStateFromOutput", () => {
+  it("extracts JSON from a code block", () => {
+    const output = 'Some text\n```json\n{"plan": "the plan"}\n```\nMore text';
+    const result = parseStateFromOutput(output);
+    assert.deepEqual(result, { plan: "the plan" });
+  });
+
+  it("uses the last JSON block when multiple are present", () => {
+    const output = '```json\n{"first": 1}\n```\n```json\n{"second": 2}\n```';
+    const result = parseStateFromOutput(output);
+    assert.deepEqual(result, { second: 2 });
+  });
+
+  it("returns empty object when no JSON block found", () => {
+    const result = parseStateFromOutput("no json here");
+    assert.deepEqual(result, {});
+  });
+
+  it("returns empty object for invalid JSON", () => {
+    const result = parseStateFromOutput('```json\nnot valid json\n```');
+    assert.deepEqual(result, {});
+  });
+
+  it("returns empty object for non-object JSON", () => {
+    const result = parseStateFromOutput('```json\n[1, 2, 3]\n```');
+    assert.deepEqual(result, {});
+  });
+});

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,8 +1,9 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { Config } from "./config.js";
+import { expandComposedBodies } from "./compiler.js";
 import {
   type GraphNode,
   type StepNode,
@@ -45,7 +46,7 @@ export class ClaudeSpawner implements Spawner {
   validate(): void {
     if (this.validated) return;
     try {
-      execSync("claude --version", { stdio: "pipe" });
+      execFileSync("claude", ["--version"], { stdio: "pipe" });
     } catch {
       throw new Error(
         "claude CLI not found. Install it from https://docs.anthropic.com/en/docs/claude-code"
@@ -73,8 +74,9 @@ export class ClaudeSpawner implements Spawner {
       "Wrap the JSON in ```json fences.",
     ].join("\n");
 
-    const result = execSync(
-      `claude --print --system-prompt ${JSON.stringify(skillContent)} ${JSON.stringify(prompt)}`,
+    const result = execFileSync(
+      "claude",
+      ["--print", "--system-prompt", skillContent, prompt],
       { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 },
     );
 
@@ -215,6 +217,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
       const node = nodes[i];
       const label = nodeLabel(node);
       steps.push({ step: i + 1, agent: label, status: "skipped" });
+      if (node.then === "end") break;
     }
     return { steps, state: {} };
   }
@@ -243,6 +246,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
         `  [${i + 1}/${nodes.length}] ${label}... skipped (async node - requires external input)\n`
       );
       steps.push({ step: i + 1, agent: label, status: "skipped" });
+      if (node.then === "end") break;
       continue;
     }
 
@@ -287,6 +291,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
 
       process.stderr.write(" done\n");
       steps.push({ step: i + 1, agent: label, status: "ok" });
+      if (node.then === "end") break;
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       process.stderr.write(` error\n`);
@@ -298,46 +303,3 @@ export async function run(options: RunOptions): Promise<RunResult> {
   return { steps, state };
 }
 
-/**
- * Expand a composed skill into its full body text by concatenating
- * all atomic skill bodies in composition order.
- */
-function expandSkill(
-  name: string,
-  config: Config,
-  bodies: Map<string, string>,
-  seen: Set<string>,
-): string[] {
-  if (seen.has(name)) return [];
-
-  const skill = config.skills[name];
-  if (!skill) return [];
-
-  if (!("compose" in skill)) {
-    const body = bodies.get(name);
-    return body !== undefined ? [body] : [];
-  }
-
-  seen.add(name);
-  const parts: string[] = [];
-  for (const ref of skill.compose) {
-    parts.push(...expandSkill(ref, config, bodies, new Set(seen)));
-  }
-  return parts;
-}
-
-/**
- * Build a map of composed skill name -> expanded body text.
- */
-function expandComposedBodies(
-  config: Config,
-  bodies: Map<string, string>,
-): Map<string, string> {
-  const result = new Map<string, string>();
-  for (const [name, skill] of Object.entries(config.skills)) {
-    if (!("compose" in skill)) continue;
-    const parts = expandSkill(name, config, bodies, new Set());
-    result.set(name, parts.join("\n\n"));
-  }
-  return result;
-}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,343 @@
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { Config } from "./config.js";
+import {
+  type GraphNode,
+  type StepNode,
+  isAsyncNode,
+  isConditionalThen,
+  isMapNode,
+  isSubFlowNode,
+} from "./graph.js";
+
+export interface RunOptions {
+  config: Config;
+  bodies: Map<string, string>;
+  outDir: string;
+  dryRun: boolean;
+  /** Working directory for state.json (defaults to process.cwd()) */
+  workDir?: string;
+  /** Override spawner for testing */
+  spawner?: Spawner;
+}
+
+export interface StepResult {
+  step: number;
+  agent: string;
+  status: "ok" | "error" | "skipped";
+  error?: string;
+}
+
+export interface RunResult {
+  steps: StepResult[];
+  state: Record<string, unknown>;
+}
+
+export interface Spawner {
+  spawn(agentName: string, skillContent: string, state: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+export class ClaudeSpawner implements Spawner {
+  private validated = false;
+
+  validate(): void {
+    if (this.validated) return;
+    try {
+      execSync("claude --version", { stdio: "pipe" });
+    } catch {
+      throw new Error(
+        "claude CLI not found. Install it from https://docs.anthropic.com/en/docs/claude-code"
+      );
+    }
+    this.validated = true;
+  }
+
+  async spawn(
+    agentName: string,
+    skillContent: string,
+    state: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    this.validate();
+
+    const prompt = [
+      "You are the " + agentName + " agent.",
+      "",
+      "## Current State",
+      "```json",
+      JSON.stringify(state, null, 2),
+      "```",
+      "",
+      "Execute your task. When done, output a JSON block with the updated state fields you are responsible for writing.",
+      "Wrap the JSON in ```json fences.",
+    ].join("\n");
+
+    const result = execSync(
+      `claude --print --system-prompt ${JSON.stringify(skillContent)} ${JSON.stringify(prompt)}`,
+      { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 },
+    );
+
+    // Extract last JSON block from output
+    return parseStateFromOutput(result);
+  }
+}
+
+/**
+ * Extract the last JSON code block from agent output.
+ * Returns an empty object if no JSON block found.
+ */
+export function parseStateFromOutput(output: string): Record<string, unknown> {
+  const jsonBlockRe = /```json\s*\n([\s\S]*?)```/g;
+  let lastMatch: string | undefined;
+  let match: RegExpExecArray | null;
+  while ((match = jsonBlockRe.exec(output)) !== null) {
+    lastMatch = match[1];
+  }
+
+  if (!lastMatch) return {};
+
+  try {
+    const parsed = JSON.parse(lastMatch.trim());
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Get the node label for display and identification.
+ */
+function nodeLabel(node: GraphNode): string {
+  if (isMapNode(node)) return "map";
+  if (isSubFlowNode(node)) return node.name;
+  if (isAsyncNode(node)) return node.name;
+  return (node as StepNode).skill;
+}
+
+/**
+ * Strip the "state." prefix from a state path.
+ */
+function stripStatePrefix(path: string): string {
+  return path.startsWith("state.") ? path.slice("state.".length) : path;
+}
+
+/**
+ * Read state.json from the working directory.
+ * Returns an empty object if the file does not exist.
+ */
+function readState(workDir: string): Record<string, unknown> {
+  const statePath = join(workDir, "state.json");
+  if (!existsSync(statePath)) return {};
+
+  try {
+    const content = readFileSync(statePath, "utf-8");
+    const parsed = JSON.parse(content);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Write state.json to the working directory.
+ */
+function writeState(workDir: string, state: Record<string, unknown>): void {
+  const statePath = join(workDir, "state.json");
+  writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Validate that the flow is linear (no conditional routing, no map nodes,
+ * no non-sequential jumps). Returns an error message if invalid, or undefined if valid.
+ */
+function validateLinearFlow(nodes: GraphNode[]): string | undefined {
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const label = nodeLabel(node);
+
+    if (isMapNode(node)) {
+      return `map nodes not supported in skillfold run MVP - use the orchestrator`;
+    }
+
+    if (isSubFlowNode(node)) {
+      return `sub-flow nodes not supported in skillfold run MVP - use the orchestrator`;
+    }
+
+    if (node.then !== undefined) {
+      if (isConditionalThen(node.then)) {
+        return `conditional routing not supported in skillfold run MVP - use the orchestrator`;
+      }
+
+      // Non-conditional then: must point to the next sequential node or "end"
+      const target = node.then;
+      if (target === "end") continue;
+
+      if (i + 1 < nodes.length) {
+        const nextLabel = nodeLabel(nodes[i + 1]);
+        if (target !== nextLabel) {
+          return `node "${label}" has non-linear jump to "${target}" - not supported in skillfold run MVP`;
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Run a pipeline flow sequentially.
+ */
+export async function run(options: RunOptions): Promise<RunResult> {
+  const { config, bodies, dryRun, spawner } = options;
+  const workDir = options.workDir ?? process.cwd();
+
+  if (!config.team) {
+    throw new Error("No team flow defined in config");
+  }
+
+  const nodes = config.team.flow.nodes;
+  const flowError = validateLinearFlow(nodes);
+  if (flowError) {
+    throw new Error(flowError);
+  }
+
+  // Dry-run mode: print plan without executing
+  if (dryRun) {
+    const steps: StepResult[] = [];
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      const label = nodeLabel(node);
+      steps.push({ step: i + 1, agent: label, status: "skipped" });
+    }
+    return { steps, state: {} };
+  }
+
+  // Build composed skill bodies (same logic as compiler expand)
+  const composedBodies = expandComposedBodies(config, bodies);
+
+  // Validate spawner (check claude CLI if using ClaudeSpawner)
+  const activeSpawner = spawner ?? new ClaudeSpawner();
+  if (activeSpawner instanceof ClaudeSpawner) {
+    activeSpawner.validate();
+  }
+
+  // Read initial state
+  let state = readState(workDir);
+
+  const steps: StepResult[] = [];
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const label = nodeLabel(node);
+
+    // Skip async nodes
+    if (isAsyncNode(node)) {
+      process.stderr.write(
+        `  [${i + 1}/${nodes.length}] ${label}... skipped (async node - requires external input)\n`
+      );
+      steps.push({ step: i + 1, agent: label, status: "skipped" });
+      continue;
+    }
+
+    const stepNode = node as StepNode;
+
+    // Find the skill content for this agent
+    const skillContent = composedBodies.get(stepNode.skill);
+    if (!skillContent) {
+      steps.push({
+        step: i + 1,
+        agent: label,
+        status: "error",
+        error: `No compiled skill content found for "${stepNode.skill}"`,
+      });
+      return { steps, state };
+    }
+
+    // Extract state fields this node reads
+    const inputState: Record<string, unknown> = {};
+    for (const path of stepNode.reads) {
+      const key = stripStatePrefix(path);
+      if (key in state) {
+        inputState[key] = state[key];
+      }
+    }
+
+    process.stderr.write(`  [${i + 1}/${nodes.length}] ${label}...`);
+
+    try {
+      const output = await activeSpawner.spawn(label, skillContent, inputState);
+
+      // Merge output into state for fields this node writes
+      for (const path of stepNode.writes) {
+        const key = stripStatePrefix(path);
+        if (key in output) {
+          state[key] = output[key];
+        }
+      }
+
+      // Write state after each step
+      writeState(workDir, state);
+
+      process.stderr.write(" done\n");
+      steps.push({ step: i + 1, agent: label, status: "ok" });
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(` error\n`);
+      steps.push({ step: i + 1, agent: label, status: "error", error: errorMsg });
+      return { steps, state };
+    }
+  }
+
+  return { steps, state };
+}
+
+/**
+ * Expand a composed skill into its full body text by concatenating
+ * all atomic skill bodies in composition order.
+ */
+function expandSkill(
+  name: string,
+  config: Config,
+  bodies: Map<string, string>,
+  seen: Set<string>,
+): string[] {
+  if (seen.has(name)) return [];
+
+  const skill = config.skills[name];
+  if (!skill) return [];
+
+  if (!("compose" in skill)) {
+    const body = bodies.get(name);
+    return body !== undefined ? [body] : [];
+  }
+
+  seen.add(name);
+  const parts: string[] = [];
+  for (const ref of skill.compose) {
+    parts.push(...expandSkill(ref, config, bodies, new Set(seen)));
+  }
+  return parts;
+}
+
+/**
+ * Build a map of composed skill name -> expanded body text.
+ */
+function expandComposedBodies(
+  config: Config,
+  bodies: Map<string, string>,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const [name, skill] of Object.entries(config.skills)) {
+    if (!("compose" in skill)) continue;
+    const parts = expandSkill(name, config, bodies, new Set());
+    result.set(name, parts.join("\n\n"));
+  }
+  return result;
+}


### PR DESCRIPTION
**[engineer]**

## Summary

- Implement `skillfold run` - an MVP pipeline runner that executes linear flows by spawning agents sequentially
- Add `run` subcommand to CLI with `--dry-run` and `--target` flags
- Add 28 tests covering the full runner surface area

## Details

**src/run.ts - Core runner module**
- `Spawner` interface for swappable subprocess mechanisms (enables testing with mocks)
- `ClaudeSpawner` that validates `claude` CLI availability and invokes `claude --print`
- `parseStateFromOutput()` extracts JSON state from agent output
- `run()` function walks flow nodes sequentially, managing `state.json` reads/writes
- Linear flow validation rejects map nodes, conditional routing, sub-flows, and non-sequential jumps with clear error messages
- Async nodes are skipped with a warning
- Dry-run mode prints the execution plan without spawning agents or touching state

**src/cli.ts - CLI wiring**
- `run` command added to Command type and parseArgs
- `--dry-run` flag support
- Requires a runtime target (errors on `--target skill` or no target)
- Errors if no team flow is defined in config
- Progress output to stderr during execution
- Dry-run output shows reads/writes for each step

**src/run.test.ts - Tests (28 tests, 9 suites)**
- Linear flow execution (order, state accumulation, read field filtering)
- State management (create, read existing, prefix stripping)
- Dry-run mode (no spawner calls, no state.json, skipped status)
- Unsupported features (map, conditional, non-linear, sub-flow errors)
- Async node handling (skip, continue past)
- Error handling (spawner error capture, halt on error, missing config, missing skill)
- Edge cases (empty flow, all-async flow, single node, then:end)
- parseStateFromOutput unit tests

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (695 tests, 0 failures)
- [x] New run tests pass (28/28)

Closes #394, closes #395, closes #396