### PR TITLE
feat: add skillfold run command for pipeline execution

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -403,6 +403,7 @@ See the [Publishing Guide](publishing.md) for package structure, required fields
 
 ## 13. Next steps
 
+- Run your pipeline with `skillfold run --target claude-code` (linear flows), or preview with `--dry-run`
 - Read the full config specification in [BRIEF.md](https://github.com/byronxlg/skillfold/blob/main/BRIEF.md)
 - Explore the [shared library examples](https://github.com/byronxlg/skillfold/tree/main/library/examples/) for real pipeline patterns
 - Use `skillfold graph` to visualize your team flow as a Mermaid diagram, or `skillfold graph --html` for interactive HTML output with clickable nodes and SVG export

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -114,6 +114,36 @@ npx skillfold graph --html > pipeline.html
 
 The `--html` output includes clickable nodes, a composition details sidebar, and SVG export.
 
+### Run
+
+Execute a compiled pipeline by spawning agents sequentially. Currently supports linear flows only (no conditionals, map, or sub-flows).
+
+```bash
+npx skillfold run --target claude-code             # execute the pipeline
+npx skillfold run --target claude-code --dry-run   # preview without running
+npx skillfold run --target claude-code --config my-pipeline.yaml
+```
+
+Requires a `--target` flag (cannot use the default `skill` target). The `--dry-run` flag prints each step with its reads and writes without spawning any agents.
+
+**State management**: The runner reads and writes `state.json` in the working directory. Before each step, the current state is passed to the agent. After each step, the agent's state updates are merged back. Only fields declared in the node's `writes` are persisted.
+
+**Async nodes**: Async nodes (external agents, humans) are skipped automatically. Execution continues to the next step.
+
+**Current limitations**:
+- Linear flows only (no conditional routing, no map/parallel, no sub-flows)
+- Requires the `claude` CLI to be installed for agent spawning
+- Agents output state updates via a JSON code block with a `stateUpdates` key
+
+Example dry-run output:
+
+```
+skillfold: dry run for my-pipeline (3 steps)
+Step 1: planner reads=[direction] writes=[plan]
+Step 2: engineer reads=[plan] writes=[code]
+Step 3: reviewer reads=[code] writes=[review]
+```
+
 ### Watch
 
 Compile and auto-recompile when config or skill files change.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,6 +20,7 @@ Commands:
   validate          Validate config without compiling
   list              Display a structured summary of the pipeline
   graph             Output Mermaid flowchart of the team flow
+  run               Execute a compiled pipeline (linear flows only)
   watch             Compile and watch for changes
   plugin            Package compiled output as a Claude Code plugin
   search [query]    Discover skill packages on npm
@@ -36,6 +37,7 @@ Commands:
   --template <name>    Start from a library template (init only)
   --html               Output interactive HTML instead of Mermaid (graph only)
   --check              Verify compiled output is up-to-date (exit 1 if stale)
+  --dry-run            Show execution plan without running (run only)
   --help               Show this help
   --version            Show version
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { type CompileTarget, check, compile, computeStats } from "./compiler.js";
 import { isAtomic, isComposed, loadConfig } from "./config.js";
-import { ConfigError, CompileError, GraphError, ResolveError } from "./errors.js";
+import { ConfigError, CompileError, GraphError, ResolveError, RunError } from "./errors.js";
 import { initFromTemplate, initProject, TEMPLATES } from "./init.js";
 import { listPipeline } from "./list.js";
 import { resolveSkills } from "./resolver.js";
@@ -27,6 +27,7 @@ Commands:
   validate          Validate config without compiling
   list              Display a structured summary of the pipeline
   graph             Output Mermaid flowchart of the team flow
+  run               Execute a compiled pipeline (linear flows only)
   watch             Compile and watch for changes
   plugin            Package compiled output as a Claude Code plugin
   search [query]    Search npm for skillfold skill packages
@@ -39,6 +40,7 @@ Options:
   --target <mode>      Output mode: skill, claude-code, cursor, windsurf, codex, copilot
   --template <name>    Start from a library template (init only)
   --check              Verify compiled output is up-to-date (exit 1 if stale)
+  --dry-run            Show execution plan without running (run only)
   --html               Output interactive HTML instead of Mermaid (graph only)
   --help               Show this help
   --version            Show version
@@ -46,7 +48,7 @@ Options:
 Templates: ${TEMPLATES.join(", ")}`);
 }
 
-type Command = "init" | "adopt" | "compile" | "graph" | "list" | "validate" | "watch" | "plugin" | "search";
+type Command = "init" | "adopt" | "compile" | "graph" | "list" | "run" | "validate" | "watch" | "plugin" | "search";
 
 interface Args {
   command: Command;
@@ -58,6 +60,7 @@ interface Args {
   template: string | undefined;
   query: string | undefined;
   check: boolean;
+  dryRun: boolean;
   html: boolean;
   help: boolean;
   version: boolean;
@@ -73,6 +76,7 @@ function parseArgs(argv: string[]): Args {
   let template: string | undefined;
   let query: string | undefined;
   let checkMode = false;
+  let dryRun = false;
   let html = false;
   let help = false;
   let version = false;
@@ -105,6 +109,9 @@ function parseArgs(argv: string[]): Args {
     i = 1;
   } else if (argv.length > 0 && argv[0] === "plugin") {
     command = "plugin";
+    i = 1;
+  } else if (argv.length > 0 && argv[0] === "run") {
+    command = "run";
     i = 1;
   } else if (argv.length > 0 && argv[0] === "search") {
     command = "search";
@@ -140,6 +147,8 @@ function parseArgs(argv: string[]): Args {
       template = argv[++i];
     } else if (argv[i] === "--check") {
       checkMode = true;
+    } else if (argv[i] === "--dry-run") {
+      dryRun = true;
     } else if (argv[i] === "--html") {
       html = true;
     } else if (argv[i] === "--help") {
@@ -175,6 +184,7 @@ function parseArgs(argv: string[]): Args {
     template,
     query,
     check: checkMode,
+    dryRun,
     html,
     help,
     version,
@@ -337,6 +347,68 @@ async function main(): Promise<void> {
         err instanceof ConfigError ||
         err instanceof ResolveError ||
         err instanceof CompileError
+      ) {
+        console.error(`skillfold error: ${err.message}`);
+        process.exit(1);
+      }
+      throw err;
+    }
+    return;
+  }
+
+  if (args.command === "run") {
+    const { run } = await import("./run.js");
+    try {
+      if (args.target === "skill") {
+        console.error("skillfold error: --target is required for run (e.g. --target claude-code)");
+        process.exit(1);
+      }
+
+      const config = await loadConfig(args.configPath);
+      if (!config.team) {
+        console.error("skillfold error: config has no team.flow defined - nothing to run");
+        process.exit(1);
+      }
+
+      const baseDir = dirname(args.configPath);
+      const bodies = await resolveSkills(config, baseDir);
+
+      const nodeCount = config.team.flow.nodes.length;
+      if (args.dryRun) {
+        process.stderr.write(`skillfold: dry run for ${config.name} (${nodeCount} steps)\n`);
+      } else {
+        process.stderr.write(`skillfold: running ${config.name} (${nodeCount} steps)\n`);
+      }
+
+      const result = await run({
+        config,
+        bodies,
+        target: args.target,
+        outDir: args.outDir,
+        dryRun: args.dryRun,
+      });
+
+      if (!args.dryRun) {
+        for (const step of result.steps) {
+          const statusLabel = step.status === "ok" ? "done" :
+            step.status === "skipped" ? "skipped (async)" :
+            `error: ${step.error}`;
+          process.stderr.write(`  [${step.step}/${nodeCount}] ${step.agent}... ${statusLabel}\n`);
+        }
+
+        const failed = result.steps.find(s => s.status === "error");
+        if (failed) {
+          process.stderr.write(`skillfold: pipeline failed at step ${failed.step}\n`);
+          process.exit(1);
+        } else {
+          process.stderr.write(`skillfold: pipeline complete\n`);
+        }
+      }
+    } catch (err) {
+      if (
+        err instanceof ConfigError ||
+        err instanceof ResolveError ||
+        err instanceof RunError
       ) {
         console.error(`skillfold error: ${err.message}`);
         process.exit(1);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -26,6 +26,13 @@ export class GraphError extends Error {
   }
 }
 
+export class RunError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RunError";
+  }
+}
+
 /**
  * Compute Levenshtein distance between two strings.
  * Used to power "Did you mean..." suggestions in error messages.

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,10 +89,15 @@ export type { Template } from "./init.js";
 export { adoptProject } from "./adopt.js";
 export type { AdoptedAgent, AdoptResult } from "./adopt.js";
 
+// Pipeline execution
+export { ClaudeSpawner, run } from "./run.js";
+export type { RunOptions, RunResult, Spawner, StepResult } from "./run.js";
+
 // Errors
 export {
   CompileError,
   ConfigError,
   GraphError,
   ResolveError,
+  RunError,
 } from "./errors.js";

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -606,5 +606,35 @@ describe("run", () => {
       assert.equal(result.steps.length, 1);
       assert.equal(result.steps[0].status, "ok");
     });
+
+    it("then: end on a middle node stops execution", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "end" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      const { spawner, calls } = recordingSpawner({
+        planner: { plan: "done" },
+        engineer: { code: "should not run" },
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[0].agent, "planner");
+      assert.equal(calls.length, 1);
+      assert.equal(result.state.plan, "done");
+      assert.equal(result.state.code, undefined);
+    });
   });
 });

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -1,0 +1,610 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import type { Config } from "./config.js";
+import { RunError } from "./errors.js";
+import type { Graph } from "./graph.js";
+import type { Spawner, StepResult } from "./run.js";
+import { run } from "./run.js";
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `skillfold-run-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Mock spawner that returns predetermined state updates. */
+function mockSpawner(updates: Record<string, Record<string, unknown>>): Spawner {
+  return {
+    async spawn(agentName: string, _skillContent: string, _state: Record<string, unknown>) {
+      return updates[agentName] ?? {};
+    },
+  };
+}
+
+/** Mock spawner that records calls in order. */
+function recordingSpawner(
+  updates: Record<string, Record<string, unknown>>,
+): { spawner: Spawner; calls: Array<{ agent: string; state: Record<string, unknown> }> } {
+  const calls: Array<{ agent: string; state: Record<string, unknown> }> = [];
+  return {
+    calls,
+    spawner: {
+      async spawn(agentName: string, _skillContent: string, state: Record<string, unknown>) {
+        calls.push({ agent: agentName, state: { ...state } });
+        return updates[agentName] ?? {};
+      },
+    },
+  };
+}
+
+/** Mock spawner that throws on a specific agent. */
+function errorSpawner(failOn: string): Spawner {
+  return {
+    async spawn(agentName: string, _skillContent: string, _state: Record<string, unknown>) {
+      if (agentName === failOn) {
+        throw new Error(`Agent ${agentName} failed`);
+      }
+      return {};
+    },
+  };
+}
+
+function makeConfig(flow: Graph): Config {
+  return {
+    name: "test-pipeline",
+    skills: {
+      planning: { path: "./skills/planning" },
+      coding: { path: "./skills/coding" },
+      reviewing: { path: "./skills/reviewing" },
+      planner: { compose: ["planning"], description: "Plans work" },
+      engineer: { compose: ["coding"], description: "Writes code" },
+      reviewer: { compose: ["reviewing"], description: "Reviews code" },
+    },
+    team: {
+      flow,
+    },
+  };
+}
+
+function makeBodies(): Map<string, string> {
+  const bodies = new Map<string, string>();
+  bodies.set("planning", "Plan the work.");
+  bodies.set("coding", "Write the code.");
+  bodies.set("reviewing", "Review the code.");
+  return bodies;
+}
+
+describe("run", () => {
+  let origCwd: string;
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+    if (origCwd) {
+      process.chdir(origCwd);
+    }
+  });
+
+  describe("linear flow execution", () => {
+    it("executes a 3-step linear flow with mock spawner", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"], then: "reviewer" },
+          { skill: "reviewer", reads: ["state.code"], writes: ["state.review"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({
+          planner: { plan: "Build feature X" },
+          engineer: { code: "function x() {}" },
+          reviewer: { review: "LGTM" },
+        }),
+      );
+
+      assert.equal(result.steps.length, 3);
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[1].status, "ok");
+      assert.equal(result.steps[2].status, "ok");
+    });
+
+    it("executes steps in order", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      const { spawner, calls } = recordingSpawner({
+        planner: { plan: "the plan" },
+        engineer: { code: "the code" },
+      });
+
+      await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0].agent, "planner");
+      assert.equal(calls[1].agent, "engineer");
+    });
+
+    it("final state contains all accumulated writes", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({
+          planner: { plan: "build it" },
+          engineer: { code: "done" },
+        }),
+      );
+
+      assert.equal(result.state.plan, "build it");
+      assert.equal(result.state.code, "done");
+    });
+  });
+
+  describe("state management", () => {
+    it("creates state.json if it does not exist", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({ planner: { plan: "created" } }),
+      );
+
+      assert.ok(existsSync(join(tmpDir, "state.json")));
+      const content = JSON.parse(readFileSync(join(tmpDir, "state.json"), "utf-8"));
+      assert.equal(content.plan, "created");
+    });
+
+    it("reads state.json at startup if it exists", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({ existing: "data" }));
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: ["state.existing"], writes: ["state.plan"] },
+        ],
+      });
+
+      const { spawner, calls } = recordingSpawner({ planner: { plan: "updated" } });
+
+      await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(calls[0].state.existing, "data");
+    });
+
+    it("state is updated after each step", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      const { spawner, calls } = recordingSpawner({
+        planner: { plan: "the plan" },
+        engineer: { code: "the code" },
+      });
+
+      await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      // Engineer should see the plan that planner wrote
+      assert.equal(calls[1].state.plan, "the plan");
+    });
+
+    it("strips state. prefix from field names", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({ planner: { plan: "stripped" } }),
+      );
+
+      assert.equal(result.state.plan, "stripped");
+      assert.equal(result.state["state.plan"], undefined);
+    });
+  });
+
+  describe("dry-run mode", () => {
+    it("does not call spawner", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      const { spawner, calls } = recordingSpawner({});
+
+      await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: true },
+        spawner,
+      );
+
+      assert.equal(calls.length, 0);
+    });
+
+    it("does not create state.json", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: true },
+        mockSpawner({}),
+      );
+
+      assert.ok(!existsSync(join(tmpDir, "state.json")));
+    });
+
+    it("returns all steps with status skipped", async () => {
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: true },
+        mockSpawner({}),
+      );
+
+      assert.equal(result.steps.length, 2);
+      assert.ok(result.steps.every(s => s.status === "skipped"));
+    });
+  });
+
+  describe("unsupported features", () => {
+    it("map node produces clear error", async () => {
+      const config = makeConfig({
+        nodes: [
+          { over: "state.items", as: "item", flow: [] },
+        ],
+      });
+
+      await assert.rejects(
+        () => run(
+          { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+          mockSpawner({}),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("map nodes not supported"));
+          return true;
+        },
+      );
+    });
+
+    it("conditional then produces clear error", async () => {
+      const config = makeConfig({
+        nodes: [
+          {
+            skill: "planner",
+            reads: [],
+            writes: ["state.plan"],
+            then: [
+              { when: 'state.plan == "good"', to: "engineer" },
+              { when: 'state.plan != "good"', to: "planner" },
+            ],
+          },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      await assert.rejects(
+        () => run(
+          { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+          mockSpawner({}),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("conditional routing not supported"));
+          return true;
+        },
+      );
+    });
+
+    it("non-linear jump produces clear error", async () => {
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "reviewer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+          { skill: "reviewer", reads: ["state.code"], writes: ["state.review"] },
+        ],
+      });
+
+      await assert.rejects(
+        () => run(
+          { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+          mockSpawner({}),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("non-linear jump"));
+          return true;
+        },
+      );
+    });
+
+    it("sub-flow node produces clear error", async () => {
+      const config = makeConfig({
+        nodes: [
+          { name: "sub", flow: "./other.yaml", reads: [], writes: [] },
+        ],
+      });
+
+      await assert.rejects(
+        () => run(
+          { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+          mockSpawner({}),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("sub-flow nodes not supported"));
+          return true;
+        },
+      );
+    });
+  });
+
+  describe("async node handling", () => {
+    it("async nodes are skipped with skipped status", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "human-review" },
+          { name: "human-review", async: true as const, reads: ["state.plan"], writes: ["state.feedback"], policy: "skip" as const, then: "engineer" },
+          { skill: "engineer", reads: ["state.feedback"], writes: ["state.code"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({
+          planner: { plan: "planned" },
+          engineer: { code: "coded" },
+        }),
+      );
+
+      assert.equal(result.steps.length, 3);
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[1].status, "skipped");
+      assert.equal(result.steps[1].agent, "human-review");
+      assert.equal(result.steps[2].status, "ok");
+    });
+
+    it("execution continues past async nodes", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { name: "external", async: true as const, reads: [], writes: ["state.data"], policy: "skip" as const, then: "planner" },
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      const { spawner, calls } = recordingSpawner({ planner: { plan: "done" } });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].agent, "planner");
+      assert.equal(result.steps[0].status, "skipped");
+      assert.equal(result.steps[1].status, "ok");
+    });
+  });
+
+  describe("error handling", () => {
+    it("spawner error is captured in step result", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        errorSpawner("planner"),
+      );
+
+      assert.equal(result.steps[0].status, "error");
+      assert.ok(result.steps[0].error?.includes("Agent planner failed"));
+    });
+
+    it("execution halts on spawner error", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        errorSpawner("planner"),
+      );
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "error");
+    });
+
+    it("no team.flow throws RunError", async () => {
+      const config: Config = {
+        name: "test",
+        skills: {},
+      };
+
+      await assert.rejects(
+        () => run(
+          { config, bodies: new Map(), target: "claude-code", outDir: "build", dryRun: false },
+          mockSpawner({}),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("no team.flow"));
+          return true;
+        },
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("empty flow completes with no steps", async () => {
+      const config = makeConfig({ nodes: [] });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({}),
+      );
+
+      assert.equal(result.steps.length, 0);
+    });
+
+    it("flow with only async nodes completes with all skipped", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { name: "human-a", async: true as const, reads: [], writes: [], policy: "skip" as const, then: "human-b" },
+          { name: "human-b", async: true as const, reads: [], writes: [], policy: "skip" as const },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({}),
+      );
+
+      assert.equal(result.steps.length, 2);
+      assert.ok(result.steps.every(s => s.status === "skipped"));
+    });
+
+    it("single-node flow works correctly", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({ planner: { plan: "only step" } }),
+      );
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.state.plan, "only step");
+    });
+
+    it("then: end is accepted as valid linear flow", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "end" },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({ planner: { plan: "done" } }),
+      );
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "ok");
+    });
+  });
+});

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,256 @@
+import { execFile, execSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { type Config } from "./config.js";
+import { type CompileTarget, expandComposedBodies } from "./compiler.js";
+import { RunError } from "./errors.js";
+import {
+  type GraphNode,
+  isAsyncNode,
+  isConditionalThen,
+  isMapNode,
+  isSubFlowNode,
+} from "./graph.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface RunOptions {
+  config: Config;
+  bodies: Map<string, string>;
+  target: CompileTarget;
+  outDir: string;
+  dryRun: boolean;
+}
+
+export interface StepResult {
+  step: number;
+  agent: string;
+  status: "ok" | "error" | "skipped";
+  error?: string;
+}
+
+export interface RunResult {
+  steps: StepResult[];
+  state: Record<string, unknown>;
+}
+
+export interface Spawner {
+  spawn(
+    agentName: string,
+    skillContent: string,
+    state: Record<string, unknown>,
+  ): Promise<Record<string, unknown>>;
+}
+
+export class ClaudeSpawner implements Spawner {
+  constructor() {
+    try {
+      execSync("claude --version", { stdio: "pipe" });
+    } catch {
+      throw new RunError(
+        "claude CLI not found. Install it from https://docs.anthropic.com/en/docs/claude-cli",
+      );
+    }
+  }
+
+  async spawn(
+    _agentName: string,
+    skillContent: string,
+    state: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const prompt = [
+      skillContent,
+      "",
+      "Current state:",
+      "```json",
+      JSON.stringify(state, null, 2),
+      "```",
+      "",
+      "After completing your task, output your state updates as a JSON block in a fenced code block tagged `json` with the key `stateUpdates`. Only include fields you want to update.",
+    ].join("\n");
+
+    const { stdout } = await execFileAsync("claude", ["--print", "-p", prompt], {
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+    return parseStateUpdates(stdout);
+  }
+}
+
+/**
+ * Parse agent output looking for a JSON code block containing stateUpdates.
+ */
+function parseStateUpdates(output: string): Record<string, unknown> {
+  const jsonBlockRe = /```json\s*\n([\s\S]*?)```/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = jsonBlockRe.exec(output)) !== null) {
+    try {
+      const parsed: unknown = JSON.parse(match[1]);
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        !Array.isArray(parsed) &&
+        "stateUpdates" in parsed
+      ) {
+        const updates = (parsed as Record<string, unknown>).stateUpdates;
+        if (typeof updates === "object" && updates !== null && !Array.isArray(updates)) {
+          return updates as Record<string, unknown>;
+        }
+      }
+    } catch {
+      // Not valid JSON, try next block
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Strip the "state." prefix from field paths used in reads/writes.
+ */
+function stripStatePrefix(path: string): string {
+  return path.startsWith("state.") ? path.slice("state.".length) : path;
+}
+
+/**
+ * Get the node label (agent name) for a graph node.
+ */
+function nodeLabel(node: GraphNode): string {
+  if (isMapNode(node)) return "map";
+  if (isSubFlowNode(node)) return node.name;
+  if (isAsyncNode(node)) return node.name;
+  return node.skill;
+}
+
+export async function run(
+  options: RunOptions,
+  spawner?: Spawner,
+): Promise<RunResult> {
+  const { config, bodies, dryRun } = options;
+
+  if (!config.team) {
+    throw new RunError("Config has no team.flow defined - nothing to run");
+  }
+
+  const nodes = config.team.flow.nodes;
+  const composedBodies = expandComposedBodies(config, bodies);
+
+  // Load initial state from state.json if it exists
+  const statePath = join(process.cwd(), "state.json");
+  let state: Record<string, unknown> = {};
+  if (!dryRun && existsSync(statePath)) {
+    try {
+      const raw = readFileSync(statePath, "utf-8");
+      const parsed: unknown = JSON.parse(raw);
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        state = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Ignore malformed state.json, start fresh
+    }
+  }
+
+  const activeSpawner = dryRun ? undefined : (spawner ?? new ClaudeSpawner());
+  const steps: StepResult[] = [];
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const stepNumber = i + 1;
+    const label = nodeLabel(node);
+
+    // Validate that the flow is linear before processing the node
+    if (node.then !== undefined) {
+      if (isConditionalThen(node.then)) {
+        throw new RunError(
+          `Step ${stepNumber} "${label}": conditional routing not supported in skillfold run MVP - use the orchestrator`,
+        );
+      }
+
+      // Non-conditional then pointing to a non-next-sequential node
+      const thenTarget = node.then;
+      if (thenTarget !== "end") {
+        const nextLabel = i + 1 < nodes.length ? nodeLabel(nodes[i + 1]) : undefined;
+        if (thenTarget !== nextLabel) {
+          throw new RunError(
+            `Step ${stepNumber} "${label}": non-linear jump to "${thenTarget}" not supported in skillfold run MVP - use the orchestrator`,
+          );
+        }
+      }
+    }
+
+    if (isMapNode(node)) {
+      throw new RunError(
+        `Step ${stepNumber} "map": map nodes not supported in skillfold run MVP - use the orchestrator`,
+      );
+    }
+
+    if (isSubFlowNode(node)) {
+      throw new RunError(
+        `Step ${stepNumber} "${label}": sub-flow nodes not supported in skillfold run MVP - use the orchestrator`,
+      );
+    }
+
+    if (isAsyncNode(node)) {
+      if (dryRun) {
+        process.stderr.write(
+          `Step ${stepNumber}: [skip] ${label} (async)\n`,
+        );
+      }
+      steps.push({ step: stepNumber, agent: label, status: "skipped" });
+      continue;
+    }
+
+    // StepNode
+    const skillBody = composedBodies.get(node.skill);
+    if (!skillBody) {
+      throw new RunError(
+        `Step ${stepNumber} "${node.skill}": no composed skill body found`,
+      );
+    }
+
+    if (dryRun) {
+      const reads = node.reads.map(stripStatePrefix);
+      const writes = node.writes.map(stripStatePrefix);
+      process.stderr.write(
+        `Step ${stepNumber}: ${node.skill}` +
+          (reads.length > 0 ? ` reads=[${reads.join(", ")}]` : "") +
+          (writes.length > 0 ? ` writes=[${writes.join(", ")}]` : "") +
+          "\n",
+      );
+      steps.push({ step: stepNumber, agent: node.skill, status: "skipped" });
+      continue;
+    }
+
+    try {
+      const updates = await activeSpawner!.spawn(node.skill, skillBody, state);
+
+      // Apply state updates (only for fields declared in writes)
+      for (const writePath of node.writes) {
+        const field = stripStatePrefix(writePath);
+        if (field in updates) {
+          state[field] = updates[field];
+        }
+      }
+
+      // Write updated state to disk after each step
+      writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n", "utf-8");
+
+      steps.push({ step: stepNumber, agent: node.skill, status: "ok" });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      steps.push({
+        step: stepNumber,
+        agent: node.skill,
+        status: "error",
+        error: message,
+      });
+      // Stop on first error
+      break;
+    }
+  }
+
+  return { steps, state };
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,4 @@
-import { execFile, execSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -47,7 +47,7 @@ export interface Spawner {
 export class ClaudeSpawner implements Spawner {
   constructor() {
     try {
-      execSync("claude --version", { stdio: "pipe" });
+      execFileSync("claude", ["--version"], { stdio: "pipe" });
     } catch {
       throw new RunError(
         "claude CLI not found. Install it from https://docs.anthropic.com/en/docs/claude-cli",
@@ -200,6 +200,7 @@ export async function run(
         );
       }
       steps.push({ step: stepNumber, agent: label, status: "skipped" });
+      if (node.then === "end") break;
       continue;
     }
 
@@ -221,6 +222,7 @@ export async function run(
           "\n",
       );
       steps.push({ step: stepNumber, agent: node.skill, status: "skipped" });
+      if (node.then === "end") break;
       continue;
     }
 
@@ -239,6 +241,7 @@ export async function run(
       writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n", "utf-8");
 
       steps.push({ step: stepNumber, agent: node.skill, status: "ok" });
+      if (node.then === "end") break;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       steps.push({


### PR DESCRIPTION
## Summary

- Adds `skillfold run` command that executes compiled pipelines by spawning agents sequentially
- Core runner module (`src/run.ts`) with `Spawner` interface, `ClaudeSpawner`, and state management via `state.json`
- Supports linear flows with dry-run mode and async node skipping
- 24 tests covering execution, state, errors, and edge cases
- CLI wiring with `--dry-run` flag and progress output
- Docs updated: CLI reference and getting-started guide

## Current limitations (MVP scope)

- Linear flows only (no conditionals, map, or sub-flows)
- Requires `claude` CLI for agent spawning
- State updates via JSON code blocks in agent output

Closes #394, closes #395, closes #396, closes #397

## Test plan

- [x] 691 tests pass (24 new), 0 failures
- [x] Type check passes
- [x] Dry-run mode prints plan without side effects
- [x] State.json created/read/updated correctly
- [x] Async nodes skipped, map/conditional/sub-flow produce clear errors
- [x] `then: "end"` stops execution mid-flow