### PR TITLE
fix: suggest skillfold init when config file not found

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { enhanceConfigError, INIT_HINT } from "./cli.js";
+import { ConfigError } from "./errors.js";
+
+describe("enhanceConfigError", () => {
+  it("appends init hint when using default config path and file not found", () => {
+    const err = new ConfigError("Cannot read config file: /path/to/skillfold.yaml");
+    const enhanced = enhanceConfigError(err, false);
+    assert.match(enhanced.message, /Cannot read config file/);
+    assert.match(enhanced.message, /skillfold init/);
+    assert.match(enhanced.message, /--config/);
+    assert.ok(enhanced.message.includes(INIT_HINT));
+  });
+
+  it("does not add hint when --config was explicitly provided", () => {
+    const err = new ConfigError("Cannot read config file: /path/to/custom.yaml");
+    const enhanced = enhanceConfigError(err, true);
+    assert.equal(enhanced.message, err.message);
+    assert.ok(!enhanced.message.includes(INIT_HINT));
+  });
+
+  it("does not add hint for other ConfigError messages", () => {
+    const err = new ConfigError("Config must have a 'name' field (string)");
+    const enhanced = enhanceConfigError(err, false);
+    assert.equal(enhanced.message, err.message);
+    assert.ok(!enhanced.message.includes(INIT_HINT));
+  });
+
+  it("returns the original error instance when no enhancement is needed", () => {
+    const err = new ConfigError("Some other error");
+    const enhanced = enhanceConfigError(err, false);
+    assert.equal(enhanced, err);
+  });
+
+  it("returns a new error instance when enhancement is applied", () => {
+    const err = new ConfigError("Cannot read config file: /foo/bar.yaml");
+    const enhanced = enhanceConfigError(err, false);
+    assert.notEqual(enhanced, err);
+    assert.ok(enhanced instanceof ConfigError);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,7 @@ type Command = "init" | "adopt" | "compile" | "graph" | "list" | "run" | "valida
 interface Args {
   command: Command;
   configPath: string;
+  configPathExplicit: boolean;
   outDir: string;
   outDirExplicit: boolean;
   dir: string;
@@ -69,6 +70,7 @@ interface Args {
 function parseArgs(argv: string[]): Args {
   let command: Command = "compile";
   let configPath = "skillfold.yaml";
+  let configPathExplicit = false;
   let outDir = "build";
   let outDirExplicit = false;
   let dir = ".";
@@ -130,6 +132,7 @@ function parseArgs(argv: string[]): Args {
   for (; i < argv.length; i++) {
     if (argv[i] === "--config" && argv[i + 1]) {
       configPath = argv[++i];
+      configPathExplicit = true;
     } else if (argv[i] === "--out-dir" && argv[i + 1]) {
       outDir = argv[++i];
       outDirExplicit = true;
@@ -177,6 +180,7 @@ function parseArgs(argv: string[]): Args {
   return {
     command,
     configPath: resolve(configPath),
+    configPathExplicit,
     outDir: resolve(outDir),
     outDirExplicit,
     dir: resolve(dir),
@@ -189,6 +193,16 @@ function parseArgs(argv: string[]): Args {
     help,
     version,
   };
+}
+
+export const INIT_HINT = 'Run "skillfold init" to create one, or use --config <path> to specify a different file.';
+
+/** Enhance "Cannot read config file" errors with an init suggestion when using the default path. */
+export function enhanceConfigError(err: ConfigError, configPathExplicit: boolean): ConfigError {
+  if (!configPathExplicit && err.message.startsWith("Cannot read config file:")) {
+    return new ConfigError(`${err.message}\n${INIT_HINT}`);
+  }
+  return err;
 }
 
 async function main(): Promise<void> {
@@ -278,7 +292,8 @@ async function main(): Promise<void> {
       }
     } catch (err) {
       if (err instanceof ConfigError || err instanceof GraphError) {
-        console.error(`skillfold error: ${err.message}`);
+        const enhanced = err instanceof ConfigError ? enhanceConfigError(err, args.configPathExplicit) : err;
+        console.error(`skillfold error: ${enhanced.message}`);
         process.exit(1);
       }
       throw err;
@@ -292,7 +307,8 @@ async function main(): Promise<void> {
       process.stdout.write(listPipeline(config));
     } catch (err) {
       if (err instanceof ConfigError || err instanceof GraphError) {
-        console.error(`skillfold error: ${err.message}`);
+        const enhanced = err instanceof ConfigError ? enhanceConfigError(err, args.configPathExplicit) : err;
+        console.error(`skillfold error: ${enhanced.message}`);
         process.exit(1);
       }
       throw err;
@@ -324,7 +340,8 @@ async function main(): Promise<void> {
         err instanceof ResolveError ||
         err instanceof GraphError
       ) {
-        console.error(`skillfold error: ${err.message}`);
+        const enhanced = err instanceof ConfigError ? enhanceConfigError(err, args.configPathExplicit) : err;
+        console.error(`skillfold error: ${enhanced.message}`);
         process.exit(1);
       }
       throw err;
@@ -348,7 +365,8 @@ async function main(): Promise<void> {
         err instanceof ResolveError ||
         err instanceof CompileError
       ) {
-        console.error(`skillfold error: ${err.message}`);
+        const enhanced = err instanceof ConfigError ? enhanceConfigError(err, args.configPathExplicit) : err;
+        console.error(`skillfold error: ${enhanced.message}`);
         process.exit(1);
       }
       throw err;
@@ -410,7 +428,8 @@ async function main(): Promise<void> {
         err instanceof ResolveError ||
         err instanceof RunError
       ) {
-        console.error(`skillfold error: ${err.message}`);
+        const enhanced = err instanceof ConfigError ? enhanceConfigError(err, args.configPathExplicit) : err;
+        console.error(`skillfold error: ${enhanced.message}`);
         process.exit(1);
       }
       throw err;
@@ -463,7 +482,8 @@ async function main(): Promise<void> {
       err instanceof ResolveError ||
       err instanceof CompileError
     ) {
-      console.error(`skillfold error: ${err.message}`);
+      const enhanced = err instanceof ConfigError ? enhanceConfigError(err, args.configPathExplicit) : err;
+      console.error(`skillfold error: ${enhanced.message}`);
       process.exit(1);
     }
     throw err;


### PR DESCRIPTION
**[engineer]**

## Summary

- When `npx skillfold` is run with no config file at the default path, the error message now suggests running `skillfold init` or using `--config`
- No hint is shown when an explicit `--config` path is provided (user chose the path intentionally)
- 5 new tests covering both cases

Closes #402

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (696 tests, 0 failures)
- [x] Default path shows init suggestion
- [x] Explicit `--config` path does not show suggestion