### PR TITLE
fix: use npm: prefix in init scaffold imports

### DIFF
--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -133,7 +133,7 @@ describe("initFromTemplate", () => {
     const config = readFileSync(join(tmpDir, "skillfold.yaml"), "utf-8");
     assert.ok(config.includes("name: dev-team"));
     assert.ok(
-      config.includes("node_modules/skillfold/library/skillfold.yaml"),
+      config.includes("npm:skillfold/library/skillfold.yaml"),
       "import path should be rewritten to npm path"
     );
     assert.ok(
@@ -154,7 +154,7 @@ describe("initFromTemplate", () => {
 
       const config = readFileSync(join(tmpDir, "skillfold.yaml"), "utf-8");
       assert.ok(config.includes(`name: ${template}`));
-      assert.ok(config.includes("node_modules/skillfold/library/skillfold.yaml"));
+      assert.ok(config.includes("npm:skillfold/library/skillfold.yaml"));
 
       rmSync(tmpDir, { recursive: true, force: true });
       tmpDir = undefined;
@@ -250,7 +250,7 @@ describe("init CLI", () => {
 
     const config = readFileSync(join(subDir, "skillfold.yaml"), "utf-8");
     assert.ok(config.includes("name: dev-team"));
-    assert.ok(config.includes("node_modules/skillfold/library/skillfold.yaml"));
+    assert.ok(config.includes("npm:skillfold/library/skillfold.yaml"));
   });
 
   it("errors on unknown template via CLI", () => {

--- a/src/init.ts
+++ b/src/init.ts
@@ -7,7 +7,7 @@ name: my-pipeline
 
 # To import shared skills from the skillfold library, uncomment:
 # imports:
-#   - node_modules/skillfold/library/skillfold.yaml
+#   - npm:skillfold/library/skillfold.yaml
 
 skills:
   atomic:
@@ -134,7 +134,7 @@ const SCHEMA_COMMENT =
   "# yaml-language-server: $schema=node_modules/skillfold/skillfold.schema.json\n";
 
 const IMPORT_REWRITE_FROM = /- \.\.\/\.\.\/skillfold\.yaml/;
-const IMPORT_REWRITE_TO = "- node_modules/skillfold/library/skillfold.yaml";
+const IMPORT_REWRITE_TO = "- npm:skillfold/library/skillfold.yaml";
 
 export function initFromTemplate(dir: string, template: string): string[] {
   if (!TEMPLATES.includes(template as Template)) {


### PR DESCRIPTION
**[engineer]**

## Summary

- Updated `skillfold init` to generate `npm:skillfold/library/skillfold.yaml` instead of `node_modules/skillfold/library/skillfold.yaml`
- Updated template rewrite logic to use the same prefix
- Updated 3 test assertions

Closes #403

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (691 tests, 0 failures)
- [x] Generated config uses `npm:` prefix