### PR TITLE
feat: add mcpServers and skills fields to agentConfig

### DIFF
--- a/skillfold.schema.json
+++ b/skillfold.schema.json
@@ -150,6 +150,20 @@
               "background": {
                 "type": "boolean",
                 "description": "Whether this agent runs in the background."
+              },
+              "mcpServers": {
+                "type": "object",
+                "description": "MCP servers scoped to this agent. Each key is a server name mapping to its configuration (command, args, env, etc.).",
+                "additionalProperties": {
+                  "type": "object",
+                  "description": "MCP server configuration.",
+                  "additionalProperties": true
+                }
+              },
+              "skills": {
+                "type": "array",
+                "description": "Skills to preload into this agent's context.",
+                "items": { "type": "string" }
               }
             }
           }

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -611,6 +611,95 @@ describe("generateAgents with agentConfig overrides", () => {
     // Legacy custom field should still be present
     assert.ok(planner.content.includes("customField: value"));
   });
+
+  it("agentConfig mcpServers emits correctly in claude-code target", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+          agentConfig: {
+            mcpServers: {
+              github: {
+                command: "npx",
+                args: ["-y", "@anthropic/github-mcp-server"],
+                env: { GITHUB_TOKEN: "${GITHUB_TOKEN}" },
+              },
+            },
+          },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("engineer", "Write code.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "claude-code");
+    const engineer = results.find((r) => r.name === "engineer");
+    assert.ok(engineer);
+
+    assert.ok(engineer.content.includes("mcpServers:"));
+    assert.ok(engineer.content.includes("github:"));
+    assert.ok(engineer.content.includes("command: npx"));
+  });
+
+  it("agentConfig skills emits correctly in claude-code target", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+          agentConfig: {
+            skills: ["/path/to/skill-a", "/path/to/skill-b"],
+          },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("engineer", "Write code.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "claude-code");
+    const engineer = results.find((r) => r.name === "engineer");
+    assert.ok(engineer);
+
+    assert.ok(engineer.content.includes("skills:"));
+    assert.ok(engineer.content.includes("- /path/to/skill-a"));
+    assert.ok(engineer.content.includes("- /path/to/skill-b"));
+  });
+
+  it("agentConfig mcpServers and skills are ignored in skill target", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+          agentConfig: {
+            mcpServers: {
+              github: { command: "npx", args: ["-y", "@anthropic/github-mcp-server"] },
+            },
+            skills: ["/path/to/skill-a"],
+          },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("engineer", "Write code.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "skill");
+    const engineer = results.find((r) => r.name === "engineer");
+    assert.ok(engineer);
+
+    assert.ok(!engineer.content.includes("mcpServers:"));
+    assert.ok(!engineer.content.includes("skills:"));
+  });
 });
 
 describe("generateRunCommand with orchestrator", () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1575,6 +1575,121 @@ skills:
       tmpDir = undefined;
     }
   });
+
+  it("parses mcpServers field", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      mcpServers:
+        github:
+          command: npx
+          args:
+            - "-y"
+            - "@anthropic/github-mcp-server"
+          env:
+            GITHUB_TOKEN: "\${GITHUB_TOKEN}"
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["quality"];
+    assert.ok(isComposed(skill));
+    assert.ok(skill.agentConfig?.mcpServers);
+    assert.equal(skill.agentConfig.mcpServers.github.command, "npx");
+    assert.deepEqual(skill.agentConfig.mcpServers.github.args, ["-y", "@anthropic/github-mcp-server"]);
+  });
+
+  it("rejects non-object mcpServers", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      mcpServers: "not a map"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /mcpServers must be a YAML map/);
+      return true;
+    });
+  });
+
+  it("rejects non-object mcpServers entry", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      mcpServers:
+        github: "not a map"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /mcpServers\.github must be a YAML map/);
+      return true;
+    });
+  });
+
+  it("parses skills field", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      skills:
+        - /path/to/skill-a
+        - /path/to/skill-b
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["quality"];
+    assert.ok(isComposed(skill));
+    assert.deepEqual(skill.agentConfig?.skills, ["/path/to/skill-a", "/path/to/skill-b"]);
+  });
+
+  it("rejects non-array skills", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      skills: "not an array"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /skills must be an array of strings/);
+      return true;
+    });
+  });
 });
 
 describe("type guards", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,8 @@ export interface AgentFrontmatter {
   effort?: "low" | "medium" | "high";
   maxTurns?: number;
   background?: boolean;
+  mcpServers?: Record<string, Record<string, unknown>>;
+  skills?: string[];
 }
 
 export const VALID_PERMISSION_MODES = ["default", "acceptEdits", "bypassPermissions", "plan"] as const;
@@ -48,6 +50,8 @@ export const AGENT_FRONTMATTER_KEYS = new Set<string>([
   "effort",
   "maxTurns",
   "background",
+  "mcpServers",
+  "skills",
 ]);
 
 export interface ComposedSkill {
@@ -272,6 +276,26 @@ function parseAgentFrontmatter(
       throw new ConfigError(`Skill "${name}": background must be a boolean`);
     }
     config.background = raw.background;
+    hasFields = true;
+  }
+
+  if ("mcpServers" in raw) {
+    if (typeof raw.mcpServers !== "object" || raw.mcpServers === null || Array.isArray(raw.mcpServers)) {
+      throw new ConfigError(`Skill "${name}": mcpServers must be a YAML map`);
+    }
+    for (const [serverName, serverConfig] of Object.entries(raw.mcpServers as Record<string, unknown>)) {
+      if (typeof serverConfig !== "object" || serverConfig === null || Array.isArray(serverConfig)) {
+        throw new ConfigError(
+          `Skill "${name}": mcpServers.${serverName} must be a YAML map`
+        );
+      }
+    }
+    config.mcpServers = raw.mcpServers as Record<string, Record<string, unknown>>;
+    hasFields = true;
+  }
+
+  if ("skills" in raw) {
+    config.skills = validateStringArray(name, "skills", raw.skills);
     hasFields = true;
   }
 


### PR DESCRIPTION
## Summary

- Add `mcpServers` (object map) and `skills` (string array) fields to the `AgentFrontmatter` interface for full Claude Code agent frontmatter parity
- `mcpServers` scopes MCP servers to specific agents, allowing fine-grained control over which external tools each agent can access
- `skills` preloads specific skills into a subagent's context without manual loading
- Both fields are validated during config parsing, serialized in claude-code target output, and ignored in skill target output

## Changes

- `src/config.ts`: Added fields to `AgentFrontmatter` interface, `AGENT_FRONTMATTER_KEYS`, and `parseAgentFrontmatter` validation
- `src/agent.test.ts`: 3 new tests for mcpServers serialization, skills serialization, and skill-target exclusion
- `src/config.test.ts`: 5 new tests for parsing and validation (valid mcpServers, invalid mcpServers, invalid mcpServers entry, valid skills, invalid skills)
- `skillfold.schema.json`: Added both fields to composed skill schema

## Test plan

- [x] All 704 tests pass (8 new tests added)
- [x] TypeScript type check passes
- [x] mcpServers field accepted in agentConfig, serialized in claude-code target output
- [x] skills field accepted in agentConfig, serialized in claude-code target output
- [x] Both fields ignored in skill target output
- [x] Invalid mcpServers (non-object, non-object entry) rejected with clear error messages
- [x] Invalid skills (non-array) rejected with clear error message
- [x] JSON Schema updated with both fields

Closes #412