### PR TITLE
feat: add mcpServers and skills fields to agentConfig

### DIFF
--- a/skillfold.schema.json
+++ b/skillfold.schema.json
@@ -150,6 +150,20 @@
               "background": {
                 "type": "boolean",
                 "description": "Whether this agent runs in the background."
+              },
+              "mcpServers": {
+                "type": "object",
+                "description": "MCP server configurations for this agent. Keys are server names, values are server config objects.",
+                "additionalProperties": {
+                  "type": "object",
+                  "description": "MCP server configuration with command, args, env, and other settings.",
+                  "additionalProperties": true
+                }
+              },
+              "skills": {
+                "type": "array",
+                "description": "Skill paths to preload for this agent.",
+                "items": { "type": "string" }
               }
             }
           }

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -741,3 +741,132 @@ describe("generateAgents: async nodes", () => {
     assert.ok(!orchestratorAgent.content.includes("Agent(engineer, owner"));
   });
 });
+
+describe("generateAgents: mcpServers and skills fields", () => {
+  it("emits mcpServers in claude-code target frontmatter", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+          agentConfig: {
+            mcpServers: {
+              filesystem: {
+                command: "npx",
+                args: ["-y", "@modelcontextprotocol/server-filesystem"],
+                env: { HOME: "/home/user" },
+              },
+            },
+          },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("engineer", "Write code.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "claude-code");
+    const engineer = results.find((r) => r.name === "engineer");
+    assert.ok(engineer);
+
+    assert.ok(engineer.content.includes("mcpServers:"));
+    assert.ok(engineer.content.includes("filesystem:"));
+    assert.ok(engineer.content.includes("command: npx"));
+    assert.ok(engineer.content.includes("- -y"));
+    assert.ok(engineer.content.includes("@modelcontextprotocol/server-filesystem"));
+  });
+
+  it("emits skills array in claude-code target frontmatter", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+          agentConfig: {
+            skills: [".claude/skills/review/SKILL.md", ".claude/skills/testing/SKILL.md"],
+          },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("engineer", "Write code.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "claude-code");
+    const engineer = results.find((r) => r.name === "engineer");
+    assert.ok(engineer);
+
+    assert.ok(engineer.content.includes("skills:"));
+    assert.ok(engineer.content.includes("- .claude/skills/review/SKILL.md"));
+    assert.ok(engineer.content.includes("- .claude/skills/testing/SKILL.md"));
+  });
+
+  it("mcpServers and skills are not emitted in skill target", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+          agentConfig: {
+            mcpServers: {
+              filesystem: { command: "npx", args: ["-y", "server"] },
+            },
+            skills: [".claude/skills/review/SKILL.md"],
+          },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("engineer", "Write code.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "skill");
+    const engineer = results.find((r) => r.name === "engineer");
+    assert.ok(engineer);
+
+    assert.ok(!engineer.content.includes("mcpServers:"));
+    assert.ok(!engineer.content.includes("skills:"));
+  });
+
+  it("emits both mcpServers and skills alongside other agentConfig fields", () => {
+    const config = makeConfig({
+      skills: {
+        planning: { path: "./skills/planning" },
+        coding: { path: "./skills/coding" },
+        engineer: {
+          compose: ["planning", "coding"],
+          description: "Writes code.",
+          agentConfig: {
+            tools: ["Read", "Edit"],
+            permissionMode: "acceptEdits",
+            mcpServers: {
+              "my-server": { command: "node", args: ["server.js"] },
+            },
+            skills: [".claude/skills/lint/SKILL.md"],
+          },
+        },
+      },
+      team: undefined,
+    });
+    const bodies = new Map<string, string>();
+    bodies.set("engineer", "Write code.");
+
+    const results = generateAgents(config, bodies, "/out", "1.0.0", "test.yaml", "claude-code");
+    const engineer = results.find((r) => r.name === "engineer");
+    assert.ok(engineer);
+
+    // All fields present
+    assert.ok(engineer.content.includes("tools:"));
+    assert.ok(engineer.content.includes("permissionMode: acceptEdits"));
+    assert.ok(engineer.content.includes("mcpServers:"));
+    assert.ok(engineer.content.includes("my-server:"));
+    assert.ok(engineer.content.includes("skills:"));
+    assert.ok(engineer.content.includes("- .claude/skills/lint/SKILL.md"));
+  });
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1575,6 +1575,127 @@ skills:
       tmpDir = undefined;
     }
   });
+
+  it("parses mcpServers field", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      mcpServers:
+        filesystem:
+          command: npx
+          args:
+            - "-y"
+            - "@modelcontextprotocol/server-filesystem"
+          env:
+            HOME: /home/user
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["quality"];
+    assert.ok(isComposed(skill));
+    assert.ok(skill.agentConfig?.mcpServers);
+    assert.deepEqual(skill.agentConfig.mcpServers.filesystem, {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem"],
+      env: { HOME: "/home/user" },
+    });
+  });
+
+  it("parses skills field", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      skills:
+        - ".claude/skills/review/SKILL.md"
+        - ".claude/skills/testing/SKILL.md"
+`);
+    const config = readConfig(configPath);
+    const skill = config.skills["quality"];
+    assert.ok(isComposed(skill));
+    assert.deepEqual(skill.agentConfig?.skills, [
+      ".claude/skills/review/SKILL.md",
+      ".claude/skills/testing/SKILL.md",
+    ]);
+  });
+
+  it("rejects non-object mcpServers", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      mcpServers: "not a map"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /mcpServers must be a YAML map/);
+      return true;
+    });
+  });
+
+  it("rejects non-object mcpServers server entry", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      mcpServers:
+        my-server: "not a map"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /mcpServers\.my-server must be a YAML map/);
+      return true;
+    });
+  });
+
+  it("rejects non-array skills", () => {
+    tmpDir = makeTmpDir();
+    const configPath = writeYaml(tmpDir, `
+name: test
+skills:
+  atomic:
+    lint: ./skills/lint
+  composed:
+    quality:
+      compose:
+        - lint
+      description: "Runs lint checks."
+      skills: "not an array"
+`);
+    assert.throws(() => readConfig(configPath), (err: unknown) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /skills must be an array of strings/);
+      return true;
+    });
+  });
 });
 
 describe("type guards", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,8 @@ export interface AgentFrontmatter {
   effort?: "low" | "medium" | "high";
   maxTurns?: number;
   background?: boolean;
+  mcpServers?: Record<string, Record<string, unknown>>;
+  skills?: string[];
 }
 
 export const VALID_PERMISSION_MODES = ["default", "acceptEdits", "bypassPermissions", "plan"] as const;
@@ -48,6 +50,8 @@ export const AGENT_FRONTMATTER_KEYS = new Set<string>([
   "effort",
   "maxTurns",
   "background",
+  "mcpServers",
+  "skills",
 ]);
 
 export interface ComposedSkill {
@@ -272,6 +276,26 @@ function parseAgentFrontmatter(
       throw new ConfigError(`Skill "${name}": background must be a boolean`);
     }
     config.background = raw.background;
+    hasFields = true;
+  }
+
+  if ("mcpServers" in raw) {
+    if (typeof raw.mcpServers !== "object" || raw.mcpServers === null || Array.isArray(raw.mcpServers)) {
+      throw new ConfigError(`Skill "${name}": mcpServers must be a YAML map`);
+    }
+    for (const [serverName, serverConfig] of Object.entries(raw.mcpServers as Record<string, unknown>)) {
+      if (typeof serverConfig !== "object" || serverConfig === null || Array.isArray(serverConfig)) {
+        throw new ConfigError(
+          `Skill "${name}": mcpServers.${serverName} must be a YAML map`
+        );
+      }
+    }
+    config.mcpServers = raw.mcpServers as Record<string, Record<string, unknown>>;
+    hasFields = true;
+  }
+
+  if ("skills" in raw) {
+    config.skills = validateStringArray(name, "skills", raw.skills);
     hasFields = true;
   }
 


### PR DESCRIPTION
## Summary

- Add `mcpServers` and `skills` fields to the `AgentFrontmatter` interface and `AGENT_FRONTMATTER_KEYS` constant in `src/config.ts`, with validation (mcpServers must be a map of maps, skills must be a string array)
- Both fields pass through to YAML frontmatter in `src/agent.ts` via the existing agentConfig serialization path, only for `claude-code` target
- Add schema definitions for both fields in `skillfold.schema.json`
- Add 9 new tests covering parsing, validation errors, and frontmatter serialization for both fields

Closes #412

## Test plan

- [x] `mcpServers` parsed correctly from YAML config
- [x] `skills` array parsed correctly from YAML config
- [x] Non-object `mcpServers` rejected with clear error
- [x] Non-object server entry in `mcpServers` rejected with clear error
- [x] Non-array `skills` rejected with clear error
- [x] `mcpServers` serialized into claude-code target frontmatter
- [x] `skills` serialized into claude-code target frontmatter
- [x] Both fields omitted in `skill` target output
- [x] Both fields coexist with other agentConfig fields
- [x] All 705 tests pass
- [x] Type check passes (`npx tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)