### PR TITLE
feat: add skills: prefix for Vercel skills CLI interop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,12 +181,13 @@ Located in `library/examples/`:
 - `skillfold search [query]` command for discovering pipeline configs on npm (searches for `skillfold-pipeline` keyword)
 - npm skill discovery: `agentskills` field in package.json uses flat key-value format for ecosystem compatibility
 - `npm:` prefix support for skill references and imports (resolves to node_modules paths)
+- `skills:` prefix support for Vercel skills CLI interop (resolves to .skills/ directory)
 - Publishing guide (`docs/publishing.md`) for sharing skills via npm
 - `skillfold.local.yaml` support for local config overrides (gitignored), with merge semantics for skills/state/team
 - Built-in state integrations for GitHub services (github-issues, github-discussions, github-pull-requests) with auto-generated URLs, filter options, and orchestrator instructions
 - `skillfold run` command for linear pipeline execution with `ClaudeSpawner`, state management via `state.json`, dry-run mode, and async node skipping (MVP: linear flows only)
 - VitePress documentation site (`docs/`) with GitHub Pages deployment, config reference, CLI reference, live demo with interactive pipeline visualizer, interactive pipeline builder (YAML editor with live Mermaid graph), examples gallery, skill authoring guide, comparison table, detailed comparisons page (vs Agent Teams, CrewAI, manual SKILL.md), and existing guides
-- Test suite with 723 tests across 136 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, integrations, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, run, cli, and e2e modules
+- Test suite with 739 tests across 141 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, integrations, visualize, remote, init, adopt, library, validate, list, search, npm, skills-prefix, watch, errors, subflow, api, run, cli, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ const SELF_IMPORT_PREFIX = "node_modules/skillfold/";
 import { ConfigError, didYouMean } from "./errors.js";
 import { type Graph, type GraphNode, type SubFlowNode, isMapNode, isSubFlowNode, parseGraph, validateGraph } from "./graph.js";
 import { isNpmRef, resolveNpmImportPath } from "./npm.js";
+import { isSkillsRef } from "./skills-prefix.js";
 import { fetchRemoteConfig } from "./remote.js";
 import { parseState, StateSchema } from "./state.js";
 
@@ -595,7 +596,7 @@ export function validateAndBuild(raw: RawConfig): Config {
 }
 
 // Rebase imported atomic skill paths from importDir-relative to targetDir-relative.
-// Remote (https://) and npm: paths are left unchanged.
+// Remote (https://), npm:, and skills: paths are left unchanged.
 function rebaseSkillPaths(
   skills: Record<string, SkillEntry>,
   importDir: string,
@@ -603,7 +604,7 @@ function rebaseSkillPaths(
 ): Record<string, SkillEntry> {
   const result: Record<string, SkillEntry> = {};
   for (const [name, skill] of Object.entries(skills)) {
-    if (isAtomic(skill) && !skill.path.startsWith("https://") && !isNpmRef(skill.path)) {
+    if (isAtomic(skill) && !skill.path.startsWith("https://") && !isNpmRef(skill.path) && !isSkillsRef(skill.path)) {
       const abs = resolve(importDir, skill.path);
       const rebased = relative(targetDir, abs);
       result[name] = { path: rebased };

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -5,6 +5,7 @@ import { type Config, isAtomic } from "./config.js";
 import { ResolveError } from "./errors.js";
 import { isNpmRef, resolveNpmSkillPath } from "./npm.js";
 import { fetchRemoteSkill } from "./remote.js";
+import { isSkillsRef, resolveSkillsPath } from "./skills-prefix.js";
 
 export function stripFrontmatter(content: string): string {
   const trimmed = content.trim();
@@ -37,11 +38,16 @@ export async function resolveSkills(
 
     const skillDir = isNpmRef(skill.path)
       ? resolveNpmSkillPath(skill.path, baseDir)
-      : resolve(baseDir, skill.path);
+      : isSkillsRef(skill.path)
+        ? resolveSkillsPath(skill.path, baseDir)
+        : resolve(baseDir, skill.path);
     const skillFile = join(skillDir, "SKILL.md");
 
     if (!existsSync(skillDir)) {
-      throw new ResolveError(name, `Directory not found: ${skillDir}`);
+      const hint = isSkillsRef(skill.path)
+        ? ` (try: npx skills add ${skill.path.slice("skills:".length)})`
+        : "";
+      throw new ResolveError(name, `Directory not found: ${skillDir}${hint}`);
     }
 
     if (!existsSync(skillFile)) {

--- a/src/skills-prefix.test.ts
+++ b/src/skills-prefix.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { loadConfig } from "./config.js";
+import { ResolveError } from "./errors.js";
+import { resolveSkills } from "./resolver.js";
+import { isSkillsRef, parseSkillsRef, resolveSkillsPath } from "./skills-prefix.js";
+
+import type { Config } from "./config.js";
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `skillfold-skills-prefix-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("isSkillsRef", () => {
+  it("returns true for skills: prefixed string", () => {
+    assert.equal(isSkillsRef("skills:some-skill"), true);
+  });
+
+  it("returns true for skills: prefixed string with slashes", () => {
+    assert.equal(isSkillsRef("skills:@org/some-skill"), true);
+  });
+
+  it("returns false for local path", () => {
+    assert.equal(isSkillsRef("./skills/review"), false);
+  });
+
+  it("returns false for https URL", () => {
+    assert.equal(isSkillsRef("https://github.com/org/repo"), false);
+  });
+
+  it("returns false for npm: prefix", () => {
+    assert.equal(isSkillsRef("npm:some-package"), false);
+  });
+
+  it("returns false for plain string containing skills", () => {
+    assert.equal(isSkillsRef("my-skills-dir"), false);
+  });
+});
+
+describe("parseSkillsRef", () => {
+  it("strips the skills: prefix", () => {
+    assert.equal(parseSkillsRef("skills:planning"), "planning");
+  });
+
+  it("strips prefix and preserves nested path", () => {
+    assert.equal(parseSkillsRef("skills:@org/code-review"), "@org/code-review");
+  });
+
+  it("strips prefix for deeply nested path", () => {
+    assert.equal(parseSkillsRef("skills:team/shared/review"), "team/shared/review");
+  });
+});
+
+describe("resolveSkillsPath", () => {
+  it("resolves to .skills/ directory under baseDir", () => {
+    const result = resolveSkillsPath("skills:planning", "/home/user/project");
+    assert.equal(result, join("/home/user/project", ".skills", "planning"));
+  });
+
+  it("resolves nested skill name to .skills/ directory", () => {
+    const result = resolveSkillsPath("skills:@org/code-review", "/home/user/project");
+    assert.equal(result, join("/home/user/project", ".skills", "@org/code-review"));
+  });
+
+  it("resolves deeply nested skill path", () => {
+    const result = resolveSkillsPath("skills:team/shared/review", "/tmp/proj");
+    assert.equal(result, join("/tmp/proj", ".skills", "team/shared/review"));
+  });
+});
+
+describe("skills: skill resolution", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("resolves atomic skill with skills: path", async () => {
+    tmpDir = makeTmpDir();
+
+    // Create .skills directory with a skill
+    const skillDir = join(tmpDir, ".skills", "planning");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# Planning\n\nPlan carefully.", "utf-8");
+
+    const config: Config = {
+      name: "test",
+      skills: {
+        planning: { path: "skills:planning" },
+      },
+    };
+
+    const bodies = await resolveSkills(config, tmpDir);
+    assert.equal(bodies.size, 1);
+    assert.equal(bodies.get("planning"), "# Planning\n\nPlan carefully.");
+  });
+
+  it("throws ResolveError with install hint for missing skills: directory", async () => {
+    tmpDir = makeTmpDir();
+
+    const config: Config = {
+      name: "test",
+      skills: {
+        ghost: { path: "skills:ghost-skill" },
+      },
+    };
+
+    await assert.rejects(
+      () => resolveSkills(config, tmpDir!),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /Directory not found/);
+        assert.match(err.message, /ghost/);
+        assert.match(err.message, /npx skills add ghost-skill/);
+        return true;
+      }
+    );
+  });
+
+  it("throws ResolveError for skills: directory without SKILL.md", async () => {
+    tmpDir = makeTmpDir();
+
+    // Create the .skills directory but without SKILL.md
+    const skillDir = join(tmpDir, ".skills", "empty-skill");
+    mkdirSync(skillDir, { recursive: true });
+
+    const config: Config = {
+      name: "test",
+      skills: {
+        empty: { path: "skills:empty-skill" },
+      },
+    };
+
+    await assert.rejects(
+      () => resolveSkills(config, tmpDir!),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /SKILL\.md not found/);
+        assert.match(err.message, /empty/);
+        return true;
+      }
+    );
+  });
+
+  it("strips frontmatter from skills: skill body", async () => {
+    tmpDir = makeTmpDir();
+
+    const skillDir = join(tmpDir, ".skills", "review");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---
+name: review
+description: Reviews code.
+---
+
+# Code Review
+
+Review the code carefully.
+`,
+      "utf-8"
+    );
+
+    const config: Config = {
+      name: "test",
+      skills: {
+        review: { path: "skills:review" },
+      },
+    };
+
+    const bodies = await resolveSkills(config, tmpDir);
+    const body = bodies.get("review")!;
+    assert.ok(!body.includes("---"), "Body should not contain frontmatter delimiters");
+    assert.ok(body.includes("# Code Review"), "Body should contain the markdown content");
+  });
+});
+
+describe("skills: paths are not rebased during import", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("skills: paths are preserved as-is during import", async () => {
+    tmpDir = makeTmpDir();
+
+    // Create a local import config that uses skills: prefix
+    const importDir = join(tmpDir, "imported");
+    mkdirSync(importDir, { recursive: true });
+    writeFileSync(
+      join(importDir, "skillfold.yaml"),
+      `name: imported
+skills:
+  atomic:
+    review: skills:code-review
+`,
+      "utf-8"
+    );
+
+    // Create the main config that imports
+    const configPath = join(tmpDir, "skillfold.yaml");
+    writeFileSync(
+      configPath,
+      `name: main
+imports:
+  - ./imported/skillfold.yaml
+
+skills:
+  atomic:
+    local: ./local
+`,
+      "utf-8"
+    );
+
+    const config = await loadConfig(configPath);
+    const reviewSkill = config.skills["review"];
+    assert.ok("path" in reviewSkill);
+    // skills: paths should be preserved as-is, not rebased
+    assert.equal(reviewSkill.path, "skills:code-review");
+  });
+});

--- a/src/skills-prefix.ts
+++ b/src/skills-prefix.ts
@@ -1,0 +1,16 @@
+import { join } from "node:path";
+
+const SKILLS_PREFIX = "skills:";
+
+export function isSkillsRef(ref: string): boolean {
+  return ref.startsWith(SKILLS_PREFIX);
+}
+
+export function parseSkillsRef(ref: string): string {
+  return ref.slice(SKILLS_PREFIX.length);
+}
+
+export function resolveSkillsPath(ref: string, baseDir: string): string {
+  const name = parseSkillsRef(ref);
+  return join(baseDir, ".skills", name);
+}


### PR DESCRIPTION
## Summary

- Add `skills:` prefix resolution for atomic skill paths, mapping to the `.skills/` directory used by the Vercel `skills` CLI
- Skip `skills:` prefixed paths during import rebasing (same treatment as `npm:` and `https://`)
- Include a helpful `npx skills add <name>` hint in the error message when a `skills:` directory is not found

## Details

New file `src/skills-prefix.ts` provides three utilities (`isSkillsRef`, `parseSkillsRef`, `resolveSkillsPath`) following the same pattern as `src/npm.ts`. The resolver and config modules are updated to recognize the new prefix alongside existing `npm:` and `https://` prefixes.

16 new tests in `src/skills-prefix.test.ts` covering unit tests for all three utilities, integration tests for skill resolution from `.skills/` directories, error messages with install hints, frontmatter stripping, and rebase passthrough during imports.

All 739 tests pass. Type checking passes.

Closes #423

## Test plan

- [x] `isSkillsRef` correctly identifies `skills:` prefix and rejects other prefixes
- [x] `parseSkillsRef` strips the prefix correctly
- [x] `resolveSkillsPath` resolves to `.skills/` under baseDir
- [x] `resolveSkills` reads SKILL.md from `.skills/` directory
- [x] Missing `.skills/` directory error includes `npx skills add` hint
- [x] Missing SKILL.md in `.skills/` directory produces clear error
- [x] Frontmatter is stripped from `.skills/` skill bodies
- [x] `rebaseSkillPaths` preserves `skills:` paths as-is during import
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (739/739)

Generated with [Claude Code](https://claude.com/claude-code)