### PR TITLE
feat: add @ref version pinning for URL references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Located in `library/examples/`:
 - Optional `team.orchestrator` config key to append generated plan to a composed skill
 - Spec-compliant output per Agent Skills standard (directory structure + YAML frontmatter)
 - `skillfold init` command to scaffold starter pipeline projects
-- URL-based skill references (GitHub tree URLs fetched via raw.githubusercontent.com, private repos via GITHUB_TOKEN)
+- URL-based skill references (GitHub tree URLs fetched via raw.githubusercontent.com, private repos via GITHUB_TOKEN) with `@ref` version pinning (tags and commit SHAs)
 - Pipeline imports (import skills and state from other configs, team is local-only)
 - End-to-end test with the brief's full example config
 - CI via GitHub Actions (Node 20 + 22)
@@ -186,7 +186,7 @@ Located in `library/examples/`:
 - Built-in state integrations for GitHub services (github-issues, github-discussions, github-pull-requests) with auto-generated URLs, filter options, and orchestrator instructions
 - `skillfold run` command for linear pipeline execution with `ClaudeSpawner`, state management via `state.json`, dry-run mode, and async node skipping (MVP: linear flows only)
 - VitePress documentation site (`docs/`) with GitHub Pages deployment, config reference, CLI reference, live demo with interactive pipeline visualizer, interactive pipeline builder (YAML editor with live Mermaid graph), examples gallery, skill authoring guide, comparison table, detailed comparisons page (vs Agent Teams, CrewAI, manual SKILL.md), and existing guides
-- Test suite with 723 tests across 136 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, integrations, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, run, cli, and e2e modules
+- Test suite with 740 tests across 138 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, integrations, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, run, cli, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/src/remote.test.ts
+++ b/src/remote.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import { ConfigError, ResolveError } from "./errors.js";
-import { fetchRemoteConfig, fetchRemoteSkill, getGitHubHeaders, parseGitHubUrl } from "./remote.js";
+import { extractPinnedRef, fetchRemoteConfig, fetchRemoteSkill, getGitHubHeaders, parseGitHubUrl } from "./remote.js";
 
 describe("getGitHubHeaders", () => {
   it("returns Authorization header when GITHUB_TOKEN is set", () => {
@@ -116,6 +116,197 @@ describe("parseGitHubUrl", () => {
   });
 });
 
+describe("extractPinnedRef", () => {
+  it("returns undefined ref when no @ is present", () => {
+    const [url, ref] = extractPinnedRef(
+      "https://github.com/org/repo/tree/main/skills/foo"
+    );
+    assert.equal(url, "https://github.com/org/repo/tree/main/skills/foo");
+    assert.equal(ref, undefined);
+  });
+
+  it("extracts a tag ref from the end of the URL", () => {
+    const [url, ref] = extractPinnedRef(
+      "https://github.com/org/repo/tree/main/skills/foo@v1.0.0"
+    );
+    assert.equal(url, "https://github.com/org/repo/tree/main/skills/foo");
+    assert.equal(ref, "v1.0.0");
+  });
+
+  it("extracts a SHA ref from the end of the URL", () => {
+    const [url, ref] = extractPinnedRef(
+      "https://github.com/org/repo/tree/main/skills/foo@abc1234"
+    );
+    assert.equal(url, "https://github.com/org/repo/tree/main/skills/foo");
+    assert.equal(ref, "abc1234");
+  });
+
+  it("throws on empty ref after @", () => {
+    assert.throws(
+      () => extractPinnedRef("https://github.com/org/repo/tree/main/skills/foo@"),
+      /Empty version ref after @/
+    );
+  });
+
+  it("throws on SHA shorter than 7 characters", () => {
+    assert.throws(
+      () => extractPinnedRef("https://github.com/org/repo/tree/main/skills/foo@abc12"),
+      /Invalid commit SHA.*must be 7-40 hex characters/
+    );
+  });
+
+  it("throws on SHA longer than 40 characters", () => {
+    const longSha = "a".repeat(41);
+    assert.throws(
+      () => extractPinnedRef(`https://github.com/org/repo/tree/main/skills/foo@${longSha}`),
+      /Invalid commit SHA.*must be 7-40 hex characters/
+    );
+  });
+
+  it("accepts a full 40-character SHA", () => {
+    const sha = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+    const [url, ref] = extractPinnedRef(
+      `https://github.com/org/repo/tree/main/skills/foo@${sha}`
+    );
+    assert.equal(url, "https://github.com/org/repo/tree/main/skills/foo");
+    assert.equal(ref, sha);
+  });
+
+  it("does not split on @ in earlier path segments", () => {
+    const [url, ref] = extractPinnedRef(
+      "https://github.com/org/repo/tree/main/skills/foo"
+    );
+    assert.equal(url, "https://github.com/org/repo/tree/main/skills/foo");
+    assert.equal(ref, undefined);
+  });
+
+  it("accepts non-hex tag-like refs without SHA validation", () => {
+    const [url, ref] = extractPinnedRef(
+      "https://github.com/org/repo/tree/main/skills/foo@release-2024"
+    );
+    assert.equal(url, "https://github.com/org/repo/tree/main/skills/foo");
+    assert.equal(ref, "release-2024");
+  });
+});
+
+describe("parseGitHubUrl with @ref pinning", () => {
+  it("uses pinned tag ref instead of branch from URL path", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/org/repo/tree/main/skills/foo@v1.0.0"
+    );
+    assert.deepEqual(parts, {
+      owner: "org",
+      repo: "repo",
+      ref: "v1.0.0",
+      path: "skills/foo",
+    });
+  });
+
+  it("uses pinned SHA ref instead of branch from URL path", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/org/repo/tree/main/skills/foo@abc1234"
+    );
+    assert.deepEqual(parts, {
+      owner: "org",
+      repo: "repo",
+      ref: "abc1234",
+      path: "skills/foo",
+    });
+  });
+
+  it("falls back to branch ref when no @ suffix is present", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/org/repo/tree/main/skills/foo"
+    );
+    assert.deepEqual(parts, {
+      owner: "org",
+      repo: "repo",
+      ref: "main",
+      path: "skills/foo",
+    });
+  });
+
+  it("throws on empty ref after @", () => {
+    assert.throws(
+      () => parseGitHubUrl("https://github.com/org/repo/tree/main/skills/foo@"),
+      /Empty version ref after @/
+    );
+  });
+
+  it("constructs correct raw URL with pinned ref via fetchRemoteSkill", async () => {
+    const fetchedUrls: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: string | URL | Request, _init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      fetchedUrls.push(url);
+      return new Response("# Pinned Skill", { status: 200 });
+    };
+
+    try {
+      const content = await fetchRemoteSkill(
+        "pinned-skill",
+        "https://github.com/org/repo/tree/main/skills/foo@v2.0.0"
+      );
+      assert.equal(content, "# Pinned Skill");
+      assert.equal(fetchedUrls.length, 1);
+      assert.equal(
+        fetchedUrls[0],
+        "https://raw.githubusercontent.com/org/repo/v2.0.0/skills/foo/SKILL.md"
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("constructs correct raw URL without pinned ref (backward compat)", async () => {
+    const fetchedUrls: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: string | URL | Request, _init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      fetchedUrls.push(url);
+      return new Response("# Branch Skill", { status: 200 });
+    };
+
+    try {
+      const content = await fetchRemoteSkill(
+        "branch-skill",
+        "https://github.com/org/repo/tree/develop/skills/foo"
+      );
+      assert.equal(content, "# Branch Skill");
+      assert.equal(fetchedUrls.length, 1);
+      assert.equal(
+        fetchedUrls[0],
+        "https://raw.githubusercontent.com/org/repo/develop/skills/foo/SKILL.md"
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("constructs correct raw URL with SHA pinned ref via fetchRemoteSkill", async () => {
+    const fetchedUrls: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: string | URL | Request, _init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      fetchedUrls.push(url);
+      return new Response("# SHA Skill", { status: 200 });
+    };
+
+    try {
+      await fetchRemoteSkill(
+        "sha-skill",
+        "https://github.com/org/repo/tree/main/skills/foo@abc1234def"
+      );
+      assert.equal(
+        fetchedUrls[0],
+        "https://raw.githubusercontent.com/org/repo/abc1234def/skills/foo/SKILL.md"
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe("fetchRemoteSkill", () => {
   it("rejects non-GitHub URLs with ResolveError", async () => {
     await assert.rejects(
@@ -149,6 +340,38 @@ describe("fetchRemoteSkill", () => {
         assert.ok(err instanceof ResolveError);
         assert.match(err.message, /Unsupported URL format/);
         assert.match(err.message, /no-tree/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects empty ref after @ with specific error message", async () => {
+    await assert.rejects(
+      () =>
+        fetchRemoteSkill(
+          "empty-ref",
+          "https://github.com/org/repo/tree/main/skills/foo@"
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /Empty version ref/);
+        assert.match(err.message, /empty-ref/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects invalid short SHA with specific error message", async () => {
+    await assert.rejects(
+      () =>
+        fetchRemoteSkill(
+          "bad-sha",
+          "https://github.com/org/repo/tree/main/skills/foo@abc"
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /Invalid commit SHA/);
+        assert.match(err.message, /bad-sha/);
         return true;
       }
     );

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -3,6 +3,8 @@ import { ConfigError, ResolveError } from "./errors.js";
 const GITHUB_TREE_RE =
   /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)$/;
 
+const HEX_RE = /^[0-9a-f]+$/i;
+
 export function getGitHubHeaders(): HeadersInit {
   const token = process.env.GITHUB_TOKEN;
   if (token) {
@@ -18,15 +20,46 @@ export interface GitHubUrlParts {
   path: string;
 }
 
+/**
+ * Extract an @ref suffix from the end of a URL path.
+ * The @ref must appear after the last `/` to avoid splitting on `@` in
+ * earlier path segments (e.g. org names).
+ *
+ * Returns [urlWithoutRef, pinnedRef | undefined].
+ */
+export function extractPinnedRef(url: string): [string, string | undefined] {
+  const lastSlash = url.lastIndexOf("/");
+  const tail = url.slice(lastSlash + 1);
+  const atIndex = tail.lastIndexOf("@");
+  if (atIndex === -1) return [url, undefined];
+
+  const ref = tail.slice(atIndex + 1);
+  if (ref.length === 0) {
+    throw new Error("Empty version ref after @ in URL");
+  }
+
+  // If the ref looks like a SHA (all hex), validate length 7-40
+  if (HEX_RE.test(ref) && (ref.length < 7 || ref.length > 40)) {
+    throw new Error(
+      `Invalid commit SHA "${ref}": must be 7-40 hex characters`
+    );
+  }
+
+  const base = url.slice(0, lastSlash + 1) + tail.slice(0, atIndex);
+  return [base, ref];
+}
+
 export function parseGitHubUrl(url: string): GitHubUrlParts {
-  const match = GITHUB_TREE_RE.exec(url);
+  const [cleanUrl, pinnedRef] = extractPinnedRef(url);
+
+  const match = GITHUB_TREE_RE.exec(cleanUrl);
   if (!match) {
     throw new Error("URL does not match GitHub tree URL pattern");
   }
   return {
     owner: match[1],
     repo: match[2],
-    ref: match[3],
+    ref: pinnedRef ?? match[3],
     path: match[4],
   };
 }
@@ -45,7 +78,13 @@ export async function fetchRemoteSkill(
   let parts: GitHubUrlParts;
   try {
     parts = parseGitHubUrl(url);
-  } catch {
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Surface specific validation errors (empty ref, bad SHA) rather than
+    // replacing them with the generic "Unsupported URL" message.
+    if (msg.includes("Empty version ref") || msg.includes("Invalid commit SHA")) {
+      throw new ResolveError(name, msg);
+    }
     throw new ResolveError(
       name,
       "Unsupported URL format. Only GitHub tree URLs are supported"
@@ -82,7 +121,11 @@ export async function fetchRemoteConfig(url: string): Promise<string> {
   let parts: GitHubUrlParts;
   try {
     parts = parseGitHubUrl(url);
-  } catch {
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("Empty version ref") || msg.includes("Invalid commit SHA")) {
+      throw new ConfigError(msg);
+    }
     throw new ConfigError(
       `Unsupported import URL format: ${url}. Only GitHub tree URLs are supported`
     );


### PR DESCRIPTION
## Summary
- Add `@ref` suffix support for GitHub URL skill references, allowing pinning to a specific tag (`@v1.0.0`) or commit SHA (`@abc1234`)
- Validate SHA refs are 7-40 hex characters; reject empty refs after `@`
- Surface specific validation errors (empty ref, invalid SHA) through `fetchRemoteSkill` and `fetchRemoteConfig` instead of swallowing them with generic messages
- Backward compatible - URLs without `@ref` continue to use the branch from the URL path

## Test plan
- [x] `extractPinnedRef` unit tests: no ref, tag ref, SHA ref, empty ref error, short SHA error, long SHA error, full 40-char SHA, non-hex tag refs
- [x] `parseGitHubUrl` with `@ref` pinning: tag override, SHA override, backward compat fallback, empty ref error
- [x] `fetchRemoteSkill` integration: mocked fetch verifies correct raw.githubusercontent.com URL for pinned tag, pinned SHA, and unpinned branch
- [x] Error propagation: empty ref and invalid SHA errors surface as `ResolveError`/`ConfigError` with specific messages
- [x] All 740 tests pass, `tsc --noEmit` clean

Closes #426

Generated with [Claude Code](https://claude.com/claude-code)