### PR TITLE
feat: extend skillfold run to support conditionals and loops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ src/
   list.ts         - Pipeline introspection (skillfold list)
   npm.ts          - npm package resolution (npm: prefix in skill refs and imports)
   search.ts       - npm registry search for skillfold-skill packages (skillfold search)
-  run.ts          - Linear flow runner for pipeline execution (skillfold run)
+  run.ts          - Pipeline runner with conditionals and loops (skillfold run)
   watch.ts        - File watching and auto-recompile (skillfold watch)
   init.ts         - skillfold init scaffolding
   integrations.ts - Built-in state integrations (GitHub issues, discussions, pull requests)
@@ -184,9 +184,9 @@ Located in `library/examples/`:
 - Publishing guide (`docs/publishing.md`) for sharing skills via npm
 - `skillfold.local.yaml` support for local config overrides (gitignored), with merge semantics for skills/state/team
 - Built-in state integrations for GitHub services (github-issues, github-discussions, github-pull-requests) with auto-generated URLs, filter options, and orchestrator instructions
-- `skillfold run` command for linear pipeline execution with `ClaudeSpawner`, state management via `state.json`, dry-run mode, and async node skipping (MVP: linear flows only)
+- `skillfold run` command for pipeline execution with `ClaudeSpawner`, state management via `state.json`, dry-run mode, async node skipping, conditional routing (when-clauses), loops with `--max-iterations` guard (default: 10), and graph-based node traversal
 - VitePress documentation site (`docs/`) with GitHub Pages deployment, config reference, CLI reference, live demo with interactive pipeline visualizer, interactive pipeline builder (YAML editor with live Mermaid graph), examples gallery, skill authoring guide, comparison table, detailed comparisons page (vs Agent Teams, CrewAI, manual SKILL.md), and existing guides
-- Test suite with 723 tests across 136 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, integrations, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, run, cli, and e2e modules
+- Test suite with 746 tests across 140 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, integrations, visualize, remote, init, adopt, library, validate, list, search, npm, watch, errors, subflow, api, run, cli, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ Commands:
   validate          Validate config without compiling
   list              Display a structured summary of the pipeline
   graph             Output Mermaid flowchart of the team flow
-  run               Execute a compiled pipeline (linear flows only)
+  run               Execute a pipeline with conditional routing and loops
   watch             Compile and watch for changes
   plugin            Package compiled output as a Claude Code plugin
   search [query]    Search npm for skillfold skill packages
@@ -41,6 +41,7 @@ Options:
   --template <name>    Start from a library template (init only)
   --check              Verify compiled output is up-to-date (exit 1 if stale)
   --dry-run            Show execution plan without running (run only)
+  --max-iterations <n> Max loop iterations before aborting (default: 10, run only)
   --html               Output interactive HTML instead of Mermaid (graph only)
   --help               Show this help
   --version            Show version
@@ -62,6 +63,7 @@ interface Args {
   query: string | undefined;
   check: boolean;
   dryRun: boolean;
+  maxIterations: number;
   html: boolean;
   help: boolean;
   version: boolean;
@@ -79,6 +81,7 @@ function parseArgs(argv: string[]): Args {
   let query: string | undefined;
   let checkMode = false;
   let dryRun = false;
+  let maxIterations = 10;
   let html = false;
   let help = false;
   let version = false;
@@ -152,6 +155,13 @@ function parseArgs(argv: string[]): Args {
       checkMode = true;
     } else if (argv[i] === "--dry-run") {
       dryRun = true;
+    } else if (argv[i] === "--max-iterations" && argv[i + 1]) {
+      const val = Number(argv[++i]);
+      if (!Number.isInteger(val) || val < 1) {
+        console.error(`skillfold error: --max-iterations must be a positive integer`);
+        process.exit(1);
+      }
+      maxIterations = val;
     } else if (argv[i] === "--html") {
       html = true;
     } else if (argv[i] === "--help") {
@@ -191,6 +201,7 @@ function parseArgs(argv: string[]): Args {
     query,
     check: checkMode,
     dryRun,
+    maxIterations,
     html,
     help,
     version,
@@ -406,6 +417,7 @@ async function main(): Promise<void> {
         target: args.target,
         outDir: args.outDir,
         dryRun: args.dryRun,
+        maxIterations: args.maxIterations,
       });
 
       if (!args.dryRun) {

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -8,7 +8,7 @@ import type { Config } from "./config.js";
 import { RunError } from "./errors.js";
 import type { Graph } from "./graph.js";
 import type { Spawner, StepResult } from "./run.js";
-import { run } from "./run.js";
+import { evaluateWhenClause, getStateValue, run } from "./run.js";
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `skillfold-run-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -36,6 +36,30 @@ function recordingSpawner(
       async spawn(agentName: string, _skillContent: string, state: Record<string, unknown>) {
         calls.push({ agent: agentName, state: { ...state } });
         return updates[agentName] ?? {};
+      },
+    },
+  };
+}
+
+/**
+ * Mock spawner that returns different updates based on call count per agent.
+ * Useful for testing loops where the same agent returns different results each time.
+ */
+function sequenceSpawner(
+  sequences: Record<string, Record<string, unknown>[]>,
+): { spawner: Spawner; calls: Array<{ agent: string; state: Record<string, unknown> }> } {
+  const calls: Array<{ agent: string; state: Record<string, unknown> }> = [];
+  const counters = new Map<string, number>();
+  return {
+    calls,
+    spawner: {
+      async spawn(agentName: string, _skillContent: string, state: Record<string, unknown>) {
+        calls.push({ agent: agentName, state: { ...state } });
+        const seq = sequences[agentName];
+        if (!seq) return {};
+        const idx = counters.get(agentName) ?? 0;
+        counters.set(agentName, idx + 1);
+        return seq[idx] ?? seq[seq.length - 1] ?? {};
       },
     },
   };
@@ -170,6 +194,35 @@ describe("run", () => {
 
       assert.equal(result.state.plan, "build it");
       assert.equal(result.state.code, "done");
+    });
+
+    it("non-linear then jumps to the correct node", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "reviewer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+          { skill: "reviewer", reads: ["state.plan"], writes: ["state.review"] },
+        ],
+      });
+
+      const { spawner, calls } = recordingSpawner({
+        planner: { plan: "skip engineer" },
+        reviewer: { review: "reviewed" },
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0].agent, "planner");
+      assert.equal(calls[1].agent, "reviewer");
+      assert.equal(result.state.review, "reviewed");
     });
   });
 
@@ -323,6 +376,371 @@ describe("run", () => {
     });
   });
 
+  describe("conditional routing", () => {
+    it("routes to the correct branch when condition matches", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          {
+            skill: "reviewer",
+            reads: ["state.code"],
+            writes: ["state.review"],
+            then: [
+              { when: "review.approved == true", to: "end" },
+              { when: "review.approved == false", to: "engineer" },
+            ],
+          },
+          { skill: "engineer", reads: ["state.review"], writes: ["state.code"] },
+        ],
+      });
+
+      // Reviewer returns approved = true, so should go to "end"
+      const { spawner, calls } = recordingSpawner({
+        reviewer: { review: { approved: true } },
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].agent, "reviewer");
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "ok");
+    });
+
+    it("routes to alternative branch when first condition does not match", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          {
+            skill: "reviewer",
+            reads: ["state.code"],
+            writes: ["state.review"],
+            then: [
+              { when: "review.approved == true", to: "end" },
+              { when: "review.approved == false", to: "engineer" },
+            ],
+          },
+          { skill: "engineer", reads: ["state.review"], writes: ["state.code"] },
+        ],
+      });
+
+      // First call: reviewer returns approved = false -> routes to engineer
+      // Second call: engineer returns code
+      // Then engineer falls through to end (no more nodes after it)
+      const { spawner, calls } = sequenceSpawner({
+        reviewer: [{ review: { approved: false } }],
+        engineer: [{ code: "fixed" }],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0].agent, "reviewer");
+      assert.equal(calls[1].agent, "engineer");
+      assert.equal(result.steps.length, 2);
+    });
+
+    it("throws when no conditional branch matches", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          {
+            skill: "reviewer",
+            reads: [],
+            writes: ["state.review"],
+            then: [
+              { when: "review.approved == true", to: "end" },
+            ],
+          },
+          { skill: "engineer", reads: [], writes: ["state.code"] },
+        ],
+      });
+
+      // Reviewer returns approved = false, but there's no branch for that
+      await assert.rejects(
+        () => run(
+          { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+          mockSpawner({ reviewer: { review: { approved: false } } }),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("no conditional branch matched"));
+          return true;
+        },
+      );
+    });
+
+    it("string equality in when clause", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          {
+            skill: "planner",
+            reads: [],
+            writes: ["state.plan"],
+            then: [
+              { when: 'plan.status == "ready"', to: "engineer" },
+              { when: 'plan.status == "needs-work"', to: "planner" },
+            ],
+          },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      const { spawner, calls } = sequenceSpawner({
+        planner: [{ plan: { status: "ready" } }],
+        engineer: [{ code: "done" }],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0].agent, "planner");
+      assert.equal(calls[1].agent, "engineer");
+    });
+
+    it("inequality operator in when clause", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          {
+            skill: "reviewer",
+            reads: [],
+            writes: ["state.review"],
+            then: [
+              { when: "review.approved != false", to: "end" },
+              { when: "review.approved == false", to: "engineer" },
+            ],
+          },
+          { skill: "engineer", reads: [], writes: ["state.code"] },
+        ],
+      });
+
+      // approved = true, which != false, so routes to "end"
+      const { spawner, calls } = recordingSpawner({
+        reviewer: { review: { approved: true } },
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(calls.length, 1);
+      assert.equal(result.steps.length, 1);
+    });
+
+    it("dry-run falls through sequentially for conditionals", async () => {
+      const config = makeConfig({
+        nodes: [
+          {
+            skill: "reviewer",
+            reads: [],
+            writes: ["state.review"],
+            then: [
+              { when: "review.approved == true", to: "end" },
+              { when: "review.approved == false", to: "engineer" },
+            ],
+          },
+          { skill: "engineer", reads: [], writes: ["state.code"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: true },
+        mockSpawner({}),
+      );
+
+      // Dry-run should fall through sequentially since we have no real state
+      assert.equal(result.steps.length, 2);
+      assert.ok(result.steps.every(s => s.status === "skipped"));
+    });
+  });
+
+  describe("loop execution", () => {
+    it("loops back to a previous node and exits on condition", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      // Flow: engineer -> reviewer -> (if approved: end, else: engineer)
+      const config = makeConfig({
+        nodes: [
+          { skill: "engineer", reads: [], writes: ["state.code"], then: "reviewer" },
+          {
+            skill: "reviewer",
+            reads: ["state.code"],
+            writes: ["state.review"],
+            then: [
+              { when: "review.approved == true", to: "end" },
+              { when: "review.approved == false", to: "engineer" },
+            ],
+          },
+        ],
+      });
+
+      // First iteration: engineer writes code, reviewer rejects
+      // Second iteration: engineer fixes code, reviewer approves
+      const { spawner, calls } = sequenceSpawner({
+        engineer: [
+          { code: "v1" },
+          { code: "v2" },
+        ],
+        reviewer: [
+          { review: { approved: false } },
+          { review: { approved: true } },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      // engineer -> reviewer -> engineer -> reviewer -> end
+      assert.equal(calls.length, 4);
+      assert.equal(calls[0].agent, "engineer");
+      assert.equal(calls[1].agent, "reviewer");
+      assert.equal(calls[2].agent, "engineer");
+      assert.equal(calls[3].agent, "reviewer");
+      assert.equal(result.steps.length, 4);
+      assert.deepEqual(result.state.review, { approved: true });
+    });
+
+    it("max-iterations stops infinite loops", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      // A loop that never exits
+      const config = makeConfig({
+        nodes: [
+          {
+            skill: "engineer",
+            reads: [],
+            writes: ["state.code"],
+            then: [
+              { when: "code.done == true", to: "end" },
+              { when: "code.done != true", to: "engineer" },
+            ],
+          },
+        ],
+      });
+
+      // Engineer never sets done = true
+      await assert.rejects(
+        () => run(
+          {
+            config,
+            bodies: makeBodies(),
+            target: "claude-code",
+            outDir: "build",
+            dryRun: false,
+            maxIterations: 3,
+          },
+          mockSpawner({ engineer: { code: { done: false } } }),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("exceeded max iterations (3)"));
+          return true;
+        },
+      );
+    });
+
+    it("default max-iterations is 10", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          {
+            skill: "engineer",
+            reads: [],
+            writes: ["state.code"],
+            then: [
+              { when: "code.done == true", to: "end" },
+              { when: "code.done != true", to: "engineer" },
+            ],
+          },
+        ],
+      });
+
+      await assert.rejects(
+        () => run(
+          { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+          mockSpawner({ engineer: { code: { done: false } } }),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("exceeded max iterations (10)"));
+          return true;
+        },
+      );
+    });
+
+    it("loop accumulates state across iterations", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          {
+            skill: "engineer",
+            reads: [],
+            writes: ["state.code"],
+            then: [
+              { when: "code.version == 3", to: "end" },
+              { when: "code.version != 3", to: "engineer" },
+            ],
+          },
+        ],
+      });
+
+      let callCount = 0;
+      const spawner: Spawner = {
+        async spawn(_agentName: string, _skillContent: string, _state: Record<string, unknown>) {
+          callCount++;
+          return { code: { version: callCount } };
+        },
+      };
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(callCount, 3);
+      assert.deepEqual(result.state.code, { version: 3 });
+    });
+  });
+
   describe("unsupported features", () => {
     it("map node produces clear error", async () => {
       const config = makeConfig({
@@ -339,57 +757,6 @@ describe("run", () => {
         (err: Error) => {
           assert.ok(err instanceof RunError);
           assert.ok(err.message.includes("map nodes not supported"));
-          return true;
-        },
-      );
-    });
-
-    it("conditional then produces clear error", async () => {
-      const config = makeConfig({
-        nodes: [
-          {
-            skill: "planner",
-            reads: [],
-            writes: ["state.plan"],
-            then: [
-              { when: 'state.plan == "good"', to: "engineer" },
-              { when: 'state.plan != "good"', to: "planner" },
-            ],
-          },
-          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
-        ],
-      });
-
-      await assert.rejects(
-        () => run(
-          { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
-          mockSpawner({}),
-        ),
-        (err: Error) => {
-          assert.ok(err instanceof RunError);
-          assert.ok(err.message.includes("conditional routing not supported"));
-          return true;
-        },
-      );
-    });
-
-    it("non-linear jump produces clear error", async () => {
-      const config = makeConfig({
-        nodes: [
-          { skill: "planner", reads: [], writes: ["state.plan"], then: "reviewer" },
-          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
-          { skill: "reviewer", reads: ["state.code"], writes: ["state.review"] },
-        ],
-      });
-
-      await assert.rejects(
-        () => run(
-          { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
-          mockSpawner({}),
-        ),
-        (err: Error) => {
-          assert.ok(err instanceof RunError);
-          assert.ok(err.message.includes("non-linear jump"));
           return true;
         },
       );
@@ -635,6 +1002,85 @@ describe("run", () => {
       assert.equal(calls.length, 1);
       assert.equal(result.state.plan, "done");
       assert.equal(result.state.code, undefined);
+    });
+  });
+
+  describe("evaluateWhenClause", () => {
+    it("equals with boolean true", () => {
+      const state = { review: { approved: true } };
+      assert.equal(evaluateWhenClause("review.approved == true", state), true);
+    });
+
+    it("equals with boolean false", () => {
+      const state = { review: { approved: false } };
+      assert.equal(evaluateWhenClause("review.approved == false", state), true);
+    });
+
+    it("not-equals with boolean", () => {
+      const state = { review: { approved: true } };
+      assert.equal(evaluateWhenClause("review.approved != false", state), true);
+    });
+
+    it("equals with string value", () => {
+      const state = { plan: { status: "ready" } };
+      assert.equal(evaluateWhenClause('plan.status == "ready"', state), true);
+    });
+
+    it("not-equals with string value", () => {
+      const state = { plan: { status: "ready" } };
+      assert.equal(evaluateWhenClause('plan.status != "draft"', state), true);
+    });
+
+    it("returns false when value does not match", () => {
+      const state = { review: { approved: false } };
+      assert.equal(evaluateWhenClause("review.approved == true", state), false);
+    });
+
+    it("handles missing path gracefully", () => {
+      const state = {};
+      assert.equal(evaluateWhenClause("review.approved == true", state), false);
+    });
+
+    it("handles state. prefix in path", () => {
+      const state = { review: { approved: true } };
+      assert.equal(evaluateWhenClause("state.review.approved == true", state), true);
+    });
+
+    it("number comparison", () => {
+      const state = { count: 5 };
+      assert.equal(evaluateWhenClause("count == 5", state), true);
+      assert.equal(evaluateWhenClause("count != 3", state), true);
+      assert.equal(evaluateWhenClause("count == 3", state), false);
+    });
+  });
+
+  describe("getStateValue", () => {
+    it("reads top-level field", () => {
+      assert.equal(getStateValue({ name: "test" }, "name"), "test");
+    });
+
+    it("reads nested field with dot-path", () => {
+      assert.deepEqual(
+        getStateValue({ review: { approved: true } }, "review.approved"),
+        true,
+      );
+    });
+
+    it("strips state. prefix", () => {
+      assert.equal(getStateValue({ name: "test" }, "state.name"), "test");
+    });
+
+    it("returns undefined for missing path", () => {
+      assert.equal(getStateValue({}, "missing.field"), undefined);
+    });
+
+    it("returns undefined for partially missing path", () => {
+      assert.equal(getStateValue({ a: { b: 1 } }, "a.c"), undefined);
+    });
+
+    it("handles deeply nested paths", () => {
+      const state = { a: { b: { c: { d: "deep" } } } };
+      assert.equal(getStateValue(state, "a.b.c.d"), "deep");
     });
   });
 });

--- a/src/run.ts
+++ b/src/run.ts
@@ -7,14 +7,18 @@ import { type Config } from "./config.js";
 import { type CompileTarget, expandComposedBodies } from "./compiler.js";
 import { RunError } from "./errors.js";
 import {
+  type ConditionalBranch,
   type GraphNode,
   isAsyncNode,
   isConditionalThen,
   isMapNode,
   isSubFlowNode,
+  parseWhenClause,
 } from "./graph.js";
 
 const execFileAsync = promisify(execFile);
+
+const DEFAULT_MAX_ITERATIONS = 10;
 
 export interface RunOptions {
   config: Config;
@@ -22,6 +26,7 @@ export interface RunOptions {
   target: CompileTarget;
   outDir: string;
   dryRun: boolean;
+  maxIterations?: number;
 }
 
 export interface StepResult {
@@ -125,11 +130,66 @@ function nodeLabel(node: GraphNode): string {
   return node.skill;
 }
 
+/**
+ * Read a value from state by dot-separated path.
+ * Supports nested access like "review.approved" -> state.review.approved
+ */
+export function getStateValue(
+  state: Record<string, unknown>,
+  path: string,
+): unknown {
+  const stripped = stripStatePrefix(path);
+  const parts = stripped.split(".");
+  let current: unknown = state;
+  for (const part of parts) {
+    if (current === null || current === undefined || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+/**
+ * Evaluate a when-clause expression against the current state.
+ * Returns true if the condition matches.
+ */
+export function evaluateWhenClause(
+  expression: string,
+  state: Record<string, unknown>,
+): boolean {
+  const clause = parseWhenClause(expression, "run");
+  const actual = getStateValue(state, clause.path);
+
+  if (clause.operator === "==") {
+    return actual === clause.value;
+  }
+  // operator === "!="
+  return actual !== clause.value;
+}
+
+/**
+ * Evaluate conditional branches against state and return the target node name.
+ * Returns undefined if no branch matches (which is an error condition).
+ */
+function resolveConditionalTarget(
+  branches: ConditionalBranch[],
+  state: Record<string, unknown>,
+): string | undefined {
+  for (const branch of branches) {
+    if (evaluateWhenClause(branch.when, state)) {
+      return branch.to;
+    }
+  }
+  return undefined;
+}
+
 export async function run(
   options: RunOptions,
   spawner?: Spawner,
 ): Promise<RunResult> {
   const { config, bodies, dryRun } = options;
+  const maxIterations = options.maxIterations ?? DEFAULT_MAX_ITERATIONS;
 
   if (!config.team) {
     throw new RunError("Config has no team.flow defined - nothing to run");
@@ -137,6 +197,15 @@ export async function run(
 
   const nodes = config.team.flow.nodes;
   const composedBodies = expandComposedBodies(config, bodies);
+
+  // Build node lookup: label -> index
+  const nodeLookup = new Map<string, number>();
+  for (let i = 0; i < nodes.length; i++) {
+    const label = nodeLabel(nodes[i]);
+    if (!nodeLookup.has(label)) {
+      nodeLookup.set(label, i);
+    }
+  }
 
   // Load initial state from state.json if it exists
   const statePath = join(process.cwd(), "state.json");
@@ -156,40 +225,35 @@ export async function run(
   const activeSpawner = dryRun ? undefined : (spawner ?? new ClaudeSpawner());
   const steps: StepResult[] = [];
 
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i];
-    const stepNumber = i + 1;
+  // Track visit counts per node for loop detection
+  const visitCounts = new Map<number, number>();
+
+  let currentIndex = 0;
+  let stepNumber = 0;
+
+  while (currentIndex >= 0 && currentIndex < nodes.length) {
+    const node = nodes[currentIndex];
+    stepNumber++;
     const label = nodeLabel(node);
 
-    // Validate that the flow is linear before processing the node
-    if (node.then !== undefined) {
-      if (isConditionalThen(node.then)) {
-        throw new RunError(
-          `Step ${stepNumber} "${label}": conditional routing not supported in skillfold run MVP - use the orchestrator`,
-        );
-      }
-
-      // Non-conditional then pointing to a non-next-sequential node
-      const thenTarget = node.then;
-      if (thenTarget !== "end") {
-        const nextLabel = i + 1 < nodes.length ? nodeLabel(nodes[i + 1]) : undefined;
-        if (thenTarget !== nextLabel) {
-          throw new RunError(
-            `Step ${stepNumber} "${label}": non-linear jump to "${thenTarget}" not supported in skillfold run MVP - use the orchestrator`,
-          );
-        }
-      }
+    // Check iteration limit for loops
+    const visits = (visitCounts.get(currentIndex) ?? 0) + 1;
+    visitCounts.set(currentIndex, visits);
+    if (visits > maxIterations) {
+      throw new RunError(
+        `Step ${stepNumber} "${label}": exceeded max iterations (${maxIterations}) - possible infinite loop`,
+      );
     }
 
     if (isMapNode(node)) {
       throw new RunError(
-        `Step ${stepNumber} "map": map nodes not supported in skillfold run MVP - use the orchestrator`,
+        `Step ${stepNumber} "map": map nodes not supported in skillfold run - use the orchestrator`,
       );
     }
 
     if (isSubFlowNode(node)) {
       throw new RunError(
-        `Step ${stepNumber} "${label}": sub-flow nodes not supported in skillfold run MVP - use the orchestrator`,
+        `Step ${stepNumber} "${label}": sub-flow nodes not supported in skillfold run - use the orchestrator`,
       );
     }
 
@@ -200,7 +264,11 @@ export async function run(
         );
       }
       steps.push({ step: stepNumber, agent: label, status: "skipped" });
-      if (node.then === "end") break;
+
+      // Resolve next node
+      const nextIndex = resolveNextIndex(node, currentIndex, nodeLookup, state, dryRun);
+      if (nextIndex === -1) break; // "end" target
+      currentIndex = nextIndex;
       continue;
     }
 
@@ -222,10 +290,15 @@ export async function run(
           "\n",
       );
       steps.push({ step: stepNumber, agent: node.skill, status: "skipped" });
-      if (node.then === "end") break;
+
+      // Resolve next node
+      const nextIndex = resolveNextIndex(node, currentIndex, nodeLookup, state, dryRun);
+      if (nextIndex === -1) break;
+      currentIndex = nextIndex;
       continue;
     }
 
+    let spawnError = false;
     try {
       const updates = await activeSpawner!.spawn(node.skill, skillBody, state);
 
@@ -241,7 +314,6 @@ export async function run(
       writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n", "utf-8");
 
       steps.push({ step: stepNumber, agent: node.skill, status: "ok" });
-      if (node.then === "end") break;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       steps.push({
@@ -251,9 +323,66 @@ export async function run(
         error: message,
       });
       // Stop on first error
-      break;
+      spawnError = true;
     }
+
+    if (spawnError) break;
+
+    // Resolve next node (outside try/catch so routing errors propagate)
+    const nextIndex = resolveNextIndex(node, currentIndex, nodeLookup, state, dryRun);
+    if (nextIndex === -1) break;
+    currentIndex = nextIndex;
   }
 
   return { steps, state };
+}
+
+/**
+ * Determine the next node index based on the current node's `then` field.
+ * Returns -1 to signal "end" (stop execution), or the index of the next node.
+ */
+function resolveNextIndex(
+  node: GraphNode,
+  currentIndex: number,
+  nodeLookup: Map<string, number>,
+  state: Record<string, unknown>,
+  dryRun: boolean,
+): number {
+  if (node.then === undefined) {
+    // Implicit fall-through to next sequential node
+    return currentIndex + 1;
+  }
+
+  if (isConditionalThen(node.then)) {
+    if (dryRun) {
+      // In dry-run mode we have no real state to evaluate, so fall through sequentially
+      return currentIndex + 1;
+    }
+    const target = resolveConditionalTarget(node.then, state);
+    if (target === undefined) {
+      const label = nodeLabel(node);
+      throw new RunError(
+        `Step "${label}": no conditional branch matched current state`,
+      );
+    }
+    if (target === "end") return -1;
+    const idx = nodeLookup.get(target);
+    if (idx === undefined) {
+      throw new RunError(
+        `Step "${nodeLabel(node)}": conditional target "${target}" not found in flow`,
+      );
+    }
+    return idx;
+  }
+
+  // Simple string then
+  if (node.then === "end") return -1;
+
+  const idx = nodeLookup.get(node.then);
+  if (idx === undefined) {
+    throw new RunError(
+      `Step "${nodeLabel(node)}": target "${node.then}" not found in flow`,
+    );
+  }
+  return idx;
 }


### PR DESCRIPTION
## Summary

- Replace linear iteration in `skillfold run` with graph-based node traversal, enabling conditional routing (when-clauses) and loops that route back to previous nodes
- Add `evaluateWhenClause` and `getStateValue` functions for evaluating when-clause expressions against state.json values (supports `==`/`!=` operators, boolean/string/number values, dot-path access)
- Add `--max-iterations` CLI flag (default: 10) to guard against infinite loops when conditional branches route back to previously-visited nodes
- Add 23 new tests covering conditional routing, loop execution, max-iterations guard, when-clause evaluation, and dot-path state access

Closes #425

## Test plan

- [x] All 746 tests pass (`npm test`)
- [x] Type checking passes (`npx tsc --noEmit`)
- [x] Existing linear flow tests still pass unchanged
- [x] Conditional routing: correct branch taken based on state values
- [x] Conditional routing: error thrown when no branch matches
- [x] Loop execution: engineer/reviewer loop exits on approval
- [x] Max-iterations: stops infinite loops with clear error message
- [x] When-clause evaluation: equality, inequality, boolean, string, number, dot-path, missing path
- [x] Dry-run mode: falls through sequentially for conditionals (no state to evaluate)
- [x] Non-linear jumps now work correctly (no longer rejected)

Generated with [Claude Code](https://claude.com/claude-code)