### PR TITLE
feat: add skill version pinning for URL references

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -32,6 +32,21 @@ skills:
     library-skill: npm:skillfold-skill-planning
 ```
 
+#### Version pinning
+
+GitHub URL references can be pinned to a specific tag or commit SHA using the `@ref` suffix. This ensures reproducible pipelines by fetching from an exact version instead of the branch HEAD.
+
+```yaml
+skills:
+  atomic:
+    # Pin to a tag
+    shared: https://github.com/org/repo/tree/main/skills/shared@v1.0.0
+    # Pin to a commit SHA (7-40 hex characters)
+    review: https://github.com/org/repo/tree/main/skills/review@abc1234def
+```
+
+The `@ref` is stripped from the path and used as the Git ref when fetching. If the ref looks like a commit SHA (all hex characters), it must be 7-40 characters long.
+
 ### Composed Skills
 
 Combine atomic skills by concatenating their SKILL.md bodies in declared order. Composition is recursive.

--- a/src/remote.test.ts
+++ b/src/remote.test.ts
@@ -114,6 +114,103 @@ describe("parseGitHubUrl", () => {
       path: "skills/shared",
     });
   });
+
+  it("parses a URL with @tag version pin", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/org/repo/tree/main/skills/foo@v1.0.0"
+    );
+    assert.deepEqual(parts, {
+      owner: "org",
+      repo: "repo",
+      ref: "v1.0.0",
+      path: "skills/foo",
+      pinnedRef: "v1.0.0",
+    });
+  });
+
+  it("parses a URL with @sha version pin (short SHA)", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/org/repo/tree/main/skills/foo@abc1234"
+    );
+    assert.deepEqual(parts, {
+      owner: "org",
+      repo: "repo",
+      ref: "abc1234",
+      path: "skills/foo",
+      pinnedRef: "abc1234",
+    });
+  });
+
+  it("parses a URL with @sha version pin (full 40-char SHA)", () => {
+    const sha = "a".repeat(40);
+    const parts = parseGitHubUrl(
+      `https://github.com/org/repo/tree/main/skills/foo@${sha}`
+    );
+    assert.deepEqual(parts, {
+      owner: "org",
+      repo: "repo",
+      ref: sha,
+      path: "skills/foo",
+      pinnedRef: sha,
+    });
+  });
+
+  it("parses a URL with @tag on nested path", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/org/repo/tree/develop/src/skills/review@v2.1.0"
+    );
+    assert.deepEqual(parts, {
+      owner: "org",
+      repo: "repo",
+      ref: "v2.1.0",
+      path: "src/skills/review",
+      pinnedRef: "v2.1.0",
+    });
+  });
+
+  it("does not set pinnedRef when no @ref is present", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/org/repo/tree/main/skills/foo"
+    );
+    assert.equal(parts.pinnedRef, undefined);
+    assert.equal(parts.ref, "main");
+    assert.equal(parts.path, "skills/foo");
+  });
+
+  it("throws on empty @ref (trailing @ with no value)", () => {
+    assert.throws(
+      () => parseGitHubUrl("https://github.com/org/repo/tree/main/skills/foo@"),
+      /Version pin ref cannot be empty/
+    );
+  });
+
+  it("throws on too-short commit SHA (less than 7 hex chars)", () => {
+    assert.throws(
+      () => parseGitHubUrl("https://github.com/org/repo/tree/main/skills/foo@abc12"),
+      /Invalid commit SHA.*must be 7-40 hex characters/
+    );
+  });
+
+  it("throws on too-long commit SHA (more than 40 hex chars)", () => {
+    const longSha = "a".repeat(41);
+    assert.throws(
+      () => parseGitHubUrl(`https://github.com/org/repo/tree/main/skills/foo@${longSha}`),
+      /Invalid commit SHA.*must be 7-40 hex characters/
+    );
+  });
+
+  it("accepts non-hex @ref as a tag without SHA validation", () => {
+    const parts = parseGitHubUrl(
+      "https://github.com/org/repo/tree/main/skills/foo@release-2024"
+    );
+    assert.deepEqual(parts, {
+      owner: "org",
+      repo: "repo",
+      ref: "release-2024",
+      path: "skills/foo",
+      pinnedRef: "release-2024",
+    });
+  });
 });
 
 describe("fetchRemoteSkill", () => {
@@ -164,6 +261,36 @@ describe("fetchRemoteSkill", () => {
       "Fetched content should contain Code Review"
     );
   });
+
+  it("rejects version-pinned URL with invalid SHA", async () => {
+    await assert.rejects(
+      () =>
+        fetchRemoteSkill(
+          "pinned",
+          "https://github.com/org/repo/tree/main/skills/foo@abc"
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /Invalid commit SHA/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects version-pinned URL with empty ref", async () => {
+    await assert.rejects(
+      () =>
+        fetchRemoteSkill(
+          "pinned",
+          "https://github.com/org/repo/tree/main/skills/foo@"
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof ResolveError);
+        assert.match(err.message, /Version pin ref cannot be empty/);
+        return true;
+      }
+    );
+  });
 });
 
 describe("fetchRemoteConfig", () => {
@@ -184,6 +311,20 @@ describe("fetchRemoteConfig", () => {
       (err: unknown) => {
         assert.ok(err instanceof ConfigError);
         assert.match(err.message, /Unsupported import URL format/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects version-pinned URL with invalid SHA", async () => {
+    await assert.rejects(
+      () =>
+        fetchRemoteConfig(
+          "https://github.com/org/repo/tree/main/configs/team@abc"
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof ConfigError);
+        assert.match(err.message, /Invalid commit SHA/);
         return true;
       }
     );

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -3,6 +3,8 @@ import { ConfigError, ResolveError } from "./errors.js";
 const GITHUB_TREE_RE =
   /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)$/;
 
+const SHA_RE = /^[0-9a-f]+$/i;
+
 export function getGitHubHeaders(): HeadersInit {
   const token = process.env.GITHUB_TOKEN;
   if (token) {
@@ -16,6 +18,22 @@ export interface GitHubUrlParts {
   repo: string;
   ref: string;
   path: string;
+  pinnedRef?: string;
+}
+
+/**
+ * Validate a version pin ref. Tags can be any non-empty string.
+ * If the ref looks like a commit SHA (all hex chars), it must be 7-40 chars.
+ */
+function validatePinnedRef(ref: string): void {
+  if (ref.length === 0) {
+    throw new Error("Version pin ref cannot be empty (trailing @ with no ref)");
+  }
+  if (SHA_RE.test(ref) && (ref.length < 7 || ref.length > 40)) {
+    throw new Error(
+      `Invalid commit SHA "${ref}": must be 7-40 hex characters`
+    );
+  }
 }
 
 export function parseGitHubUrl(url: string): GitHubUrlParts {
@@ -23,12 +41,33 @@ export function parseGitHubUrl(url: string): GitHubUrlParts {
   if (!match) {
     throw new Error("URL does not match GitHub tree URL pattern");
   }
-  return {
+
+  let path = match[4];
+  let ref = match[3];
+  let pinnedRef: string | undefined;
+
+  // Check for @ref version pin at the end of the path
+  const atIndex = path.lastIndexOf("@");
+  if (atIndex !== -1) {
+    const pin = path.slice(atIndex + 1);
+    validatePinnedRef(pin);
+    pinnedRef = pin;
+    path = path.slice(0, atIndex);
+    ref = pin;
+  }
+
+  const parts: GitHubUrlParts = {
     owner: match[1],
     repo: match[2],
-    ref: match[3],
-    path: match[4],
+    ref,
+    path,
   };
+
+  if (pinnedRef !== undefined) {
+    parts.pinnedRef = pinnedRef;
+  }
+
+  return parts;
 }
 
 export async function fetchRemoteSkill(
@@ -45,10 +84,13 @@ export async function fetchRemoteSkill(
   let parts: GitHubUrlParts;
   try {
     parts = parseGitHubUrl(url);
-  } catch {
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     throw new ResolveError(
       name,
-      "Unsupported URL format. Only GitHub tree URLs are supported"
+      message.includes("Version pin") || message.includes("Invalid commit SHA")
+        ? message
+        : "Unsupported URL format. Only GitHub tree URLs are supported"
     );
   }
 
@@ -82,9 +124,12 @@ export async function fetchRemoteConfig(url: string): Promise<string> {
   let parts: GitHubUrlParts;
   try {
     parts = parseGitHubUrl(url);
-  } catch {
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     throw new ConfigError(
-      `Unsupported import URL format: ${url}. Only GitHub tree URLs are supported`
+      message.includes("Version pin") || message.includes("Invalid commit SHA")
+        ? message
+        : `Unsupported import URL format: ${url}. Only GitHub tree URLs are supported`
     );
   }
 


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `@ref` suffix support on GitHub tree URLs for pinning skills to a specific tag or commit SHA
- Parse the version pin from the URL path, validate SHA format (7-40 hex chars), and use the pinned ref when constructing raw.githubusercontent.com URLs
- Propagate version pin validation errors with clear messages through `fetchRemoteSkill` and `fetchRemoteConfig`

## Changes

- `src/remote.ts` - Add `@ref` parsing to `parseGitHubUrl`, `validatePinnedRef` helper, `pinnedRef` field on `GitHubUrlParts`, error propagation in fetch functions
- `src/remote.test.ts` - 12 new tests covering tag pins, SHA pins (short and full), nested paths, backward compat without `@ref`, empty ref, invalid SHA length, non-hex tags, and error propagation through fetch functions
- `docs/reference/config.md` - Document version pinning syntax with examples

## Test plan

- [x] All 751 tests pass (12 new + 739 existing)
- [x] TypeScript type check passes
- [x] Tag version pin: `@v1.0.0` overrides ref and sets `pinnedRef`
- [x] SHA version pin: `@abc1234` (7 chars) and full 40-char SHA both work
- [x] Backward compat: URLs without `@ref` work exactly as before (no `pinnedRef` field)
- [x] Empty `@ref` (trailing `@`) throws clear error
- [x] Too-short SHA (`@abc`) and too-long SHA (41+ chars) throw validation error
- [x] Non-hex refs like `@release-2024` accepted as tags without SHA validation
- [x] Errors propagate correctly through `fetchRemoteSkill` (ResolveError) and `fetchRemoteConfig` (ConfigError)

Closes #426

Generated with [Claude Code](https://claude.com/claude-code)