### PR TITLE
feat: add error handling, recovery modes, and step timing to skillfold run

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { type CompileTarget, check, compile, computeStats } from "./compiler.js";
+import type { OnErrorMode } from "./run.js";
 import { isAtomic, isComposed, loadConfig } from "./config.js";
 import { ConfigError, CompileError, GraphError, ResolveError, RunError } from "./errors.js";
 import { initFromTemplate, initProject, TEMPLATES } from "./init.js";
@@ -42,6 +43,8 @@ Options:
   --check              Verify compiled output is up-to-date (exit 1 if stale)
   --dry-run            Show execution plan without running (run only)
   --max-iterations <n> Max loop iterations before aborting (default: 10, run only)
+  --on-error <mode>    Error handling: retry, skip, or abort (default: abort, run only)
+  --max-retries <n>    Max retry attempts per step (default: 3, run only)
   --html               Output interactive HTML instead of Mermaid (graph only)
   --help               Show this help
   --version            Show version
@@ -64,6 +67,8 @@ interface Args {
   check: boolean;
   dryRun: boolean;
   maxIterations: number;
+  onError: OnErrorMode;
+  maxRetries: number;
   html: boolean;
   help: boolean;
   version: boolean;
@@ -82,6 +87,8 @@ function parseArgs(argv: string[]): Args {
   let checkMode = false;
   let dryRun = false;
   let maxIterations = 10;
+  let onError: OnErrorMode = "abort";
+  let maxRetries = 3;
   let html = false;
   let help = false;
   let version = false;
@@ -162,6 +169,20 @@ function parseArgs(argv: string[]): Args {
         process.exit(1);
       }
       maxIterations = val;
+    } else if (argv[i] === "--on-error" && argv[i + 1]) {
+      const val = argv[++i];
+      if (val !== "retry" && val !== "skip" && val !== "abort") {
+        console.error(`skillfold error: --on-error must be retry, skip, or abort`);
+        process.exit(1);
+      }
+      onError = val;
+    } else if (argv[i] === "--max-retries" && argv[i + 1]) {
+      const val = Number(argv[++i]);
+      if (!Number.isInteger(val) || val < 1) {
+        console.error(`skillfold error: --max-retries must be a positive integer`);
+        process.exit(1);
+      }
+      maxRetries = val;
     } else if (argv[i] === "--html") {
       html = true;
     } else if (argv[i] === "--help") {
@@ -202,6 +223,8 @@ function parseArgs(argv: string[]): Args {
     check: checkMode,
     dryRun,
     maxIterations,
+    onError,
+    maxRetries,
     html,
     help,
     version,
@@ -388,7 +411,7 @@ async function main(): Promise<void> {
   }
 
   if (args.command === "run") {
-    const { run } = await import("./run.js");
+    const { run, formatDuration } = await import("./run.js");
     try {
       if (args.target === "skill") {
         console.error("skillfold error: --target is required for run (e.g. --target claude-code)");
@@ -418,22 +441,39 @@ async function main(): Promise<void> {
         outDir: args.outDir,
         dryRun: args.dryRun,
         maxIterations: args.maxIterations,
+        onError: args.onError,
+        maxRetries: args.maxRetries,
       });
 
       if (!args.dryRun) {
+        // Print execution summary
+        process.stderr.write("\n");
         for (const step of result.steps) {
-          const statusLabel = step.status === "ok" ? "done" :
-            step.status === "skipped" ? "skipped (async)" :
-            `error: ${step.error}`;
-          process.stderr.write(`  [${step.step}/${nodeCount}] ${step.agent}... ${statusLabel}\n`);
+          const duration = step.durationMs !== undefined ? ` (${formatDuration(step.durationMs)})` : "";
+          const retries = step.attempts && step.attempts > 1 ? ` [${step.attempts} attempts]` : "";
+          const statusLabel = step.status === "ok" ? "pass" :
+            step.status === "skipped" ? (step.error ? "skip" : "skip (async)") :
+            "FAIL";
+          const errorSuffix = step.status === "error" && step.error ? `: ${step.error}` : "";
+          process.stderr.write(
+            `  ${statusLabel.padEnd(12)} ${step.agent}${retries}${duration}${errorSuffix}\n`,
+          );
         }
 
-        const failed = result.steps.find(s => s.status === "error");
-        if (failed) {
-          process.stderr.write(`skillfold: pipeline failed at step ${failed.step}\n`);
+        const okCount = result.steps.filter(s => s.status === "ok").length;
+        const failCount = result.steps.filter(s => s.status === "error").length;
+        const skipCount = result.steps.filter(s => s.status === "skipped").length;
+        const parts: string[] = [];
+        if (okCount > 0) parts.push(`${okCount} passed`);
+        if (failCount > 0) parts.push(`${failCount} failed`);
+        if (skipCount > 0) parts.push(`${skipCount} skipped`);
+
+        process.stderr.write(
+          `\nskillfold: ${parts.join(", ")} in ${formatDuration(result.durationMs)}\n`,
+        );
+
+        if (failCount > 0) {
           process.exit(1);
-        } else {
-          process.stderr.write(`skillfold: pipeline complete\n`);
         }
       }
     } catch (err) {

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -7,8 +7,8 @@ import { tmpdir } from "node:os";
 import type { Config } from "./config.js";
 import { RunError } from "./errors.js";
 import type { Graph } from "./graph.js";
-import type { Spawner, StepResult } from "./run.js";
-import { evaluateWhenClause, getStateValue, run } from "./run.js";
+import type { OnErrorMode, Spawner, StepResult } from "./run.js";
+import { evaluateWhenClause, formatDuration, getStateValue, run } from "./run.js";
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `skillfold-run-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -73,6 +73,35 @@ function errorSpawner(failOn: string): Spawner {
         throw new Error(`Agent ${agentName} failed`);
       }
       return {};
+    },
+  };
+}
+
+/**
+ * Mock spawner that fails N times then succeeds for a specific agent.
+ * Records all spawn attempts.
+ */
+function retrySpawner(
+  failOn: string,
+  failCount: number,
+  successUpdate: Record<string, unknown>,
+): { spawner: Spawner; attempts: number[] } {
+  const state = { count: 0 };
+  const attempts: number[] = [];
+  return {
+    attempts,
+    spawner: {
+      async spawn(agentName: string, _skillContent: string, _state: Record<string, unknown>) {
+        if (agentName === failOn) {
+          state.count++;
+          attempts.push(state.count);
+          if (state.count <= failCount) {
+            throw new Error(`Agent ${agentName} failed (attempt ${state.count})`);
+          }
+          return successUpdate;
+        }
+        return {};
+      },
     },
   };
 }
@@ -839,7 +868,7 @@ describe("run", () => {
   });
 
   describe("error handling", () => {
-    it("spawner error is captured in step result", async () => {
+    it("spawner error is captured in step result (abort mode)", async () => {
       tmpDir = makeTmpDir();
       origCwd = process.cwd();
       process.chdir(tmpDir);
@@ -851,7 +880,7 @@ describe("run", () => {
       });
 
       const result = await run(
-        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "abort" },
         errorSpawner("planner"),
       );
 
@@ -859,7 +888,28 @@ describe("run", () => {
       assert.ok(result.steps[0].error?.includes("Agent planner failed"));
     });
 
-    it("execution halts on spawner error", async () => {
+    it("execution halts on spawner error in abort mode", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "abort" },
+        errorSpawner("planner"),
+      );
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "error");
+    });
+
+    it("default onError mode is abort", async () => {
       tmpDir = makeTmpDir();
       origCwd = process.cwd();
       process.chdir(tmpDir);
@@ -876,6 +926,7 @@ describe("run", () => {
         errorSpawner("planner"),
       );
 
+      // Default abort: stops at first error
       assert.equal(result.steps.length, 1);
       assert.equal(result.steps[0].status, "error");
     });
@@ -897,6 +948,270 @@ describe("run", () => {
           return true;
         },
       );
+    });
+  });
+
+  describe("onError: retry", () => {
+    it("retries a failed step and succeeds", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      // Fails once, then succeeds
+      const { spawner, attempts } = retrySpawner("planner", 1, { plan: "recovered" });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "retry", maxRetries: 3 },
+        spawner,
+      );
+
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[0].attempts, 2);
+      assert.equal(result.state.plan, "recovered");
+      assert.equal(attempts.length, 2);
+    });
+
+    it("exhausts retries and fails", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      // Fails 5 times, maxRetries is 3 so never succeeds
+      const { spawner, attempts } = retrySpawner("planner", 5, { plan: "never" });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "retry", maxRetries: 3 },
+        spawner,
+      );
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "error");
+      assert.equal(result.steps[0].attempts, 3);
+      assert.equal(attempts.length, 3);
+    });
+
+    it("records errors in state._errors on retry exhaustion", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      const { spawner } = retrySpawner("planner", 5, {});
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "retry", maxRetries: 2 },
+        spawner,
+      );
+
+      assert.ok(Array.isArray(result.state._errors));
+      const errors = result.state._errors as Array<{ step: number; agent: string; attempts: number }>;
+      assert.equal(errors.length, 1);
+      assert.equal(errors[0].step, 1);
+      assert.equal(errors[0].agent, "planner");
+      assert.equal(errors[0].attempts, 2);
+    });
+
+    it("successful step on first attempt does not record attempts count", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "retry" },
+        mockSpawner({ planner: { plan: "done" } }),
+      );
+
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[0].attempts, undefined);
+    });
+  });
+
+  describe("onError: skip", () => {
+    it("skips failed step and continues pipeline", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "skip" },
+        errorSpawner("planner"),
+      );
+
+      assert.equal(result.steps.length, 2);
+      assert.equal(result.steps[0].status, "skipped");
+      assert.ok(result.steps[0].error?.includes("Agent planner failed"));
+      assert.equal(result.steps[1].status, "ok");
+    });
+
+    it("records skipped errors in state._errors", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "skip" },
+        errorSpawner("planner"),
+      );
+
+      assert.ok(Array.isArray(result.state._errors));
+      const errors = result.state._errors as Array<{ agent: string }>;
+      assert.equal(errors[0].agent, "planner");
+    });
+
+    it("multiple errors are accumulated in state._errors", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      // Both agents fail
+      const spawner: Spawner = {
+        async spawn(agentName: string) {
+          throw new Error(`${agentName} broke`);
+        },
+      };
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "skip" },
+        spawner,
+      );
+
+      assert.equal(result.steps.length, 2);
+      assert.equal(result.steps[0].status, "skipped");
+      assert.equal(result.steps[1].status, "skipped");
+      const errors = result.state._errors as Array<{ agent: string }>;
+      assert.equal(errors.length, 2);
+    });
+  });
+
+  describe("step timing", () => {
+    it("records durationMs for each step", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({
+          planner: { plan: "done" },
+          engineer: { code: "done" },
+        }),
+      );
+
+      assert.equal(result.steps.length, 2);
+      for (const step of result.steps) {
+        assert.equal(typeof step.durationMs, "number");
+        assert.ok(step.durationMs! >= 0);
+      }
+    });
+
+    it("records total pipeline durationMs", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({ planner: { plan: "done" } }),
+      );
+
+      assert.equal(typeof result.durationMs, "number");
+      assert.ok(result.durationMs >= 0);
+    });
+
+    it("records durationMs for failed steps", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        errorSpawner("planner"),
+      );
+
+      assert.equal(result.steps[0].status, "error");
+      assert.equal(typeof result.steps[0].durationMs, "number");
+    });
+  });
+
+  describe("formatDuration", () => {
+    it("formats milliseconds", () => {
+      assert.equal(formatDuration(50), "50ms");
+      assert.equal(formatDuration(999), "999ms");
+    });
+
+    it("formats seconds", () => {
+      assert.equal(formatDuration(1000), "1s");
+      assert.equal(formatDuration(5000), "5s");
+      assert.equal(formatDuration(59000), "59s");
+    });
+
+    it("formats minutes and seconds", () => {
+      assert.equal(formatDuration(60000), "1m");
+      assert.equal(formatDuration(90000), "1m 30s");
+      assert.equal(formatDuration(151000), "2m 31s");
     });
   });
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -19,6 +19,9 @@ import {
 const execFileAsync = promisify(execFile);
 
 const DEFAULT_MAX_ITERATIONS = 10;
+const DEFAULT_MAX_RETRIES = 3;
+
+export type OnErrorMode = "retry" | "skip" | "abort";
 
 export interface RunOptions {
   config: Config;
@@ -27,6 +30,8 @@ export interface RunOptions {
   outDir: string;
   dryRun: boolean;
   maxIterations?: number;
+  onError?: OnErrorMode;
+  maxRetries?: number;
 }
 
 export interface StepResult {
@@ -34,11 +39,14 @@ export interface StepResult {
   agent: string;
   status: "ok" | "error" | "skipped";
   error?: string;
+  attempts?: number;
+  durationMs?: number;
 }
 
 export interface RunResult {
   steps: StepResult[];
   state: Record<string, unknown>;
+  durationMs: number;
 }
 
 export interface Spawner {
@@ -184,12 +192,26 @@ function resolveConditionalTarget(
   return undefined;
 }
 
+/**
+ * Format a duration in milliseconds as a human-readable string.
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+}
+
 export async function run(
   options: RunOptions,
   spawner?: Spawner,
 ): Promise<RunResult> {
   const { config, bodies, dryRun } = options;
   const maxIterations = options.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+  const onError: OnErrorMode = options.onError ?? "abort";
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
 
   if (!config.team) {
     throw new RunError("Config has no team.flow defined - nothing to run");
@@ -224,6 +246,7 @@ export async function run(
 
   const activeSpawner = dryRun ? undefined : (spawner ?? new ClaudeSpawner());
   const steps: StepResult[] = [];
+  const pipelineStart = Date.now();
 
   // Track visit counts per node for loop detection
   const visitCounts = new Map<number, number>();
@@ -298,35 +321,79 @@ export async function run(
       continue;
     }
 
-    let spawnError = false;
-    try {
-      const updates = await activeSpawner!.spawn(node.skill, skillBody, state);
+    const stepStart = Date.now();
+    let stepSucceeded = false;
+    let lastError: string | undefined;
+    let attempts = 0;
+    const attemptsAllowed = onError === "retry" ? maxRetries : 1;
 
-      // Apply state updates (only for fields declared in writes)
-      for (const writePath of node.writes) {
-        const field = stripStatePrefix(writePath);
-        if (field in updates) {
-          state[field] = updates[field];
+    for (let attempt = 1; attempt <= attemptsAllowed; attempt++) {
+      attempts = attempt;
+      try {
+        const updates = await activeSpawner!.spawn(node.skill, skillBody, state);
+
+        // Apply state updates (only for fields declared in writes)
+        for (const writePath of node.writes) {
+          const field = stripStatePrefix(writePath);
+          if (field in updates) {
+            state[field] = updates[field];
+          }
         }
+
+        // Write updated state to disk after each step
+        writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n", "utf-8");
+
+        stepSucceeded = true;
+        break;
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
       }
+    }
 
-      // Write updated state to disk after each step
-      writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n", "utf-8");
+    const stepDuration = Date.now() - stepStart;
 
-      steps.push({ step: stepNumber, agent: node.skill, status: "ok" });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+    if (stepSucceeded) {
       steps.push({
         step: stepNumber,
         agent: node.skill,
-        status: "error",
-        error: message,
+        status: "ok",
+        attempts: attempts > 1 ? attempts : undefined,
+        durationMs: stepDuration,
       });
-      // Stop on first error
-      spawnError = true;
-    }
+    } else {
+      // Record error in state for debugging
+      const errors: unknown[] = Array.isArray(state._errors) ? state._errors : [];
+      errors.push({
+        step: stepNumber,
+        agent: node.skill,
+        error: lastError,
+        attempts,
+      });
+      state._errors = errors;
+      writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n", "utf-8");
 
-    if (spawnError) break;
+      if (onError === "skip") {
+        steps.push({
+          step: stepNumber,
+          agent: node.skill,
+          status: "skipped",
+          error: lastError,
+          attempts,
+          durationMs: stepDuration,
+        });
+      } else {
+        // abort or retry-exhausted
+        steps.push({
+          step: stepNumber,
+          agent: node.skill,
+          status: "error",
+          error: lastError,
+          attempts: onError === "retry" ? attempts : undefined,
+          durationMs: stepDuration,
+        });
+        break;
+      }
+    }
 
     // Resolve next node (outside try/catch so routing errors propagate)
     const nextIndex = resolveNextIndex(node, currentIndex, nodeLookup, state, dryRun);
@@ -334,7 +401,8 @@ export async function run(
     currentIndex = nextIndex;
   }
 
-  return { steps, state };
+  const pipelineDuration = Date.now() - pipelineStart;
+  return { steps, state, durationMs: pipelineDuration };
 }
 
 /**


### PR DESCRIPTION
**[engineer]**

## Summary

- Add `--on-error` flag with three modes: `retry`, `skip`, `abort` (default) for configurable error recovery during pipeline execution
- Add `--max-retries` flag (default: 3) for retry mode
- Track wall-clock duration per step and total pipeline duration
- Print structured execution summary with pass/fail/skip status, timing, and retry counts
- Record failed step details in `state.json` under `_errors` key for debugging

## Details

When an agent fails mid-pipeline, `skillfold run` now supports three recovery behaviors:

| Mode | Behavior |
|------|----------|
| `abort` (default) | Stop pipeline immediately on first error |
| `retry` | Retry the failed step up to `--max-retries` attempts, then abort |
| `skip` | Skip the failed step and continue to the next node |

The execution summary printed at the end shows each step's status and duration:

```
  pass         planner (1s)
  FAIL         engineer [3 attempts] (5s): Agent engineer failed
  skip         reviewer (0ms)

skillfold: 1 passed, 1 failed, 1 skipped in 6s
```

## Test plan

- [x] 14 new tests covering retry success, retry exhaustion, skip mode, abort mode, error accumulation, step timing, pipeline duration, and formatDuration
- [x] All 795 tests pass (up from 781)
- [x] Type check passes

Closes #434, closes #436