### PR TITLE
feat: add pipeline execution state persistence and resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/build/
+.skillfold/
 test-output/
 docs/.vitepress/dist/
 docs/.vitepress/cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Configuration language and compiler for multi-agent AI pipelines. Compiles YAML 
 
 - **Run compiler**: `npx tsx src/cli.ts`
 - **Run pipeline**: `npx tsx src/cli.ts run --target claude-code`
+- **Resume pipeline**: `npx tsx src/cli.ts run --target claude-code --resume`
 - **Dry run**: `npx tsx src/cli.ts run --target claude-code --dry-run`
 - **Compile to Claude Code agents**: `npx tsx src/cli.ts --target claude-code`
 - **Package as plugin**: `npx tsx src/cli.ts plugin`
@@ -185,9 +186,9 @@ Located in `library/examples/`:
 - Publishing guide (`docs/publishing.md`) for sharing skills via npm
 - `skillfold.local.yaml` support for local config overrides (gitignored), with merge semantics for skills/state/team
 - Built-in state integrations for GitHub services (github-issues, github-discussions, github-pull-requests) with auto-generated URLs, filter options, and orchestrator instructions
-- `skillfold run` command for pipeline execution with `ClaudeSpawner`, state management via `state.json`, dry-run mode, async node skipping, conditional routing (when-clauses), loops with `--max-iterations` guard (default: 10), and graph-based node traversal
+- `skillfold run` command for pipeline execution with `ClaudeSpawner`, state management via `state.json`, dry-run mode, async node skipping, conditional routing (when-clauses), loops with `--max-iterations` guard (default: 10), graph-based node traversal, error handling with `--on-error` (retry/skip/abort), `--max-retries`, step timing, execution summary, and `--resume` for checkpoint-based pipeline resumption (state persisted to `.skillfold/run/`, config hash validation)
 - VitePress documentation site (`docs/`) with GitHub Pages deployment, config reference, CLI reference, live demo with interactive pipeline visualizer, interactive pipeline builder (YAML editor with live Mermaid graph), examples gallery, skill authoring guide, comparison table, detailed comparisons page (vs Agent Teams, CrewAI, manual SKILL.md), and existing guides
-- Test suite with 781 tests across 147 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, integrations, visualize, remote, init, adopt, library, validate, list, search, npm, skills-prefix, watch, errors, subflow, api, run, cli, and e2e modules
+- Test suite with 800 tests across 152 suites covering config, resolver, compiler, agent, plugin, state, graph, orchestrator, integrations, visualize, remote, init, adopt, library, validate, list, search, npm, skills-prefix, watch, errors, subflow, api, run, cli, and e2e modules
   - Run with `npm test` (uses `node:test`, no extra dependencies)
 
 ## What's Next

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -42,6 +43,7 @@ Options:
   --template <name>    Start from a library template (init only)
   --check              Verify compiled output is up-to-date (exit 1 if stale)
   --dry-run            Show execution plan without running (run only)
+  --resume             Resume from last checkpoint (run only)
   --max-iterations <n> Max loop iterations before aborting (default: 10, run only)
   --on-error <mode>    Error handling: retry, skip, or abort (default: abort, run only)
   --max-retries <n>    Max retry attempts per step (default: 3, run only)
@@ -66,6 +68,7 @@ interface Args {
   query: string | undefined;
   check: boolean;
   dryRun: boolean;
+  resume: boolean;
   maxIterations: number;
   onError: OnErrorMode;
   maxRetries: number;
@@ -86,6 +89,7 @@ function parseArgs(argv: string[]): Args {
   let query: string | undefined;
   let checkMode = false;
   let dryRun = false;
+  let resume = false;
   let maxIterations = 10;
   let onError: OnErrorMode = "abort";
   let maxRetries = 3;
@@ -162,6 +166,8 @@ function parseArgs(argv: string[]): Args {
       checkMode = true;
     } else if (argv[i] === "--dry-run") {
       dryRun = true;
+    } else if (argv[i] === "--resume") {
+      resume = true;
     } else if (argv[i] === "--max-iterations" && argv[i + 1]) {
       const val = Number(argv[++i]);
       if (!Number.isInteger(val) || val < 1) {
@@ -222,6 +228,7 @@ function parseArgs(argv: string[]): Args {
     query,
     check: checkMode,
     dryRun,
+    resume,
     maxIterations,
     onError,
     maxRetries,
@@ -434,12 +441,17 @@ async function main(): Promise<void> {
         process.stderr.write(`skillfold: running ${config.name} (${nodeCount} steps)\n`);
       }
 
+      const configContent = readFileSync(args.configPath, "utf-8");
+      const configHash = createHash("sha256").update(configContent).digest("hex");
+
       const result = await run({
         config,
         bodies,
         target: args.target,
         outDir: args.outDir,
         dryRun: args.dryRun,
+        resume: args.resume,
+        configHash,
         maxIterations: args.maxIterations,
         onError: args.onError,
         maxRetries: args.maxRetries,

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import type { Config } from "./config.js";
 import { RunError } from "./errors.js";
 import type { Graph } from "./graph.js";
-import type { OnErrorMode, Spawner, StepResult } from "./run.js";
+import type { Checkpoint, OnErrorMode, Spawner, StepResult } from "./run.js";
 import { evaluateWhenClause, formatDuration, getStateValue, run } from "./run.js";
 
 function makeTmpDir(): string {
@@ -1396,6 +1396,216 @@ describe("run", () => {
     it("handles deeply nested paths", () => {
       const state = { a: { b: { c: { d: "deep" } } } };
       assert.equal(getStateValue(state, "a.b.c.d"), "deep");
+    });
+  });
+
+  describe("checkpoint and resume", () => {
+    it("resumes from mid-pipeline when checkpoint exists", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"], then: "reviewer" },
+          { skill: "reviewer", reads: ["state.code"], writes: ["state.review"] },
+        ],
+      });
+
+      // Write a checkpoint indicating planner and engineer are done
+      const checkpointDir = join(tmpDir, ".skillfold", "run");
+      mkdirSync(checkpointDir, { recursive: true });
+      const checkpoint: Checkpoint = {
+        configHash: "abc123",
+        completedSteps: ["planner", "engineer"],
+        currentStepIndex: 2,
+        state: { plan: "the plan", code: "the code" },
+        startedAt: "2026-03-22T00:00:00.000Z",
+      };
+      writeFileSync(join(checkpointDir, "checkpoint.json"), JSON.stringify(checkpoint));
+
+      // Also write state.json (which would exist from the previous partial run)
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({ plan: "the plan", code: "the code" }));
+
+      const { spawner, calls } = recordingSpawner({
+        reviewer: { review: "LGTM" },
+      });
+
+      const result = await run(
+        {
+          config,
+          bodies: makeBodies(),
+          target: "claude-code",
+          outDir: "build",
+          dryRun: false,
+          resume: true,
+          configHash: "abc123",
+        },
+        spawner,
+      );
+
+      // Only the reviewer should have been called
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].agent, "reviewer");
+      // State from checkpoint should have been passed to the spawner
+      assert.equal(calls[0].state.plan, "the plan");
+      assert.equal(calls[0].state.code, "the code");
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.state.review, "LGTM");
+    });
+
+    it("throws RunError when resuming with no checkpoint", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      await assert.rejects(
+        () => run(
+          {
+            config,
+            bodies: makeBodies(),
+            target: "claude-code",
+            outDir: "build",
+            dryRun: false,
+            resume: true,
+          },
+          mockSpawner({}),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("No checkpoint found"));
+          return true;
+        },
+      );
+    });
+
+    it("throws RunError when config hash does not match checkpoint", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      // Write checkpoint with one hash
+      const checkpointDir = join(tmpDir, ".skillfold", "run");
+      mkdirSync(checkpointDir, { recursive: true });
+      const checkpoint: Checkpoint = {
+        configHash: "original-hash",
+        completedSteps: [],
+        currentStepIndex: 0,
+        state: {},
+        startedAt: "2026-03-22T00:00:00.000Z",
+      };
+      writeFileSync(join(checkpointDir, "checkpoint.json"), JSON.stringify(checkpoint));
+
+      // Resume with a different hash
+      await assert.rejects(
+        () => run(
+          {
+            config,
+            bodies: makeBodies(),
+            target: "claude-code",
+            outDir: "build",
+            dryRun: false,
+            resume: true,
+            configHash: "different-hash",
+          },
+          mockSpawner({}),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("Config has changed"));
+          return true;
+        },
+      );
+    });
+
+    it("clean run clears previous checkpoint", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      // Write an existing checkpoint
+      const checkpointDir = join(tmpDir, ".skillfold", "run");
+      mkdirSync(checkpointDir, { recursive: true });
+      writeFileSync(
+        join(checkpointDir, "checkpoint.json"),
+        JSON.stringify({ configHash: "old", completedSteps: ["planner"], currentStepIndex: 1, state: {}, startedAt: "" }),
+      );
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"] },
+        ],
+      });
+
+      await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({ planner: { plan: "fresh" } }),
+      );
+
+      // The old checkpoint dir should have been cleared and a new checkpoint written
+      const newCheckpoint = JSON.parse(readFileSync(join(checkpointDir, "checkpoint.json"), "utf-8")) as Checkpoint;
+      assert.equal(newCheckpoint.completedSteps.length, 1);
+      assert.equal(newCheckpoint.completedSteps[0], "planner");
+    });
+
+    it("checkpoint is written after each successful step", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan"], then: "engineer" },
+          { skill: "engineer", reads: ["state.plan"], writes: ["state.code"] },
+        ],
+      });
+
+      // Use a spawner that checks checkpoint after planner runs
+      let checkpointAfterPlanner: Checkpoint | undefined;
+      const spawner: Spawner = {
+        async spawn(agentName: string, _skillContent: string, _state: Record<string, unknown>) {
+          if (agentName === "engineer") {
+            // Read checkpoint that was written after planner completed
+            const cpPath = join(tmpDir!, ".skillfold", "run", "checkpoint.json");
+            if (existsSync(cpPath)) {
+              checkpointAfterPlanner = JSON.parse(readFileSync(cpPath, "utf-8")) as Checkpoint;
+            }
+          }
+          if (agentName === "planner") return { plan: "done" };
+          return { code: "done" };
+        },
+      };
+
+      await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      // After planner ran but before engineer, checkpoint should show planner completed
+      assert.ok(checkpointAfterPlanner);
+      assert.deepEqual(checkpointAfterPlanner!.completedSteps, ["planner"]);
+      assert.equal(checkpointAfterPlanner!.state.plan, "done");
+
+      // Final checkpoint should show both steps completed
+      const finalCheckpoint = JSON.parse(
+        readFileSync(join(tmpDir, ".skillfold", "run", "checkpoint.json"), "utf-8"),
+      ) as Checkpoint;
+      assert.deepEqual(finalCheckpoint.completedSteps, ["planner", "engineer"]);
+      assert.equal(finalCheckpoint.state.code, "done");
     });
   });
 });

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,5 @@
 import { execFile, execFileSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
 
@@ -32,6 +32,16 @@ export interface RunOptions {
   maxIterations?: number;
   onError?: OnErrorMode;
   maxRetries?: number;
+  resume?: boolean;
+  configHash?: string;
+}
+
+export interface Checkpoint {
+  configHash: string;
+  completedSteps: string[];
+  currentStepIndex: number;
+  state: Record<string, unknown>;
+  startedAt: string;
 }
 
 export interface StepResult {
@@ -204,6 +214,33 @@ export function formatDuration(ms: number): string {
   return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
 }
 
+const CHECKPOINT_DIR = ".skillfold/run";
+const CHECKPOINT_FILE = "checkpoint.json";
+
+function checkpointPath(): string {
+  return join(process.cwd(), CHECKPOINT_DIR, CHECKPOINT_FILE);
+}
+
+function loadCheckpoint(): Checkpoint | undefined {
+  const path = checkpointPath();
+  if (!existsSync(path)) return undefined;
+  const raw = readFileSync(path, "utf-8");
+  return JSON.parse(raw) as Checkpoint;
+}
+
+function saveCheckpoint(checkpoint: Checkpoint): void {
+  const dir = join(process.cwd(), CHECKPOINT_DIR);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(checkpointPath(), JSON.stringify(checkpoint, null, 2) + "\n", "utf-8");
+}
+
+function clearCheckpointDir(): void {
+  const dir = join(process.cwd(), CHECKPOINT_DIR);
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 export async function run(
   options: RunOptions,
   spawner?: Spawner,
@@ -229,6 +266,28 @@ export async function run(
     }
   }
 
+  // Handle resume / clean start
+  let completedSteps: string[] = [];
+  let resumeFromIndex = 0;
+  let startedAt = new Date().toISOString();
+
+  if (options.resume) {
+    const checkpoint = loadCheckpoint();
+    if (!checkpoint) {
+      throw new RunError("No checkpoint found - cannot resume. Run without --resume first.");
+    }
+    if (options.configHash && checkpoint.configHash !== options.configHash) {
+      throw new RunError(
+        "Config has changed since the last run - cannot resume. Run without --resume to start fresh.",
+      );
+    }
+    completedSteps = checkpoint.completedSteps;
+    resumeFromIndex = checkpoint.currentStepIndex;
+    startedAt = checkpoint.startedAt;
+  } else if (!dryRun) {
+    clearCheckpointDir();
+  }
+
   // Load initial state from state.json if it exists
   const statePath = join(process.cwd(), "state.json");
   let state: Record<string, unknown> = {};
@@ -244,6 +303,14 @@ export async function run(
     }
   }
 
+  // If resuming, restore state from checkpoint
+  if (options.resume) {
+    const checkpoint = loadCheckpoint();
+    if (checkpoint) {
+      state = checkpoint.state;
+    }
+  }
+
   const activeSpawner = dryRun ? undefined : (spawner ?? new ClaudeSpawner());
   const steps: StepResult[] = [];
   const pipelineStart = Date.now();
@@ -251,7 +318,7 @@ export async function run(
   // Track visit counts per node for loop detection
   const visitCounts = new Map<number, number>();
 
-  let currentIndex = 0;
+  let currentIndex = options.resume ? resumeFromIndex : 0;
   let stepNumber = 0;
 
   while (currentIndex >= 0 && currentIndex < nodes.length) {
@@ -359,6 +426,17 @@ export async function run(
         status: "ok",
         attempts: attempts > 1 ? attempts : undefined,
         durationMs: stepDuration,
+      });
+
+      // Save checkpoint after each successful step
+      completedSteps.push(node.skill);
+      const nextIdx = resolveNextIndex(node, currentIndex, nodeLookup, state, dryRun);
+      saveCheckpoint({
+        configHash: options.configHash ?? "",
+        completedSteps,
+        currentStepIndex: nextIdx === -1 ? currentIndex + 1 : nextIdx,
+        state,
+        startedAt,
       });
     } else {
       // Record error in state for debugging


### PR DESCRIPTION
## Summary

- Save execution checkpoint to `.skillfold/run/checkpoint.json` after each completed step so interrupted pipelines can resume from where they left off
- Add `--resume` flag to CLI that reads saved checkpoint and continues from the last completed step
- Validate config hash on resume to detect config changes between runs, failing with a clear message if the config has changed
- Clean runs (no `--resume`) clear any previous checkpoint before starting

## Changes

**`src/run.ts`**
- Add `resume` and `configHash` fields to `RunOptions`
- Add `Checkpoint` interface with `configHash`, `completedSteps`, `currentStepIndex`, `state`, and `startedAt`
- Add checkpoint helpers: `loadCheckpoint`, `saveCheckpoint`, `clearCheckpointDir`, `checkpointPath`
- On resume: load checkpoint, validate config hash, restore state, skip to next uncompleted step
- On clean start: clear `.skillfold/run/` directory
- After each successful step: write checkpoint with current progress and state

**`src/cli.ts`**
- Add `--resume` boolean flag parsing
- Add `resume` to `Args` interface
- Compute SHA-256 config hash from config file content and pass to `run()`
- Add `--resume` to help text

**`src/run.test.ts`**
- Resume from mid-pipeline (checkpoint exists, 2 of 3 steps done, resumes from step 3)
- Resume with no checkpoint throws RunError
- Resume with config hash mismatch throws RunError
- Clean run clears previous checkpoint
- Checkpoint written after each step (verified mid-pipeline via spawner inspection)

**`.gitignore`**
- Add `.skillfold/` to gitignore

## Test plan

- [x] All 800 tests pass (5 new checkpoint/resume tests)
- [x] `npx tsc --noEmit` passes with no type errors
- [ ] Manual test: `skillfold run --target claude-code` creates checkpoint, `skillfold run --target claude-code --resume` resumes

Closes #435