### PR TITLE
feat: add map/parallel execution to skillfold run

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -467,9 +467,17 @@ async function main(): Promise<void> {
             step.status === "skipped" ? (step.error ? "skip" : "skip (async)") :
             "FAIL";
           const errorSuffix = step.status === "error" && step.error ? `: ${step.error}` : "";
-          process.stderr.write(
-            `  ${statusLabel.padEnd(12)} ${step.agent}${retries}${duration}${errorSuffix}\n`,
-          );
+          if (step.agent === "map" && step.mapItems) {
+            const okItems = step.mapItems.filter(i => i.status === "ok").length;
+            const failItems = step.mapItems.filter(i => i.status === "error").length;
+            process.stderr.write(
+              `  ${statusLabel.padEnd(12)} map (${step.mapItems.length} items: ${okItems} ok, ${failItems} failed)${duration}\n`,
+            );
+          } else {
+            process.stderr.write(
+              `  ${statusLabel.padEnd(12)} ${step.agent}${retries}${duration}${errorSuffix}\n`,
+            );
+          }
         }
 
         const okCount = result.steps.filter(s => s.status === "ok").length;

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export type { AdoptedAgent, AdoptResult } from "./adopt.js";
 
 // Pipeline execution
 export { ClaudeSpawner, run } from "./run.js";
-export type { RunOptions, RunResult, Spawner, StepResult } from "./run.js";
+export type { MapItemResult, RunOptions, RunResult, Spawner, StepResult } from "./run.js";
 
 // Errors
 export {

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -771,26 +771,6 @@ describe("run", () => {
   });
 
   describe("unsupported features", () => {
-    it("map node produces clear error", async () => {
-      const config = makeConfig({
-        nodes: [
-          { over: "state.items", as: "item", flow: [] },
-        ],
-      });
-
-      await assert.rejects(
-        () => run(
-          { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
-          mockSpawner({}),
-        ),
-        (err: Error) => {
-          assert.ok(err instanceof RunError);
-          assert.ok(err.message.includes("map nodes not supported"));
-          return true;
-        },
-      );
-    });
-
     it("sub-flow node produces clear error", async () => {
       const config = makeConfig({
         nodes: [
@@ -1606,6 +1586,576 @@ describe("run", () => {
       ) as Checkpoint;
       assert.deepEqual(finalCheckpoint.completedSteps, ["planner", "engineer"]);
       assert.equal(finalCheckpoint.state.code, "done");
+    });
+  });
+
+  describe("map execution", () => {
+    it("executes subgraph for each item in parallel", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      // Pre-seed state with a list of items
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: [
+          { title: "task-a", output: "" },
+          { title: "task-b", output: "" },
+        ],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: ["task.title"], writes: ["task.output"] },
+            ],
+          },
+        ],
+      });
+
+      const { spawner, calls } = recordingSpawner({
+        engineer: { output: "done" },
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      // Both items should have been processed
+      assert.equal(calls.length, 2);
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].agent, "map");
+      assert.equal(result.steps[0].status, "ok");
+      assert.ok(result.steps[0].mapItems);
+      assert.equal(result.steps[0].mapItems!.length, 2);
+      assert.equal(result.steps[0].mapItems![0].status, "ok");
+      assert.equal(result.steps[0].mapItems![1].status, "ok");
+
+      // State should have updated items
+      const tasks = result.state.tasks as Array<{ title: string; output: string }>;
+      assert.equal(tasks[0].output, "done");
+      assert.equal(tasks[1].output, "done");
+    });
+
+    it("scopes item state correctly per item", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: [
+          { title: "first" },
+          { title: "second" },
+        ],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: ["task.title"], writes: ["task.output"] },
+            ],
+          },
+        ],
+      });
+
+      // Return different output per call to verify scoped state
+      const callStates: Array<Record<string, unknown>> = [];
+      const spawner: Spawner = {
+        async spawn(_agentName: string, _skillContent: string, state: Record<string, unknown>) {
+          callStates.push(JSON.parse(JSON.stringify(state)));
+          const task = state.task as Record<string, unknown>;
+          return { output: `processed-${task.title}` };
+        },
+      };
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      // Each call should have received scoped state with the task variable
+      assert.equal(callStates.length, 2);
+      assert.deepEqual((callStates[0].task as Record<string, unknown>).title, "first");
+      assert.deepEqual((callStates[1].task as Record<string, unknown>).title, "second");
+
+      const tasks = result.state.tasks as Array<{ title: string; output: string }>;
+      assert.equal(tasks[0].output, "processed-first");
+      assert.equal(tasks[1].output, "processed-second");
+    });
+
+    it("handles empty list gracefully", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({ tasks: [] }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: [], writes: ["task.output"] },
+            ],
+          },
+        ],
+      });
+
+      const { spawner, calls } = recordingSpawner({});
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(calls.length, 0);
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[0].mapItems!.length, 0);
+    });
+
+    it("map with multi-step subgraph executes steps in order per item", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: [{ title: "task-1" }],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: ["task.title"], writes: ["task.output"], then: "reviewer" },
+              { skill: "reviewer", reads: ["task.output"], writes: ["task.approved"] },
+            ],
+          },
+        ],
+      });
+
+      const callOrder: string[] = [];
+      const spawner: Spawner = {
+        async spawn(agentName: string) {
+          callOrder.push(agentName);
+          if (agentName === "engineer") return { output: "code" };
+          return { approved: true };
+        },
+      };
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.deepEqual(callOrder, ["engineer", "reviewer"]);
+      assert.equal(result.steps[0].mapItems![0].steps.length, 2);
+      assert.equal(result.steps[0].mapItems![0].steps[0].agent, "engineer");
+      assert.equal(result.steps[0].mapItems![0].steps[1].agent, "reviewer");
+
+      const tasks = result.state.tasks as Array<{ output: string; approved: boolean }>;
+      assert.equal(tasks[0].output, "code");
+      assert.equal(tasks[0].approved, true);
+    });
+
+    it("map with conditional routing in subgraph", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: [{ title: "task-1" }],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: ["task.title"], writes: ["task.output"], then: "reviewer" },
+              {
+                skill: "reviewer",
+                reads: ["task.output"],
+                writes: ["task.approved"],
+                then: [
+                  { when: "task.approved == false", to: "engineer" },
+                  { when: "task.approved == true", to: "end" },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      // Engineer runs twice, reviewer approves on second pass
+      let engineerCalls = 0;
+      let reviewerCalls = 0;
+      const spawner: Spawner = {
+        async spawn(agentName: string) {
+          if (agentName === "engineer") {
+            engineerCalls++;
+            return { output: `code-v${engineerCalls}` };
+          }
+          reviewerCalls++;
+          return { approved: reviewerCalls >= 2 };
+        },
+      };
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(engineerCalls, 2);
+      assert.equal(reviewerCalls, 2);
+      const tasks = result.state.tasks as Array<{ approved: boolean }>;
+      assert.equal(tasks[0].approved, true);
+    });
+
+    it("per-item error handling with abort mode", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: [{ title: "good" }, { title: "bad" }],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: ["task.title"], writes: ["task.output"] },
+            ],
+          },
+        ],
+      });
+
+      const spawner: Spawner = {
+        async spawn(_agentName: string, _skillContent: string, state: Record<string, unknown>) {
+          const task = state.task as Record<string, unknown>;
+          if (task.title === "bad") throw new Error("Item failed");
+          return { output: "ok" };
+        },
+      };
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "abort" },
+        spawner,
+      );
+
+      // Map step should report error because at least one item failed
+      assert.equal(result.steps[0].status, "error");
+      const items = result.steps[0].mapItems!;
+      // One should be ok, one should be error (order may vary since parallel)
+      const okItems = items.filter(i => i.status === "ok");
+      const errorItems = items.filter(i => i.status === "error");
+      assert.equal(okItems.length, 1);
+      assert.equal(errorItems.length, 1);
+    });
+
+    it("per-item error handling with skip mode", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: [{ title: "good" }, { title: "bad" }],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: ["task.title"], writes: ["task.output"] },
+            ],
+          },
+        ],
+      });
+
+      const spawner: Spawner = {
+        async spawn(_agentName: string, _skillContent: string, state: Record<string, unknown>) {
+          const task = state.task as Record<string, unknown>;
+          if (task.title === "bad") throw new Error("Item failed");
+          return { output: "ok" };
+        },
+      };
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "skip" },
+        spawner,
+      );
+
+      // With skip mode, overall map step should be ok
+      assert.equal(result.steps[0].status, "ok");
+    });
+
+    it("map before and after linear steps", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        plan: "",
+        tasks: [{ title: "task-1" }],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          { skill: "planner", reads: [], writes: ["state.plan", "state.tasks"] },
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: ["task.title"], writes: ["task.output"] },
+            ],
+            then: "reviewer",
+          },
+          { skill: "reviewer", reads: ["state.tasks"], writes: ["state.review"] },
+        ],
+      });
+
+      const spawner: Spawner = {
+        async spawn(agentName: string) {
+          if (agentName === "planner") return { plan: "planned", tasks: [{ title: "task-1" }] };
+          if (agentName === "engineer") return { output: "coded" };
+          return { review: "approved" };
+        },
+      };
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(result.steps.length, 3);
+      assert.equal(result.steps[0].agent, "planner");
+      assert.equal(result.steps[0].status, "ok");
+      assert.equal(result.steps[1].agent, "map");
+      assert.equal(result.steps[1].status, "ok");
+      assert.equal(result.steps[2].agent, "reviewer");
+      assert.equal(result.steps[2].status, "ok");
+    });
+
+    it("dry run logs map steps without executing", async () => {
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: ["task.title"], writes: ["task.output"] },
+            ],
+          },
+        ],
+      });
+
+      // Pre-set state for dry run to read
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: true },
+        mockSpawner({}),
+      );
+
+      assert.equal(result.steps.length, 1);
+      assert.equal(result.steps[0].agent, "map");
+      assert.equal(result.steps[0].status, "skipped");
+    });
+
+    it("errors when over field is not an array", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: "not-an-array",
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: [], writes: ["task.output"] },
+            ],
+          },
+        ],
+      });
+
+      await assert.rejects(
+        () => run(
+          { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+          mockSpawner({}),
+        ),
+        (err: Error) => {
+          assert.ok(err instanceof RunError);
+          assert.ok(err.message.includes("not an array"));
+          return true;
+        },
+      );
+    });
+
+    it("map item timing is recorded", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: [{ title: "a" }, { title: "b" }],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: [], writes: ["task.output"] },
+            ],
+          },
+        ],
+      });
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({ engineer: { output: "done" } }),
+      );
+
+      assert.ok(result.steps[0].durationMs! >= 0);
+      for (const item of result.steps[0].mapItems!) {
+        assert.equal(typeof item.durationMs, "number");
+        assert.ok(item.durationMs! >= 0);
+      }
+    });
+
+    it("map with retry on per-item error", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: [{ title: "flaky" }],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: ["task.title"], writes: ["task.output"] },
+            ],
+          },
+        ],
+      });
+
+      let attempts = 0;
+      const spawner: Spawner = {
+        async spawn() {
+          attempts++;
+          if (attempts < 2) throw new Error("Transient failure");
+          return { output: "recovered" };
+        },
+      };
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false, onError: "retry", maxRetries: 3 },
+        spawner,
+      );
+
+      assert.equal(result.steps[0].status, "ok");
+      const tasks = result.state.tasks as Array<{ output: string }>;
+      assert.equal(tasks[0].output, "recovered");
+    });
+
+    it("map writes state.json after completion", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: [{ title: "a" }],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: [], writes: ["task.output"] },
+            ],
+          },
+        ],
+      });
+
+      await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        mockSpawner({ engineer: { output: "done" } }),
+      );
+
+      const saved = JSON.parse(readFileSync(join(tmpDir, "state.json"), "utf-8")) as { tasks: Array<{ output: string }> };
+      assert.equal(saved.tasks[0].output, "done");
+    });
+
+    it("async nodes inside map subgraph are skipped", async () => {
+      tmpDir = makeTmpDir();
+      origCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      writeFileSync(join(tmpDir, "state.json"), JSON.stringify({
+        tasks: [{ title: "a" }],
+      }));
+
+      const config = makeConfig({
+        nodes: [
+          {
+            over: "state.tasks",
+            as: "task",
+            flow: [
+              { skill: "engineer", reads: [], writes: ["task.output"], then: "human" },
+              { name: "human", async: true as const, reads: [], writes: ["task.feedback"], policy: "skip" as const, then: "reviewer" },
+              { skill: "reviewer", reads: ["task.feedback"], writes: ["task.approved"] },
+            ],
+          },
+        ],
+      });
+
+      const spawner: Spawner = {
+        async spawn(agentName: string) {
+          if (agentName === "engineer") return { output: "code" };
+          return { approved: true };
+        },
+      };
+
+      const result = await run(
+        { config, bodies: makeBodies(), target: "claude-code", outDir: "build", dryRun: false },
+        spawner,
+      );
+
+      assert.equal(result.steps[0].status, "ok");
+      const itemSteps = result.steps[0].mapItems![0].steps;
+      assert.equal(itemSteps.length, 3);
+      assert.equal(itemSteps[0].agent, "engineer");
+      assert.equal(itemSteps[0].status, "ok");
+      assert.equal(itemSteps[1].agent, "human");
+      assert.equal(itemSteps[1].status, "skipped");
+      assert.equal(itemSteps[2].agent, "reviewer");
+      assert.equal(itemSteps[2].status, "ok");
     });
   });
 });

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ import { RunError } from "./errors.js";
 import {
   type ConditionalBranch,
   type GraphNode,
+  type MapNode,
   isAsyncNode,
   isConditionalThen,
   isMapNode,
@@ -42,6 +43,16 @@ export interface Checkpoint {
   currentStepIndex: number;
   state: Record<string, unknown>;
   startedAt: string;
+  /** Tracks completed item indices for map nodes during resume. */
+  completedMapItems?: Record<string, number[]>;
+}
+
+export interface MapItemResult {
+  index: number;
+  status: "ok" | "error" | "skipped";
+  steps: StepResult[];
+  error?: string;
+  durationMs?: number;
 }
 
 export interface StepResult {
@@ -51,6 +62,7 @@ export interface StepResult {
   error?: string;
   attempts?: number;
   durationMs?: number;
+  mapItems?: MapItemResult[];
 }
 
 export interface RunResult {
@@ -241,6 +253,347 @@ function clearCheckpointDir(): void {
   }
 }
 
+interface MapExecutionResult {
+  stepResult: StepResult;
+  updatedItems: unknown[];
+}
+
+/**
+ * Execute a map node by running its subgraph for each item in the list concurrently.
+ */
+async function executeMapNode(
+  node: MapNode,
+  stepNumber: number,
+  state: Record<string, unknown>,
+  composedBodies: Map<string, string>,
+  spawner: Spawner | undefined,
+  dryRun: boolean,
+  onError: OnErrorMode,
+  maxRetries: number,
+  maxIterations: number,
+  _completedSteps: string[],
+  _configHash: string,
+  _startedAt: string,
+  _currentIndex: number,
+): Promise<MapExecutionResult> {
+  const overField = stripStatePrefix(node.over);
+  const items = state[overField];
+
+  if (dryRun) {
+    const count = Array.isArray(items) ? items.length : 0;
+    process.stderr.write(
+      `Step ${stepNumber}: map over ${node.over} (${count} items)\n`,
+    );
+    for (let si = 0; si < node.flow.length; si++) {
+      const subNode = node.flow[si];
+      const subLabel = nodeLabel(subNode);
+      process.stderr.write(
+        `  Step ${stepNumber}.${si + 1}: ${subLabel}\n`,
+      );
+    }
+    return {
+      stepResult: {
+        step: stepNumber,
+        agent: "map",
+        status: "skipped",
+        mapItems: Array.isArray(items)
+          ? items.map((_, i) => ({ index: i, status: "skipped" as const, steps: [] as StepResult[] }))
+          : [],
+      },
+      updatedItems: Array.isArray(items) ? items : [],
+    };
+  }
+
+  if (!Array.isArray(items)) {
+    throw new RunError(
+      `Step ${stepNumber} "map": "${node.over}" is not an array in current state`,
+    );
+  }
+
+  const mapStart = Date.now();
+
+  // Execute all items concurrently
+  const itemPromises = items.map((item, itemIndex) =>
+    executeMapItem(
+      node,
+      stepNumber,
+      itemIndex,
+      item,
+      state,
+      composedBodies,
+      spawner!,
+      onError,
+      maxRetries,
+      maxIterations,
+    ),
+  );
+
+  const itemResults = await Promise.allSettled(itemPromises);
+
+  const mapItems: MapItemResult[] = [];
+  const updatedItems: unknown[] = [...items];
+  let hasError = false;
+
+  for (let i = 0; i < itemResults.length; i++) {
+    const result = itemResults[i];
+    if (result.status === "fulfilled") {
+      mapItems.push(result.value.itemResult);
+      updatedItems[i] = result.value.updatedItem;
+      if (result.value.itemResult.status === "error") {
+        hasError = true;
+      }
+    } else {
+      hasError = true;
+      mapItems.push({
+        index: i,
+        status: "error",
+        steps: [],
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      });
+    }
+  }
+
+  const mapDuration = Date.now() - mapStart;
+
+  // Determine overall map status
+  const allOk = mapItems.every(r => r.status === "ok" || r.status === "skipped");
+  const overallStatus: "ok" | "error" | "skipped" =
+    allOk ? "ok" : (onError === "skip" ? "ok" : "error");
+
+  return {
+    stepResult: {
+      step: stepNumber,
+      agent: "map",
+      status: overallStatus,
+      durationMs: mapDuration,
+      mapItems,
+    },
+    updatedItems,
+  };
+}
+
+interface MapItemExecutionResult {
+  itemResult: MapItemResult;
+  updatedItem: unknown;
+}
+
+/**
+ * Execute the subgraph for a single map item.
+ */
+async function executeMapItem(
+  node: MapNode,
+  parentStep: number,
+  itemIndex: number,
+  item: unknown,
+  parentState: Record<string, unknown>,
+  composedBodies: Map<string, string>,
+  spawner: Spawner,
+  onError: OnErrorMode,
+  maxRetries: number,
+  maxIterations: number,
+): Promise<MapItemExecutionResult> {
+  const subNodes = node.flow;
+  const subSteps: StepResult[] = [];
+  const itemStart = Date.now();
+
+  // The item scope: reads/writes using node.as prefix access fields on the item
+  let currentItem: Record<string, unknown> =
+    typeof item === "object" && item !== null ? { ...(item as Record<string, unknown>) } : {};
+
+  // Build node lookup for the subgraph
+  const subNodeLookup = new Map<string, number>();
+  for (let i = 0; i < subNodes.length; i++) {
+    const label = nodeLabel(subNodes[i]);
+    if (!subNodeLookup.has(label)) {
+      subNodeLookup.set(label, i);
+    }
+  }
+
+  const visitCounts = new Map<number, number>();
+  let subIndex = 0;
+  let subStepNumber = 0;
+
+  while (subIndex >= 0 && subIndex < subNodes.length) {
+    const subNode = subNodes[subIndex];
+    subStepNumber++;
+    const subLabel = nodeLabel(subNode);
+
+    // Loop detection
+    const visits = (visitCounts.get(subIndex) ?? 0) + 1;
+    visitCounts.set(subIndex, visits);
+    if (visits > maxIterations) {
+      throw new RunError(
+        `Step ${parentStep}.${subStepNumber} "${subLabel}" (item ${itemIndex}): exceeded max iterations (${maxIterations})`,
+      );
+    }
+
+    if (isAsyncNode(subNode)) {
+      subSteps.push({
+        step: subStepNumber,
+        agent: subLabel,
+        status: "skipped",
+      });
+      const nextIdx = resolveSubgraphNext(subNode, subIndex, subNodeLookup, parentState, currentItem, node.as);
+      if (nextIdx === -1) break;
+      subIndex = nextIdx;
+      continue;
+    }
+
+    if (isMapNode(subNode) || isSubFlowNode(subNode)) {
+      throw new RunError(
+        `Step ${parentStep}.${subStepNumber} "${subLabel}" (item ${itemIndex}): nested map/sub-flow nodes not supported inside map subgraphs`,
+      );
+    }
+
+    // StepNode
+    const skillBody = composedBodies.get(subNode.skill);
+    if (!skillBody) {
+      throw new RunError(
+        `Step ${parentStep}.${subStepNumber} "${subNode.skill}" (item ${itemIndex}): no composed skill body found`,
+      );
+    }
+
+    // Build scoped state for this spawn: parent state + item fields under node.as
+    const scopedState: Record<string, unknown> = { ...parentState, [node.as]: currentItem };
+
+    const stepStart = Date.now();
+    let stepSucceeded = false;
+    let lastError: string | undefined;
+    let attempts = 0;
+    const attemptsAllowed = onError === "retry" ? maxRetries : 1;
+
+    for (let attempt = 1; attempt <= attemptsAllowed; attempt++) {
+      attempts = attempt;
+      try {
+        const updates = await spawner.spawn(subNode.skill, skillBody, scopedState);
+
+        // Apply updates to item scope (node.as prefix) and parent state scope
+        for (const writePath of subNode.writes) {
+          if (writePath.startsWith(node.as + ".")) {
+            const field = writePath.slice(node.as.length + 1);
+            if (field in updates) {
+              currentItem[field] = updates[field];
+            }
+          } else {
+            const field = stripStatePrefix(writePath);
+            if (field in updates) {
+              parentState[field] = updates[field];
+            }
+          }
+        }
+
+        stepSucceeded = true;
+        break;
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    const stepDuration = Date.now() - stepStart;
+
+    if (stepSucceeded) {
+      subSteps.push({
+        step: subStepNumber,
+        agent: subNode.skill,
+        status: "ok",
+        attempts: attempts > 1 ? attempts : undefined,
+        durationMs: stepDuration,
+      });
+    } else if (onError === "skip") {
+      subSteps.push({
+        step: subStepNumber,
+        agent: subNode.skill,
+        status: "skipped",
+        error: lastError,
+        attempts,
+        durationMs: stepDuration,
+      });
+    } else {
+      subSteps.push({
+        step: subStepNumber,
+        agent: subNode.skill,
+        status: "error",
+        error: lastError,
+        attempts: onError === "retry" ? attempts : undefined,
+        durationMs: stepDuration,
+      });
+      const itemDuration = Date.now() - itemStart;
+      return {
+        itemResult: {
+          index: itemIndex,
+          status: "error",
+          steps: subSteps,
+          error: lastError,
+          durationMs: itemDuration,
+        },
+        updatedItem: currentItem,
+      };
+    }
+
+    // Resolve next subgraph node
+    const nextIdx = resolveSubgraphNext(subNode, subIndex, subNodeLookup, parentState, currentItem, node.as);
+    if (nextIdx === -1) break;
+    subIndex = nextIdx;
+  }
+
+  const itemDuration = Date.now() - itemStart;
+  return {
+    itemResult: {
+      index: itemIndex,
+      status: "ok",
+      steps: subSteps,
+      durationMs: itemDuration,
+    },
+    updatedItem: currentItem,
+  };
+}
+
+/**
+ * Resolve the next node index within a map subgraph.
+ * When-clauses can reference both parent state and item-scoped fields.
+ */
+function resolveSubgraphNext(
+  node: GraphNode,
+  currentIndex: number,
+  nodeLookup: Map<string, number>,
+  parentState: Record<string, unknown>,
+  currentItem: Record<string, unknown>,
+  asName: string,
+): number {
+  if (node.then === undefined) {
+    return currentIndex + 1;
+  }
+
+  if (isConditionalThen(node.then)) {
+    // Build a merged state view for when-clause evaluation
+    const mergedState: Record<string, unknown> = { ...parentState, [asName]: currentItem };
+    const target = resolveConditionalTarget(node.then, mergedState);
+    if (target === undefined) {
+      throw new RunError(
+        `Map subgraph step "${nodeLabel(node)}": no conditional branch matched current state`,
+      );
+    }
+    if (target === "end") return -1;
+    const idx = nodeLookup.get(target);
+    if (idx === undefined) {
+      throw new RunError(
+        `Map subgraph step "${nodeLabel(node)}": conditional target "${target}" not found`,
+      );
+    }
+    return idx;
+  }
+
+  if (node.then === "end") return -1;
+
+  const idx = nodeLookup.get(node.then);
+  if (idx === undefined) {
+    throw new RunError(
+      `Map subgraph step "${nodeLabel(node)}": target "${node.then}" not found`,
+    );
+  }
+  return idx;
+}
+
 export async function run(
   options: RunOptions,
   spawner?: Spawner,
@@ -336,9 +689,47 @@ export async function run(
     }
 
     if (isMapNode(node)) {
-      throw new RunError(
-        `Step ${stepNumber} "map": map nodes not supported in skillfold run - use the orchestrator`,
+      const mapResult = await executeMapNode(
+        node,
+        stepNumber,
+        state,
+        composedBodies,
+        activeSpawner,
+        dryRun,
+        onError,
+        maxRetries,
+        maxIterations,
+        completedSteps,
+        options.configHash ?? "",
+        startedAt,
+        currentIndex,
       );
+      steps.push(mapResult.stepResult);
+
+      if (!dryRun) {
+        // Merge map results back into the list in state
+        const overField = stripStatePrefix(node.over);
+        state[overField] = mapResult.updatedItems;
+        writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n", "utf-8");
+
+        completedSteps.push("map");
+        const nextIdx = resolveNextIndex(node, currentIndex, nodeLookup, state, dryRun);
+        saveCheckpoint({
+          configHash: options.configHash ?? "",
+          completedSteps,
+          currentStepIndex: nextIdx === -1 ? currentIndex + 1 : nextIdx,
+          state,
+          startedAt,
+        });
+      }
+
+      // If any item errored and we're in abort mode, stop
+      if (mapResult.stepResult.status === "error") break;
+
+      const nextIndex = resolveNextIndex(node, currentIndex, nodeLookup, state, dryRun);
+      if (nextIndex === -1) break;
+      currentIndex = nextIndex;
+      continue;
     }
 
     if (isSubFlowNode(node)) {


### PR DESCRIPTION
**[engineer]**

## Summary

- Implement parallel map execution in `skillfold run`, replacing the previous "not supported" error
- Each map item runs its subgraph concurrently via `Promise.allSettled()`
- Scoped state binding per item (the `as` variable is bound to each list element)
- Per-item error handling respects `--on-error` modes (abort/skip/retry)
- Conditional routing and loop detection within map subgraphs
- Async nodes inside map subgraphs are skipped
- CLI execution summary shows map item counts
- `MapItemResult` type exported from public API

## Test plan

- [x] 13 new tests covering: basic parallel execution, scoped state, empty list, multi-step subgraphs, conditional routing in subgraphs, per-item abort/skip error handling, map before/after linear steps, dry-run mode, non-array error, item timing, retry within map, state persistence, async nodes in subgraphs
- [x] All 813 tests pass
- [x] `npx tsc --noEmit` clean

Closes #443

Generated with [Claude Code](https://claude.com/claude-code)