### PR TITLE
docs: add skillfold run guide and update CLI reference

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
           { text: "Live Demo", link: "/demo" },
           { text: "Pipeline Builder", link: "/builder" },
           { text: "Examples", link: "/examples" },
+          { text: "Running Pipelines", link: "/running-pipelines" },
           { text: "Platform Integration", link: "/integrations" },
           { text: "Publishing Skills", link: "/publishing" },
           { text: "Authoring Skills", link: "/authoring" },

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -116,31 +116,36 @@ The `--html` output includes clickable nodes, a composition details sidebar, and
 
 ### Run
 
-Execute a compiled pipeline by spawning agents sequentially. Currently supports linear flows only (no conditionals, map, or sub-flows).
+Execute a compiled pipeline by spawning agents through the flow graph. Supports linear flows, conditional routing, loops, and parallel map execution.
 
 ```bash
-npx skillfold run --target claude-code             # execute the pipeline
-npx skillfold run --target claude-code --dry-run   # preview without running
-npx skillfold run --target claude-code --config my-pipeline.yaml
+npx skillfold run --target claude-code                            # execute the pipeline
+npx skillfold run --target claude-code --dry-run                  # preview without running
+npx skillfold run --target claude-code --resume                   # resume from checkpoint
+npx skillfold run --target claude-code --on-error retry           # retry failed steps
+npx skillfold run --target claude-code --config my-pipeline.yaml  # custom config
 ```
 
-Requires a `--target` flag (cannot use the default `skill` target). The `--dry-run` flag prints each step with its reads and writes without spawning any agents.
+Requires a `--target` flag. See the [Running Pipelines](/running-pipelines) guide for full documentation.
 
-**State management**: The runner reads and writes `state.json` in the working directory. Before each step, the current state is passed to the agent. After each step, the agent's state updates are merged back. Only fields declared in the node's `writes` are persisted.
-
-**Async nodes**: Async nodes (external agents, humans) are skipped automatically. Execution continues to the next step.
-
-**Current limitations**:
-- Linear flows only (no conditional routing, no map/parallel, no sub-flows)
-- Requires the `claude` CLI to be installed for agent spawning
-- Agents output state updates via a JSON code block with a `stateUpdates` key
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--target` | (required) | Compilation target (`claude-code`) |
+| `--config` | `skillfold.yaml` | Path to pipeline config |
+| `--dry-run` | `false` | Preview without executing |
+| `--on-error` | `abort` | Error mode: `abort`, `skip`, or `retry` |
+| `--max-retries` | `3` | Max retry attempts (with `--on-error retry`) |
+| `--max-iterations` | `10` | Max visits per node (loop guard) |
+| `--resume` | `false` | Resume from last checkpoint |
 
 Example dry-run output:
 
 ```
 skillfold: dry run for my-pipeline (3 steps)
 Step 1: planner reads=[direction] writes=[plan]
-Step 2: engineer reads=[plan] writes=[code]
+Step 2: map over state.tasks (3 items)
+  Step 2.1: engineer
+  Step 2.2: reviewer
 Step 3: reviewer reads=[code] writes=[review]
 ```
 

--- a/docs/running-pipelines.md
+++ b/docs/running-pipelines.md
@@ -1,0 +1,173 @@
+# Running Pipelines
+
+Skillfold can execute your pipeline directly, spawning agents in sequence and managing state between steps.
+
+## Basic Usage
+
+```bash
+npx skillfold run --target claude-code
+```
+
+This compiles the pipeline and executes it step by step. Each agent in the flow is spawned via the Claude CLI, receives the current state, and returns state updates.
+
+The `--target` flag is required. Currently `claude-code` is the only supported execution target.
+
+## How It Works
+
+1. The runner reads your `skillfold.yaml` and compiles agent skills
+2. It walks the flow graph node by node
+3. For each step node, it spawns the agent with its compiled skill and current state
+4. The agent returns state updates, which are applied before the next step
+5. State is persisted to `state.json` after each step
+
+## Dry Run
+
+Preview the execution plan without spawning agents:
+
+```bash
+npx skillfold run --target claude-code --dry-run
+```
+
+Output shows each step with its reads and writes:
+
+```
+Step 1: planner reads=[direction] writes=[plan, tasks]
+Step 2: engineer reads=[plan, tasks] writes=[implementation]
+Step 3: reviewer reads=[implementation] writes=[review]
+```
+
+## Error Handling
+
+Control what happens when an agent fails with `--on-error`:
+
+```bash
+# Stop the pipeline on first error (default)
+npx skillfold run --target claude-code --on-error abort
+
+# Skip the failed step and continue
+npx skillfold run --target claude-code --on-error skip
+
+# Retry the failed step up to N times
+npx skillfold run --target claude-code --on-error retry --max-retries 3
+```
+
+In `retry` mode, the runner will attempt the step up to `--max-retries` times (default: 3) before falling through to abort behavior.
+
+Errors are recorded in `state.json` under the `_errors` array for debugging.
+
+## Loop Guards
+
+Pipelines with conditional routing can create loops (e.g., engineer -> reviewer -> engineer). The `--max-iterations` flag prevents infinite loops:
+
+```bash
+npx skillfold run --target claude-code --max-iterations 5
+```
+
+The default is 10 iterations per node. If a node is visited more than this limit, the runner throws an error.
+
+## Resume from Checkpoint
+
+If a pipeline is interrupted, resume from the last completed step:
+
+```bash
+npx skillfold run --target claude-code --resume
+```
+
+The runner saves a checkpoint after each step to `.skillfold/run/checkpoint.json`. On resume, it:
+
+1. Loads the checkpoint and validates the config hash matches
+2. Restores the state from the checkpoint
+3. Skips already-completed steps
+4. Continues execution from where it left off
+
+If the config has changed since the interrupted run, the runner rejects the resume and asks you to start fresh.
+
+To start a fresh run (clearing any previous checkpoint):
+
+```bash
+npx skillfold run --target claude-code
+```
+
+## Parallel Map Execution
+
+When the flow includes a `map` node, the runner executes the subgraph for each item in the list concurrently:
+
+```yaml
+team:
+  flow:
+    - planner:
+        writes: [state.tasks]
+      then: map
+
+    - map:
+        over: state.tasks
+        as: task
+        flow:
+          - engineer:
+              reads: [task.description]
+              writes: [task.output]
+            then: reviewer
+          - reviewer:
+              reads: [task.output]
+              writes: [task.approved]
+      then: end
+```
+
+Each item runs its own subgraph independently with isolated state. The `task` variable is bound to the current item. Error handling (`--on-error`) applies per item.
+
+The execution summary shows map item counts:
+
+```
+  pass         planner (2s)
+  pass         map (3 items: 3 ok, 0 failed) (8s)
+```
+
+## Async Nodes
+
+Async nodes (representing external agents like humans or CI) are automatically skipped during execution. The runner continues past them to the next step.
+
+## Execution Summary
+
+After execution, the runner prints a summary:
+
+```
+  pass         planner (1s)
+  pass         engineer [2 attempts] (5s)
+  skip (async) human-review
+  pass         reviewer (2s)
+
+skillfold: 3 passed, 1 skipped in 8s
+```
+
+Each step shows its status, agent name, retry count (if applicable), and duration.
+
+## State Persistence
+
+State is managed in two locations:
+
+| File | Purpose |
+|------|---------|
+| `state.json` | Working state, updated after each step |
+| `.skillfold/run/checkpoint.json` | Execution checkpoint for resume |
+
+Both files are written to the current working directory. Add `.skillfold/` to your `.gitignore`.
+
+## Custom Config Path
+
+Run a pipeline from a non-default config:
+
+```bash
+npx skillfold run --target claude-code --config path/to/pipeline.yaml
+```
+
+## All Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--target` | (required) | Compilation target (`claude-code`) |
+| `--config` | `skillfold.yaml` | Path to pipeline config |
+| `--dry-run` | `false` | Preview without executing |
+| `--on-error` | `abort` | Error mode: `abort`, `skip`, or `retry` |
+| `--max-retries` | `3` | Max retry attempts (with `--on-error retry`) |
+| `--max-iterations` | `10` | Max visits per node (loop guard) |
+| `--resume` | `false` | Resume from last checkpoint |


### PR DESCRIPTION
**[designer]**

## Summary

- Add comprehensive guide page at `/running-pipelines` covering `skillfold run` usage
- Update CLI reference to reflect current capabilities (conditionals, loops, map, resume)
- Add guide to sidebar navigation

## Sections covered

- Basic usage and how it works
- Dry-run mode
- Error handling (abort/skip/retry)
- Loop guards (--max-iterations)
- Resume from checkpoint
- Parallel map execution
- Async node handling
- Execution summary format
- State persistence locations
- Complete flags reference table

## Test plan

- [x] New page renders correctly in VitePress
- [x] Sidebar navigation updated
- [x] CLI reference reflects current run capabilities

Closes #444

Generated with [Claude Code](https://claude.com/claude-code)