### PR TITLE
docs: update CLI reference, add SDK spawner docs, enrich landing page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -38,6 +38,16 @@ export default defineConfig({
         items: [
           { text: "Config Format", link: "/reference/config" },
           { text: "CLI", link: "/reference/cli" },
+          { text: "Changelog", link: "/changelog" },
+        ],
+      },
+      {
+        text: "Blog",
+        items: [
+          {
+            text: "My Dev Team Is a YAML File",
+            link: "/blog/self-hosting-pipeline",
+          },
         ],
       },
     ],

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,102 @@
+# Changelog
+
+For the full release history with detailed notes, see [GitHub Releases](https://github.com/byronxlg/skillfold/releases).
+
+## v1.19.0
+
+- Agent SDK spawner for `skillfold run` (`--spawner sdk`) - agents get full tool access via `@anthropic-ai/claude-agent-sdk`
+- State backend integration - `skillfold run` reads/writes state from GitHub issues, discussions, and pull requests
+
+## v1.18.0
+
+- `skillfold run` guide and CLI reference documentation
+
+## v1.17.0
+
+- Pipeline execution state persistence and checkpoint-based resume (`--resume`)
+
+## v1.16.0
+
+- Error handling and recovery modes (`--on-error abort|skip|retry`)
+- Step timing and execution summary
+
+## v1.15.0
+
+- `--target gemini` compilation output for Gemini CLI
+- `mcpServers` and `skills` fields in `agentConfig` for Claude Code agent frontmatter
+
+## v1.14.0
+
+- `skillfold init --template` for scaffolding from library example configs
+- `skillfold run` with conditional routing, loops, and `--max-iterations` guard
+
+## v1.13.0
+
+- Parallel map execution for `skillfold run` (concurrent subgraph execution per list item)
+
+## v1.12.0
+
+- `skillfold run` command for pipeline execution with dry-run mode
+
+## v1.11.0
+
+- `@ref` version pinning for GitHub URL skill references (tags and commit SHAs)
+- `skills:` prefix support for Vercel skills CLI interop
+
+## v1.10.0
+
+- `skillfold search` command for discovering pipeline configs on npm
+- `npm:` prefix support for skill references and imports
+
+## v1.9.0
+
+- Sub-flow imports: flow nodes can reference external pipeline configs
+- Async flow nodes for external agents with `async: true`
+
+## v1.8.0
+
+- Top-level `resources` section for resource namespace declarations
+- Built-in state integrations (github-issues, github-discussions, github-pull-requests)
+
+## v1.7.0
+
+- `skillfold adopt` command for importing existing Claude Code agents
+- `--target copilot` compilation output
+
+## v1.6.0
+
+- `--target codex` compilation output (single `AGENTS.md`)
+- `--target windsurf` compilation output
+
+## v1.5.0
+
+- `--target cursor` compilation output (`.cursor/rules/*.mdc`)
+
+## v1.4.0
+
+- `skillfold plugin` command for Claude Code plugin packaging
+- `--target claude-code` compilation output
+
+## v1.3.0
+
+- Shared skills library with 11 generic atomic skills
+- `skillfold.local.yaml` support for local config overrides
+
+## v1.2.0
+
+- `skillfold watch` command for auto-recompile on changes
+- `--check` flag for CI integration
+
+## v1.1.0
+
+- `skillfold validate` and `skillfold list` commands
+- JSON Schema for IDE autocompletion
+
+## v1.0.0
+
+- Initial stable release
+- YAML config with skills (atomic/composed), state, and team sections
+- Recursive skill composition and compilation
+- Team flow graphs with conditional routing and parallel map
+- Typed state schema with validation
+- Orchestrator generation

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,56 @@ features:
     details: Compile to Claude Code agents, Cursor rules, VS Code Copilot instructions, OpenAI Codex, or standard SKILL.md files.
 ---
 
+## What It Looks Like
+
+Define your agent pipeline in YAML:
+
+```yaml
+skills:
+  atomic:
+    planning: npm:skillfold/library/skills/planning
+    code-writing: npm:skillfold/library/skills/code-writing
+    testing: npm:skillfold/library/skills/testing
+  composed:
+    engineer:
+      compose: [planning, code-writing, testing]
+
+state:
+  tasks:
+    type: list<Task>
+    location:
+      github-issues: { repo: my-org/my-repo, label: task }
+
+team:
+  flow:
+    - planner:
+        writes: [state.tasks]
+      then: map
+    - map:
+        over: state.tasks
+        as: task
+        flow:
+          - engineer:
+              reads: [task.description]
+              writes: [task.output]
+      then: end
+```
+
+Compile to any platform:
+
+```bash
+npx skillfold --target claude-code   # .claude/agents/*.md
+npx skillfold --target cursor        # .cursor/rules/*.mdc
+npx skillfold --target codex         # AGENTS.md
+npx skillfold --target gemini        # .gemini/agents/*.md
+```
+
+Or run the pipeline directly:
+
+```bash
+npx skillfold run --target claude-code --spawner sdk
+```
+
 ## How Skillfold Compares to Runtime Orchestration
 
 Skillfold is a compiler, not a runtime framework. It validates your pipeline at compile time and emits plain files that agents read directly. Runtime orchestration tools like CrewAI, AutoGen, and LangGraph take a different approach - they coordinate agents at execution time through a framework process. Both are valid; which one fits depends on your pipeline.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,11 +33,16 @@ Commands:
   --config <path>      Config file (default: skillfold.yaml)
   --out-dir <path>     Output directory (default varies by target)
   --dir <path>         Target directory for init (default: .)
-  --target <mode>      Output mode: skill, claude-code, cursor, windsurf, codex, copilot
+  --target <mode>      Output mode: skill, claude-code, cursor, windsurf, codex, copilot, gemini
   --template <name>    Start from a library template (init only)
   --html               Output interactive HTML instead of Mermaid (graph only)
   --check              Verify compiled output is up-to-date (exit 1 if stale)
   --dry-run            Show execution plan without running (run only)
+  --spawner <type>     Agent spawner: cli (default) or sdk (run only)
+  --on-error <mode>    Error mode: abort (default), skip, or retry (run only)
+  --max-retries <n>    Max retry attempts, default 3 (run only)
+  --max-iterations <n> Max visits per node, default 10 (run only)
+  --resume             Resume from last checkpoint (run only)
   --help               Show this help
   --version            Show version
 ```
@@ -55,6 +60,7 @@ npx skillfold --target cursor              # compile to .cursor/rules/*.mdc
 npx skillfold --target windsurf            # compile to .windsurf/rules/*.md
 npx skillfold --target codex               # compile to build/AGENTS.md
 npx skillfold --target copilot             # compile to .github/ structure
+npx skillfold --target gemini              # compile to .gemini/ structure
 npx skillfold --check                      # verify output is current (CI mode)
 ```
 
@@ -123,6 +129,7 @@ npx skillfold run --target claude-code                            # execute the 
 npx skillfold run --target claude-code --dry-run                  # preview without running
 npx skillfold run --target claude-code --resume                   # resume from checkpoint
 npx skillfold run --target claude-code --on-error retry           # retry failed steps
+npx skillfold run --target claude-code --spawner sdk              # use Agent SDK spawner
 npx skillfold run --target claude-code --config my-pipeline.yaml  # custom config
 ```
 
@@ -133,6 +140,7 @@ Requires a `--target` flag. See the [Running Pipelines](/running-pipelines) guid
 | `--target` | (required) | Compilation target (`claude-code`) |
 | `--config` | `skillfold.yaml` | Path to pipeline config |
 | `--dry-run` | `false` | Preview without executing |
+| `--spawner` | `cli` | Agent spawner: `cli` or `sdk` |
 | `--on-error` | `abort` | Error mode: `abort`, `skip`, or `retry` |
 | `--max-retries` | `3` | Max retry attempts (with `--on-error retry`) |
 | `--max-iterations` | `10` | Max visits per node (loop guard) |

--- a/docs/running-pipelines.md
+++ b/docs/running-pipelines.md
@@ -141,6 +141,38 @@ skillfold: 3 passed, 1 skipped in 8s
 
 Each step shows its status, agent name, retry count (if applicable), and duration.
 
+## Agent Spawners
+
+The runner supports two agent spawners, selected with `--spawner`:
+
+### CLI spawner (default)
+
+```bash
+npx skillfold run --target claude-code --spawner cli
+```
+
+Uses `claude --print` to invoke agents. Each agent receives its compiled skill as a prompt and returns state updates as JSON. No additional dependencies required.
+
+Best for: quick iteration, environments without the Agent SDK installed.
+
+### SDK spawner
+
+```bash
+npx skillfold run --target claude-code --spawner sdk
+```
+
+Uses `@anthropic-ai/claude-agent-sdk` to spawn agents programmatically. Agents get full tool access (Read, Write, Bash, Grep, Glob, etc.), the Claude Code system prompt, and project settings loading.
+
+Install the SDK as a peer dependency:
+
+```bash
+npm install @anthropic-ai/claude-agent-sdk
+```
+
+Best for: production pipelines where agents need to read files, run commands, and interact with the codebase. The SDK spawner gives agents the same capabilities they have in an interactive Claude Code session.
+
+If the SDK is not installed and `--spawner sdk` is specified, the runner exits with an error.
+
 ## State Backends
 
 When state fields declare integration locations, the runner connects to external backends automatically:
@@ -203,6 +235,7 @@ npx skillfold run --target claude-code --config path/to/pipeline.yaml
 | `--target` | (required) | Compilation target (`claude-code`) |
 | `--config` | `skillfold.yaml` | Path to pipeline config |
 | `--dry-run` | `false` | Preview without executing |
+| `--spawner` | `cli` | Agent spawner: `cli` or `sdk` |
 | `--on-error` | `abort` | Error mode: `abort`, `skip`, or `retry` |
 | `--max-retries` | `3` | Max retry attempts (with `--on-error retry`) |
 | `--max-iterations` | `10` | Max visits per node (loop guard) |


### PR DESCRIPTION
## Summary

- Add `gemini` target and `--spawner` flag to CLI reference (all 7 targets now documented)
- Document Agent SDK spawner section in running-pipelines guide with install instructions and usage guidance
- Add YAML config example, compile commands, and run command to VitePress landing page
- Add blog and changelog sections to docs sidebar navigation
- Create changelog page with full version history from v1.0.0 to v1.19.0
- Fix repo homepage URL to point to docs site

Closes #458, closes #459, closes #460

## Test plan

- [x] 830 tests pass
- [ ] Verify docs site builds and renders correctly
- [ ] Check CLI reference lists all flags and targets
- [ ] Check changelog page renders with proper formatting

Direction: Discussion #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)