### PR TITLE
docs: link Agent Teams tutorial from getting-started page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -403,6 +403,7 @@ See the [Publishing Guide](publishing.md) for package structure, required fields
 
 ## 13. Next steps
 
+- **Using Agent Teams?** Follow the [Agent Teams Tutorial](/agent-teams-tutorial) to go from YAML to a running team with `/start-team`
 - Run your pipeline with `skillfold run --target claude-code` (linear flows), or preview with `--dry-run`
 - Read the full config specification in [BRIEF.md](https://github.com/byronxlg/skillfold/blob/main/BRIEF.md)
 - Explore the [shared library examples](https://github.com/byronxlg/skillfold/tree/main/library/examples/) for real pipeline patterns


### PR DESCRIPTION
**[orchestrator]**

## Summary

- Added link to the Agent Teams Tutorial from the Getting Started page's "Next steps" section
- The tutorial itself was already committed in ce0fffe; this completes the cross-linking

Closes #476

## Checklist from #476

- [x] Tutorial exists in docs/
- [x] Can be followed start to finish by someone who has never used skillfold
- [x] Uses `--target agent-teams` as the compilation target
- [x] Shows actual terminal output at each step
- [x] Linked from docs sidebar and getting-started page