### PR TITLE
fix: suggest npm install when npm: imports fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ $ npx skillfold init demo --template dev-team
 skillfold: project initialized
   -> skillfold.yaml
 
-Next: cd demo && npx skillfold
+Next: cd demo && npm install skillfold && npx skillfold
 
-$ cd demo && npx skillfold --target claude-code
+$ cd demo && npm install skillfold && npx skillfold --target claude-code
 skillfold: compiled dev-team
   -> .claude/skills/planner/SKILL.md
   -> .claude/skills/engineer/SKILL.md

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -293,7 +293,11 @@ async function main(): Promise<void> {
       const rel = relative(process.cwd(), abs);
       const cdTarget = rel === "" ? "" : rel.startsWith("..") ? abs : rel;
       const cdPrefix = cdTarget ? `cd ${cdTarget} && ` : "";
-      console.log(`\nNext: ${cdPrefix}npx skillfold`);
+      if (args.template) {
+        console.log(`\nNext: ${cdPrefix}npm install skillfold && npx skillfold`);
+      } else {
+        console.log(`\nNext: ${cdPrefix}npx skillfold`);
+      }
       if (!args.template) {
         console.log(
           "\nTip: import shared skills from the library by uncommenting the imports line in skillfold.yaml"

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -247,6 +247,7 @@ describe("init CLI", () => {
     );
     assert.ok(output.includes("project initialized"));
     assert.ok(existsSync(join(subDir, "skillfold.yaml")));
+    assert.ok(output.includes("npm install skillfold"), "should suggest npm install for template");
 
     const config = readFileSync(join(subDir, "skillfold.yaml"), "utf-8");
     assert.ok(config.includes("name: dev-team"));

--- a/src/npm.test.ts
+++ b/src/npm.test.ts
@@ -303,6 +303,7 @@ skills:
         assert.ok(err instanceof ConfigError);
         assert.match(err.message, /Cannot read npm imported config/);
         assert.match(err.message, /npm:@nonexistent\/package/);
+        assert.match(err.message, /npm install @nonexistent\/package/);
         return true;
       }
     );

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -138,6 +138,24 @@ Review the code carefully.
     assert.ok(body.includes("Review the code carefully."), "Body should contain the body text");
   });
 
+  it("throws ResolveError with npm install hint for missing npm: skill", async () => {
+    tmpDir = makeTmpDir();
+
+    const config: Config = {
+      name: "test",
+      skills: {
+        planning: { path: "npm:@team/shared/skills/planning" },
+      },
+    };
+
+    await assert.rejects(() => resolveSkills(config, tmpDir!), (err: unknown) => {
+      assert.ok(err instanceof ResolveError);
+      assert.match(err.message, /Directory not found/);
+      assert.match(err.message, /npm install @team\/shared/);
+      return true;
+    });
+  });
+
   it("preserves body when no frontmatter present", async () => {
     tmpDir = makeTmpDir();
 


### PR DESCRIPTION
**[engineer]**

## Summary

- When `npm:` imports or skill references fail due to missing `node_modules`, the error messages already suggested `npm install <package>` - this PR adds test coverage verifying those hints are present
- `skillfold init --template` CLI output now suggests `npm install skillfold && npx skillfold` instead of just `npx skillfold`, so users don't hit the error in the first place
- README "See it in action" example updated to show the `npm install skillfold` step for template usage

Closes #499

## Test plan

- [x] Existing npm.test.ts test now asserts `npm install @nonexistent/package` hint in error message
- [x] New resolver.test.ts test verifies `npm install @team/shared` hint for missing npm: skill paths
- [x] init.test.ts "scaffolds from template via CLI" test asserts `npm install skillfold` in CLI output
- [x] All 859 tests pass