### PR TITLE
docs: polish frontend site with custom theme and visual improvements

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -13,8 +13,8 @@ export default defineConfig({
       { text: "Reference", link: "/reference/config" },
       { text: "Builder", link: "/builder" },
       { text: "Demo", link: "/demo" },
+      { text: "Blog", link: "/blog/" },
       { text: "GitHub", link: "https://github.com/byronxlg/skillfold" },
-      { text: "npm", link: "https://www.npmjs.com/package/skillfold" },
     ],
 
     sidebar: [
@@ -46,6 +46,7 @@ export default defineConfig({
       {
         text: "Blog",
         items: [
+          { text: "All Posts", link: "/blog/" },
           {
             text: "My Dev Team Is a YAML File",
             link: "/blog/self-hosting-pipeline",
@@ -60,6 +61,11 @@ export default defineConfig({
 
     socialLinks: [
       { icon: "github", link: "https://github.com/byronxlg/skillfold" },
+      {
+        icon: { svg: '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z" fill="currentColor"/></svg>' },
+        link: "https://www.npmjs.com/package/skillfold",
+        ariaLabel: "npm",
+      },
     ],
 
     editLink: {
@@ -70,6 +76,7 @@ export default defineConfig({
 
     footer: {
       message: "Released under the MIT License.",
+      copyright: "Copyright 2024-present Skillfold Contributors",
     },
   },
 

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from "vitepress/theme";
+import "./styles.css";
+
+export default DefaultTheme;

--- a/docs/.vitepress/theme/styles.css
+++ b/docs/.vitepress/theme/styles.css
@@ -1,0 +1,95 @@
+/* Brand colors */
+:root {
+  --vp-c-brand-1: #10b981;
+  --vp-c-brand-2: #059669;
+  --vp-c-brand-3: #047857;
+  --vp-c-brand-soft: rgba(16, 185, 129, 0.14);
+
+  /* Hero gradient text */
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: -webkit-linear-gradient(
+    120deg,
+    #10b981 30%,
+    #06b6d4
+  );
+
+  /* Hero image glow */
+  --vp-home-hero-image-background-image: linear-gradient(
+    -45deg,
+    #10b981 50%,
+    #06b6d4 50%
+  );
+  --vp-home-hero-image-filter: blur(44px);
+}
+
+.dark {
+  --vp-c-brand-1: #34d399;
+  --vp-c-brand-2: #10b981;
+  --vp-c-brand-3: #059669;
+  --vp-c-brand-soft: rgba(52, 211, 153, 0.14);
+}
+
+/* Subtle hero image glow sizing */
+@media (min-width: 640px) {
+  :root {
+    --vp-home-hero-image-filter: blur(56px);
+  }
+}
+
+@media (min-width: 960px) {
+  :root {
+    --vp-home-hero-image-filter: blur(68px);
+  }
+}
+
+/* Custom homepage sections below the VitePress features grid */
+.vp-doc .targets-section {
+  max-width: 688px;
+  margin: 0 auto;
+  padding: 48px 24px;
+}
+
+.vp-doc .targets-section h2 {
+  text-align: center;
+  font-size: 24px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.vp-doc .targets-section p {
+  text-align: center;
+  color: var(--vp-c-text-2);
+  margin-bottom: 32px;
+}
+
+.vp-doc .targets-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+@media (min-width: 640px) {
+  .vp-doc .targets-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.vp-doc .targets-grid .target {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 16px;
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vp-c-text-1);
+  text-align: center;
+  transition: border-color 0.25s, background-color 0.25s;
+}
+
+.vp-doc .targets-grid .target:hover {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+}

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,0 +1,11 @@
+# Blog
+
+Posts about building and using multi-agent pipelines with Skillfold.
+
+---
+
+## [My Dev Team Is a YAML File](/blog/self-hosting-pipeline)
+
+How skillfold manages its own development with a multi-agent pipeline defined in 128 lines of YAML. Seven AI agents coordinate through a config that the compiler reads, validates, and compiles into the skill files those same agents use.
+
+[Read more ->](/blog/self-hosting-pipeline)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,10 @@ hero:
   name: Skillfold
   text: Typed coordination for multi-agent pipelines
   tagline: Compile YAML configs into agent skills, execution flows, and orchestrators - validated at compile time.
+  image:
+    light: /hero-light.svg
+    dark: /hero-dark.svg
+    alt: Skillfold pipeline diagram
   actions:
     - theme: brand
       text: Get Started
@@ -91,3 +95,28 @@ Skillfold is a compiler, not a runtime framework. It validates your pipeline at 
 | **Best for** | Known pipelines with static topology and typed state | Dynamic workflows where topology changes based on intermediate results |
 
 Runtime tools are the better choice when your pipeline needs to make structural decisions mid-execution - spawning new agents, rewiring flows, or adapting the graph based on intermediate output. Skillfold is the better choice when you know the shape of your pipeline ahead of time and want the compiler to catch errors before anything runs.
+
+<div class="targets-section">
+
+## Compile Once, Run Anywhere
+
+One config, 12 platform targets. Write your pipeline in YAML and compile to whichever agent platform your team uses.
+
+<div class="targets-grid">
+  <div class="target">Claude Code</div>
+  <div class="target">Agent Teams</div>
+  <div class="target">Cursor</div>
+  <div class="target">Windsurf</div>
+  <div class="target">VS Code Copilot</div>
+  <div class="target">OpenAI Codex</div>
+  <div class="target">Gemini CLI</div>
+  <div class="target">Goose</div>
+  <div class="target">Roo Code</div>
+  <div class="target">Kiro</div>
+  <div class="target">Junie</div>
+  <div class="target">SKILL.md</div>
+</div>
+
+[See platform integration details ->](/integrations)
+
+</div>

--- a/docs/public/hero-dark.svg
+++ b/docs/public/hero-dark.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320" fill="none">
+  <!-- Pipeline flow visualization (dark mode) -->
+  <defs>
+    <linearGradient id="grad-dark" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#34d399" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#22d3ee" stop-opacity="0.9"/>
+    </linearGradient>
+    <linearGradient id="line-dark" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#34d399" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#22d3ee" stop-opacity="0.6"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Node: YAML Config (top) -->
+  <rect x="100" y="30" width="120" height="44" rx="10" fill="url(#grad-dark)"/>
+  <text x="160" y="57" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="600" fill="#1a1a2e">YAML</text>
+
+  <!-- Arrow down -->
+  <line x1="160" y1="74" x2="160" y2="110" stroke="url(#line-dark)" stroke-width="2.5" stroke-dasharray="6 4"/>
+  <polygon points="154,106 160,116 166,106" fill="#34d399" opacity="0.7"/>
+
+  <!-- Node: Compiler (center) -->
+  <rect x="85" y="116" width="150" height="44" rx="10" fill="url(#grad-dark)"/>
+  <text x="160" y="143" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="600" fill="#1a1a2e">Compiler</text>
+
+  <!-- Arrow fan-out -->
+  <line x1="120" y1="160" x2="65" y2="210" stroke="url(#line-dark)" stroke-width="2.5" stroke-dasharray="6 4"/>
+  <polygon points="60,205 62,216 72,210" fill="#22d3ee" opacity="0.7"/>
+  <line x1="160" y1="160" x2="160" y2="210" stroke="url(#line-dark)" stroke-width="2.5" stroke-dasharray="6 4"/>
+  <polygon points="154,206 160,216 166,206" fill="#34d399" opacity="0.7"/>
+  <line x1="200" y1="160" x2="255" y2="210" stroke="url(#line-dark)" stroke-width="2.5" stroke-dasharray="6 4"/>
+  <polygon points="248,210 258,216 260,205" fill="#22d3ee" opacity="0.7"/>
+
+  <!-- Output nodes -->
+  <rect x="15" y="216" width="100" height="38" rx="8" fill="#34d399" opacity="0.12" stroke="#34d399" stroke-opacity="0.4" stroke-width="1.5"/>
+  <text x="65" y="240" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="500" fill="#6ee7b7">Claude Code</text>
+
+  <rect x="110" y="216" width="100" height="38" rx="8" fill="#34d399" opacity="0.12" stroke="#34d399" stroke-opacity="0.4" stroke-width="1.5"/>
+  <text x="160" y="240" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="500" fill="#6ee7b7">Cursor</text>
+
+  <rect x="205" y="216" width="100" height="38" rx="8" fill="#22d3ee" opacity="0.12" stroke="#22d3ee" stroke-opacity="0.4" stroke-width="1.5"/>
+  <text x="255" y="240" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="500" fill="#67e8f9">Codex</text>
+
+  <!-- Bottom label -->
+  <text x="160" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#9ca3af">+ 9 more targets</text>
+</svg>

--- a/docs/public/hero-light.svg
+++ b/docs/public/hero-light.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320" fill="none">
+  <!-- Pipeline flow visualization -->
+  <defs>
+    <linearGradient id="grad-light" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#10b981" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0.8"/>
+    </linearGradient>
+    <linearGradient id="line-light" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#10b981" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0.5"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Node: YAML Config (top) -->
+  <rect x="100" y="30" width="120" height="44" rx="10" fill="url(#grad-light)"/>
+  <text x="160" y="57" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="600" fill="white">YAML</text>
+
+  <!-- Arrow down -->
+  <line x1="160" y1="74" x2="160" y2="110" stroke="url(#line-light)" stroke-width="2.5" stroke-dasharray="6 4"/>
+  <polygon points="154,106 160,116 166,106" fill="#10b981" opacity="0.6"/>
+
+  <!-- Node: Compiler (center) -->
+  <rect x="85" y="116" width="150" height="44" rx="10" fill="url(#grad-light)"/>
+  <text x="160" y="143" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="600" fill="white">Compiler</text>
+
+  <!-- Arrow fan-out: three lines going to three output nodes -->
+  <!-- Left -->
+  <line x1="120" y1="160" x2="65" y2="210" stroke="url(#line-light)" stroke-width="2.5" stroke-dasharray="6 4"/>
+  <polygon points="60,205 62,216 72,210" fill="#06b6d4" opacity="0.6"/>
+  <!-- Center -->
+  <line x1="160" y1="160" x2="160" y2="210" stroke="url(#line-light)" stroke-width="2.5" stroke-dasharray="6 4"/>
+  <polygon points="154,206 160,216 166,206" fill="#10b981" opacity="0.6"/>
+  <!-- Right -->
+  <line x1="200" y1="160" x2="255" y2="210" stroke="url(#line-light)" stroke-width="2.5" stroke-dasharray="6 4"/>
+  <polygon points="248,210 258,216 260,205" fill="#06b6d4" opacity="0.6"/>
+
+  <!-- Output nodes -->
+  <rect x="15" y="216" width="100" height="38" rx="8" fill="#10b981" opacity="0.15" stroke="#10b981" stroke-opacity="0.4" stroke-width="1.5"/>
+  <text x="65" y="240" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="500" fill="#047857">Claude Code</text>
+
+  <rect x="110" y="216" width="100" height="38" rx="8" fill="#10b981" opacity="0.15" stroke="#10b981" stroke-opacity="0.4" stroke-width="1.5"/>
+  <text x="160" y="240" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="500" fill="#047857">Cursor</text>
+
+  <rect x="205" y="216" width="100" height="38" rx="8" fill="#06b6d4" opacity="0.15" stroke="#06b6d4" stroke-opacity="0.4" stroke-width="1.5"/>
+  <text x="255" y="240" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="500" fill="#0e7490">Codex</text>
+
+  <!-- Bottom label -->
+  <text x="160" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#6b7280">+ 9 more targets</text>
+</svg>


### PR DESCRIPTION
## Summary

- Added custom VitePress theme with emerald-to-cyan brand gradient on the hero "Skillfold" name text, matching the polish of top VitePress sites (Vite, Vue, Vitest)
- Created hero SVG images (light/dark) showing the YAML -> Compiler -> platform fan-out pipeline diagram with a blurred color glow backdrop
- Added "Compile Once, Run Anywhere" section with a 12-target platform grid (responsive 3-col/4-col layout)
- Created blog index page at `/blog/` to fix the 404 that occurred when navigating to the blog section
- Added footer copyright, npm social link icon, and Blog nav link

Closes #522, #523, #524, #525

## Test plan

- [x] `npx vitepress build docs` compiles with no errors
- [x] All 859 existing tests pass
- [ ] Verify hero gradient renders in light and dark modes
- [ ] Verify `/blog/` loads the index page
- [ ] Verify platform grid is responsive at mobile breakpoints
- [ ] Verify hero SVGs render correctly

Generated with [Claude Code](https://claude.com/claude-code)