### PR TITLE
ci: publish to npm via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -15,11 +16,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
+      # Trusted publishing (OIDC) needs npm 11.5.1+; Node 22 ships npm 10.
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npm test
       - run: npm run build
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
NPM_TOKEN expired (npm granular tokens cap at 90 days), failing the v2.0.0 publish with E404. Byron configured a trusted publisher on npmjs.com for this repo + publish.yml (no environment), so this switches the workflow to tokenless OIDC publishing:

- drop `registry-url` / `NODE_AUTH_TOKEN` (setup-node writes an .npmrc referencing the env var, which errors when unset)
- `npm install -g npm@latest` on the runner - trusted publishing needs npm 11.5.1+
- add `workflow_dispatch` so the 2.0.0 publish can be re-run from main without re-cutting the release

Publish never runs on PRs, so verification is the dispatch run after merge.